### PR TITLE
fix: route URL scan to original scanner pipeline, fix version metadata

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwnkit-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "bin": {
     "pwnkit-cli": "dist/index.js"

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -1,8 +1,11 @@
 import type { Command } from "commander";
 import chalk from "chalk";
 import type { ScanDepth, OutputFormat, RuntimeMode } from "@pwnkit/shared";
+import { VERSION } from "@pwnkit/shared";
+import { scan } from "@pwnkit/core";
 import { renderReplay } from "../formatters/replay.js";
-import { runUnified } from "./run.js";
+import { formatReport } from "../formatters/index.js";
+import { checkRuntimeAvailability } from "../utils.js";
 
 export function registerScanCommand(program: Command): void {
   program
@@ -55,17 +58,51 @@ export function registerScanCommand(program: Command): void {
         }
       }
 
-      await runUnified({
-        target: opts.target,
-        targetType: "url",
-        depth: opts.depth as ScanDepth,
-        format: (opts.format === "md" ? "markdown" : opts.format) as OutputFormat,
-        runtime: (opts.runtime as RuntimeMode) ?? "auto",
-        timeout: parseInt(opts.timeout, 10),
-        verbose: opts.verbose as boolean,
-        dbPath: opts.dbPath as string | undefined,
-        apiKey: opts.apiKey as string | undefined,
-        model: opts.model as string | undefined,
-      });
+      const format = (opts.format === "md" ? "markdown" : opts.format) as OutputFormat;
+      const runtime = (opts.runtime as RuntimeMode) ?? "auto";
+
+      if (format === "terminal") checkRuntimeAvailability();
+
+      // URL targets use the original scanner pipeline (discovery → attack → verify → report)
+      // instead of the unified pipeline which only supports npm-package and source-code targets.
+      let inkUI: { onEvent: (event: any) => void; setReport: (report: any) => void; waitForExit: () => Promise<void> } | null = null;
+      let eventHandler: (event: any) => void = () => {};
+
+      if (format === "terminal") {
+        const { renderScanUI } = await import("../ui/renderScan.js");
+        inkUI = renderScanUI({ version: VERSION, target: opts.target, depth: opts.depth, mode: "scan" });
+        eventHandler = inkUI.onEvent;
+      }
+
+      try {
+        const report = await scan(
+          {
+            target: opts.target,
+            depth: opts.depth as ScanDepth,
+            format,
+            runtime,
+            timeout: parseInt(opts.timeout, 10),
+            verbose: opts.verbose as boolean,
+            apiKey: opts.apiKey as string | undefined,
+            model: opts.model as string | undefined,
+          },
+          eventHandler,
+          opts.dbPath as string | undefined,
+        );
+
+        if (inkUI) {
+          inkUI.setReport(report as any);
+          await inkUI.waitForExit();
+        } else {
+          console.log(formatReport(report, format));
+        }
+
+        if (report.summary.critical > 0 || report.summary.high > 0) {
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+        process.exit(2);
+      }
     });
 }

--- a/www/src/layouts/Layout.astro
+++ b/www/src/layouts/Layout.astro
@@ -56,7 +56,7 @@ const { title, description = "Open-source agentic framework for autonomous secur
       },
       "url": "https://pwnkit.com",
       "downloadUrl": "https://www.npmjs.com/package/pwnkit-cli",
-      "softwareVersion": "0.1.4",
+      "softwareVersion": "0.3.3",
       "author": {
         "@type": "Person",
         "name": "Doruk Tan Ozturk",


### PR DESCRIPTION
## Summary

- **URL scan path fixed**: `pwnkit scan --target <url>` was routing through the unified pipeline (npm/source-code only), producing "not yet supported" errors. Now correctly routes to the original scanner pipeline with discovery → attack → verify → report stages.
- **Website version synced**: Structured data `softwareVersion` updated from `0.1.4` to `0.3.3`.
- **packages/cli version synced**: `0.3.2` → `0.3.3` to match root package.json.

Fixes GHO-48.

## Test plan

- [ ] Run `pwnkit scan --target <url> --format json` and verify it enters the scanner pipeline (not unified)
- [ ] Verify website build produces correct `softwareVersion: 0.3.3` in JSON-LD
- [ ] Verify `pnpm build` succeeds cleanly

Co-Authored-By: Paperclip <noreply@paperclip.ing>