### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe the user-facing or code-level change in a few sentences.
+
+## Testing
+
+- [ ] Tested locally or explain why not applicable
+- [ ] Added or updated tests where needed
+
+## Checklist
+
+- [ ] Branch name uses an approved prefix such as `feature/*`, `fix/*`, `chore/*`, or `docs/*`
+- [ ] No direct commits to `main`
+- [ ] Linked the relevant issue, ticket, or context in the PR body
+- [ ] Updated docs or release notes if needed


### PR DESCRIPTION
## Summary
Add a shared pull request template with testing and workflow checks.

## Why
This supports the new protected-main workflow and makes branch naming plus review expectations explicit in every PR.

## Testing
- not applicable (template-only change)