### PR TITLE
Consensus audit: 13 fixes across security, reliability, and testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,13 +62,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         whatweb wafw00f dirb \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Node.js 20 from the builder stage instead of curl-pipe-bash from nodesource.
-# This eliminates a supply-chain risk (arbitrary remote script execution) and also
-# removes a network dependency during the runtime stage build.
+# Copy the entire Node.js installation from the builder stage instead of
+# curl-pipe-bash from nodesource. This eliminates a supply-chain risk
+# (arbitrary remote script execution) and removes a network dependency.
 COPY --from=builder /usr/local/bin/node /usr/local/bin/node
-COPY --from=builder /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=builder /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=builder /usr/local/include/node /usr/local/include/node
 COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Optional: SecLists wordlists (large)
 RUN if [ "$INSTALL_SECLISTS" = "1" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,15 +54,21 @@ ENV NODE_ENV=production \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
     PATH=/usr/local/bin:/usr/bin:/bin
 
-# Base system + Node 20 + pentest tooling
+# Base system + pentest tooling (Node copied from builder below)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates curl wget gnupg jq git unzip xz-utils \
         python3 python3-requests python3-bs4 \
         sqlmap nmap nikto gobuster hydra john ffuf wfuzz \
         whatweb wafw00f dirb \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy Node.js 20 from the builder stage instead of curl-pipe-bash from nodesource.
+# This eliminates a supply-chain risk (arbitrary remote script execution) and also
+# removes a network dependency during the runtime stage build.
+COPY --from=builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=builder /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=builder /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Optional: SecLists wordlists (large)
 RUN if [ "$INSTALL_SECLISTS" = "1" ]; then \

--- a/packages/core/src/__tests__/pipeline.test.ts
+++ b/packages/core/src/__tests__/pipeline.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration test scaffold for the full pwnkit scan pipeline.
+ *
+ * Exercises scan() end-to-end against the built-in test-target servers
+ * (vulnerable + safe) with all API keys cleared so no real LLM calls are
+ * made. The tests verify that the pipeline stages run to completion and
+ * return structurally valid reports.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Server } from "http";
+import { scan } from "../scanner.js";
+
+/* ------------------------------------------------------------------ */
+/*  Environment: strip API keys so the baseline (non-AI) path is used */
+/* ------------------------------------------------------------------ */
+const savedEnv: Record<string, string | undefined> = {};
+const API_KEY_VARS = [
+  "OPENROUTER_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "OPENAI_API_KEY",
+];
+
+/* ------------------------------------------------------------------ */
+/*  Test-target servers                                               */
+/* ------------------------------------------------------------------ */
+let vulnServer: Server;
+let safeServer: Server;
+let vulnEndpoint = "";
+let safeEndpoint = "";
+let vulnMcpEndpoint = "";
+
+beforeAll(async () => {
+  // Save and clear API keys
+  for (const key of API_KEY_VARS) {
+    savedEnv[key] = process.env[key];
+    process.env[key] = "";
+  }
+
+  // Dynamically import test-target servers (they live outside the core
+  // package but are part of the monorepo workspace).
+  const { startVulnerableServer } = await import(
+    "../../../../test-targets/src/vulnerable-server.js"
+  );
+  const { startSafeServer } = await import(
+    "../../../../test-targets/src/safe-server.js"
+  );
+
+  const vuln = startVulnerableServer(0);
+  const safe = startSafeServer(0);
+
+  vulnServer = vuln.server;
+  safeServer = safe.server;
+  vulnEndpoint = `http://localhost:${vuln.port}/v1/chat/completions`;
+  safeEndpoint = `http://localhost:${safe.port}/v1/chat/completions`;
+  vulnMcpEndpoint = `mcp://localhost:${vuln.port}/mcp`;
+});
+
+afterAll(async () => {
+  // Shut down servers
+  await Promise.all([
+    new Promise<void>((resolve) => vulnServer?.close(() => resolve())),
+    new Promise<void>((resolve) => safeServer?.close(() => resolve())),
+  ]);
+
+  // Restore API keys
+  for (const key of API_KEY_VARS) {
+    if (savedEnv[key] !== undefined) {
+      process.env[key] = savedEnv[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/*  Full pipeline tests                                               */
+/* ------------------------------------------------------------------ */
+describe("scan pipeline integration", () => {
+  it("completes a quick scan against the vulnerable target without throwing", async () => {
+    const report = await scan({
+      target: vulnEndpoint,
+      depth: "quick",
+      format: "json",
+      timeout: 5_000,
+    });
+
+    expect(report).toBeDefined();
+    expect(report.summary).toBeDefined();
+    expect(report.findings).toBeDefined();
+    expect(Array.isArray(report.findings)).toBe(true);
+    expect(report.target).toBe(vulnEndpoint);
+    expect(report.scanDepth).toBe("quick");
+    expect(report.durationMs).toBeGreaterThan(0);
+    expect(report.startedAt).toBeTruthy();
+    expect(report.completedAt).toBeTruthy();
+  }, 30_000);
+
+  it("returns a clean report for the safe target", async () => {
+    const report = await scan({
+      target: safeEndpoint,
+      depth: "quick",
+      format: "json",
+      timeout: 5_000,
+    });
+
+    expect(report.summary.totalFindings).toBe(0);
+    expect(report.findings).toHaveLength(0);
+  }, 30_000);
+
+  it("runs default depth without errors", async () => {
+    const report = await scan({
+      target: safeEndpoint,
+      depth: "default",
+      format: "json",
+      timeout: 5_000,
+    });
+
+    expect(report.summary).toBeDefined();
+    expect(report.summary.totalFindings).toBe(0);
+  }, 30_000);
+
+  it("detects MCP vulnerabilities on the vulnerable target", async () => {
+    const report = await scan({
+      target: vulnMcpEndpoint,
+      depth: "quick",
+      format: "json",
+      mode: "mcp",
+      timeout: 5_000,
+    });
+
+    expect(report.summary.totalFindings).toBeGreaterThan(0);
+    expect(
+      report.findings.some((f) => f.title.toLowerCase().includes("mcp")),
+    ).toBe(true);
+  }, 30_000);
+
+  it("emits stage events throughout the pipeline", async () => {
+    const events: Array<{ type: string; stage?: string }> = [];
+
+    await scan(
+      {
+        target: vulnEndpoint,
+        depth: "quick",
+        format: "json",
+        timeout: 5_000,
+      },
+      (event) => {
+        events.push({ type: event.type, stage: event.stage });
+      },
+    );
+
+    // The pipeline must emit start/end for discovery, attack, verify, report
+    const stageStarts = events
+      .filter((e) => e.type === "stage:start")
+      .map((e) => e.stage);
+    expect(stageStarts).toContain("discovery");
+    expect(stageStarts).toContain("attack");
+    expect(stageStarts).toContain("verify");
+    expect(stageStarts).toContain("report");
+
+    const stageEnds = events
+      .filter((e) => e.type === "stage:end")
+      .map((e) => e.stage);
+    expect(stageEnds).toContain("discovery");
+    expect(stageEnds).toContain("attack");
+    expect(stageEnds).toContain("verify");
+    expect(stageEnds).toContain("report");
+  }, 30_000);
+
+  it("respects the timeout config without hanging", async () => {
+    const start = Date.now();
+    const report = await scan({
+      target: safeEndpoint,
+      depth: "quick",
+      format: "json",
+      timeout: 3_000,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(report).toBeDefined();
+    // Should complete well within a generous upper bound
+    expect(elapsed).toBeLessThan(30_000);
+  }, 30_000);
+
+  it("includes warnings array in report even when empty", async () => {
+    const report = await scan({
+      target: safeEndpoint,
+      depth: "quick",
+      format: "json",
+      timeout: 5_000,
+    });
+
+    expect(report.warnings).toBeDefined();
+    expect(Array.isArray(report.warnings)).toBe(true);
+  }, 30_000);
+});

--- a/packages/core/src/agent/cost.ts
+++ b/packages/core/src/agent/cost.ts
@@ -1,18 +1,64 @@
-/** Approximate cost per 1M tokens by provider/model */
+/** Approximate cost per 1M tokens by model (USD) */
 const PRICING: Record<string, { input: number; output: number }> = {
+  // OpenAI
   "gpt-5.4": { input: 2.50, output: 10.00 },
   "gpt-4o": { input: 2.50, output: 10.00 },
+  "gpt-4o-mini": { input: 0.15, output: 0.60 },
+  "gpt-4.1": { input: 2.00, output: 8.00 },
+  "gpt-4.1-mini": { input: 0.40, output: 1.60 },
+  "gpt-4.1-nano": { input: 0.10, output: 0.40 },
+  "o3": { input: 2.00, output: 8.00 },
+  "o3-mini": { input: 1.10, output: 4.40 },
+  "o4-mini": { input: 1.10, output: 4.40 },
+
+  // Anthropic
   "claude-sonnet-4-6": { input: 3.00, output: 15.00 },
   "claude-opus-4-6": { input: 15.00, output: 75.00 },
   "claude-haiku-4-5": { input: 0.80, output: 4.00 },
+
+  // Google
+  "gemini-2.5-pro": { input: 1.25, output: 10.00 },
+  "gemini-2.5-flash": { input: 0.15, output: 0.60 },
+  "gemini-2.0-flash": { input: 0.10, output: 0.40 },
+
+  // DeepSeek
+  "deepseek-chat": { input: 0.27, output: 1.10 },
+  "deepseek-reasoner": { input: 0.55, output: 2.19 },
+
+  // Meta Llama (common OpenRouter names)
+  "llama-4-maverick": { input: 0.50, output: 0.70 },
+  "llama-4-scout": { input: 0.18, output: 0.35 },
+  "llama-3.3-70b": { input: 0.40, output: 0.40 },
+  "llama-3.1-405b": { input: 2.00, output: 2.00 },
+  "llama-3.1-70b": { input: 0.40, output: 0.40 },
+  "llama-3.1-8b": { input: 0.05, output: 0.08 },
+
+  // Mistral
+  "mistral-large": { input: 2.00, output: 6.00 },
+  "mistral-small": { input: 0.10, output: 0.30 },
+
+  // Qwen
+  "qwen-2.5-72b": { input: 0.40, output: 0.40 },
+
   default: { input: 3.00, output: 15.00 },
 };
+
+/** Strip vendor prefixes like "anthropic/", "openai/", "google/" from OpenRouter-style model strings */
+function normalizeModel(model: string): string {
+  return model.replace(/^[a-z-]+\//, "");
+}
 
 export function estimateCost(
   usage: { inputTokens: number; outputTokens: number },
   model?: string,
 ): number {
-  const rates = PRICING[model ?? ""] ?? PRICING.default;
+  const normalized = model ? normalizeModel(model) : "";
+  const rates = PRICING[normalized] ?? (() => {
+    if (normalized) {
+      console.warn(`Unknown model pricing for ${normalized}, using default estimate`);
+    }
+    return PRICING.default;
+  })();
   return (
     (usage.inputTokens / 1_000_000) * rates.input +
     (usage.outputTokens / 1_000_000) * rates.output

--- a/packages/core/src/agent/docker-executor.ts
+++ b/packages/core/src/agent/docker-executor.ts
@@ -73,6 +73,7 @@ export class DockerExecutor {
   private constructor() {
     this.containerName = `${CONTAINER_PREFIX}-${randomUUID().slice(0, 8)}`;
     this.image = process.env.PWNKIT_DOCKER_IMAGE || PREBUILT_IMAGE;
+    this.registerExitHandlers();
   }
 
   /** Singleton — one container per process. */
@@ -81,6 +82,37 @@ export class DockerExecutor {
       DockerExecutor.instance = new DockerExecutor();
     }
     return DockerExecutor.instance;
+  }
+
+  /**
+   * Register process exit handlers to ensure the container is cleaned up
+   * when the process exits, preventing orphaned containers.
+   */
+  private registerExitHandlers(): void {
+    const cleanup = () => {
+      if (this.containerId) {
+        try {
+          execSync(`docker rm -f ${this.containerId}`, {
+            timeout: 10_000,
+            stdio: "pipe",
+          });
+        } catch {
+          // Best-effort cleanup on exit
+        }
+        this.containerId = null;
+        this.ready = false;
+      }
+    };
+
+    process.on("exit", cleanup);
+    process.on("SIGTERM", () => {
+      cleanup();
+      process.exit(143);
+    });
+    process.on("SIGINT", () => {
+      cleanup();
+      process.exit(130);
+    });
   }
 
   /** Reset the singleton (for testing). */
@@ -116,16 +148,19 @@ export class DockerExecutor {
 
     // Start the container with:
     //  - shared /tmp/pwnkit-shared volume for file exchange
-    //  - host networking so it can reach targets
+    //  - bridge networking (default) for isolation; override with PWNKIT_DOCKER_NETWORK=host if needed
+    //  - --rm so the container is auto-removed when stopped
     //  - long-running sleep to keep it alive
+    const networkMode = process.env.PWNKIT_DOCKER_NETWORK || "bridge";
     const runCmd = [
       "docker",
       "run",
       "-d",
+      "--rm",
       "--name",
       this.containerName,
       "--network",
-      "host",
+      networkMode,
       "-v",
       "/tmp/pwnkit-shared:/shared",
       "-e",

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -116,6 +116,30 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
     });
   }
 
+  // ── Cleanup safety net ──
+  const cleanupOnce = (() => {
+    let cleaned = false;
+    return async () => {
+      if (cleaned) return;
+      cleaned = true;
+      await executor.cleanup();
+    };
+  })();
+
+  const onSignal = async () => {
+    await cleanupOnce();
+    process.exit(1);
+  };
+  const onExit = () => {
+    void executor.cleanup();
+  };
+
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  process.on("exit", onExit);
+
+  try {
+
   // ── Main loop ──
 
   while (!state.done && state.turnCount < config.maxTurns) {
@@ -292,6 +316,13 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
       },
       timestamp: Date.now(),
     });
+  }
+
+  } finally {
+    await cleanupOnce();
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    process.removeListener("exit", onExit);
   }
 
   return state;

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -330,21 +330,101 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
 
 // ── Parse tool calls from assistant response ──
 
-const TOOL_CALL_RE = /^TOOL_CALL:\s*(\w+)\s+(\{[\s\S]*?\})\s*$/gm;
+/**
+ * Extract a complete JSON object from `text` starting at `startIndex` (which
+ * must point to the opening `{`).  Uses brace/bracket counting and respects
+ * JSON string literals so that nested objects, arrays, and escaped characters
+ * are handled correctly.
+ *
+ * Returns the substring containing the full JSON object, or `null` if the
+ * braces never balance.
+ */
+function extractJsonObject(text: string, startIndex: number): string | null {
+  if (text[startIndex] !== "{") return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startIndex; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (ch === "\\" && inString) {
+      escape = true;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (ch === "{" || ch === "[") {
+      depth++;
+    } else if (ch === "}" || ch === "]") {
+      depth--;
+      if (depth === 0) {
+        return text.slice(startIndex, i + 1);
+      }
+    }
+  }
+
+  return null; // unbalanced braces
+}
+
+const TOOL_CALL_LINE_RE = /^TOOL_CALL:\s*(\w+)\s*/gm;
 
 export function parseToolCalls(text: string): ToolCall[] {
   const calls: ToolCall[] = [];
   let match: RegExpExecArray | null;
-  const re = new RegExp(TOOL_CALL_RE.source, "gm");
+  const re = new RegExp(TOOL_CALL_LINE_RE.source, TOOL_CALL_LINE_RE.flags);
 
   while ((match = re.exec(text)) !== null) {
-    try {
-      const args = JSON.parse(match[2]);
-      calls.push({ name: match[1], arguments: args });
-    } catch {
-      // Skip malformed JSON
+    const toolName = match[1];
+    const afterMatch = match.index + match[0].length;
+
+    // No arguments — tool name only (e.g. bare `TOOL_CALL: done`)
+    if (afterMatch >= text.length || text[afterMatch] === "\n") {
+      calls.push({ name: toolName, arguments: {} });
+      continue;
     }
+
+    // Find the opening brace (may have leading whitespace)
+    const braceIndex = text.indexOf("{", afterMatch);
+    if (braceIndex === -1 || braceIndex - afterMatch > 2) {
+      // No JSON object follows — treat as no-arg call
+      calls.push({ name: toolName, arguments: {} });
+      continue;
+    }
+
+    const jsonStr = extractJsonObject(text, braceIndex);
+    if (jsonStr === null) {
+      console.warn(
+        `[pwnkit] TOOL_CALL "${toolName}": failed to extract JSON (unbalanced braces) — skipping`,
+      );
+      continue;
+    }
+
+    try {
+      const args = JSON.parse(jsonStr);
+      calls.push({ name: toolName, arguments: args });
+    } catch (err) {
+      console.warn(
+        `[pwnkit] TOOL_CALL "${toolName}": malformed JSON — ${err instanceof Error ? err.message : err}`,
+      );
+    }
+
+    // Advance the regex past the extracted JSON so we don't re-match inside it
+    re.lastIndex = braceIndex + jsonStr.length;
   }
+
   return calls;
 }
 

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -13,14 +13,18 @@ import { ToolExecutor, getToolsForRole } from "./tools.js";
 import { features } from "./features.js";
 import { detectPlaybooks, buildPlaybookInjection } from "./playbooks.js";
 import { estimateCost } from "./cost.js";
+import { EXTERNAL_MEMORY_PATH_PLACEHOLDER } from "./prompts.js";
 import type { pwnkitDB } from "@pwnkit/db";
 import type { Finding, AttackResult, TargetInfo } from "@pwnkit/shared";
 
 // ── External Memory ──
-// The agent can persist working state (creds, endpoints, attack plans) to this
-// file via bash. At reflection checkpoints the contents are injected back into
-// the conversation so the agent doesn't lose track of discoveries.
-const EXTERNAL_MEMORY_PATH = "/tmp/pwnkit-state.json";
+// The agent can persist working state (creds, endpoints, attack plans) to a
+// per-scan file via bash. At reflection checkpoints the contents are injected
+// back into the conversation so the agent doesn't lose track of discoveries.
+// Each scan gets its own isolated file to prevent cross-scan data leaks.
+function externalMemoryPath(scanId: string): string {
+  return `/tmp/pwnkit-state-${scanId}.json`;
+}
 const EXTERNAL_MEMORY_MAX_CHARS = 2000;
 
 // ── Native Agent Loop Config ──
@@ -101,6 +105,18 @@ export async function runNativeAgentLoop(
 ): Promise<NativeAgentState> {
   const { config, runtime, db, onTurn, onEvent } = opts;
 
+  // Per-scan isolated memory file path
+  const memoryPath = externalMemoryPath(config.scanId || randomUUID());
+
+  // Replace the placeholder in the system prompt so the agent writes to the
+  // correct per-scan file instead of a global singleton.
+  if (config.systemPrompt) {
+    config.systemPrompt = config.systemPrompt.replaceAll(
+      EXTERNAL_MEMORY_PATH_PLACEHOLDER,
+      memoryPath,
+    );
+  }
+
   const toolCtx: ToolContext = {
     target: config.target,
     scanId: config.scanId,
@@ -147,7 +163,7 @@ export async function runNativeAgentLoop(
 
     // Clean up external memory file at the start of a new scan (not between retries)
     if (features.externalMemory && (config.retryCount ?? 0) === 0) {
-      try { fs.unlinkSync(EXTERNAL_MEMORY_PATH); } catch { /* file may not exist */ }
+      try { fs.unlinkSync(memoryPath); } catch { /* file may not exist */ }
     }
   }
 
@@ -343,7 +359,7 @@ export async function runNativeAgentLoop(
           content: [
             {
               type: "text",
-              text: buildContinuePrompt(config, state.turnCount),
+              text: buildContinuePrompt(config, state.turnCount, memoryPath),
             },
           ],
         });
@@ -613,6 +629,11 @@ export async function runNativeAgentLoop(
   } finally {
     // Clean up browser and PTY resources regardless of how the loop exits
     await cleanupOnce();
+
+    // Clean up per-scan external memory file to avoid leaking state on disk
+    if (features.externalMemory) {
+      try { fs.unlinkSync(memoryPath); } catch { /* file may not exist */ }
+    }
 
     // Remove signal handlers to avoid leaking listeners across calls
     process.removeListener("SIGINT", onSignal);
@@ -968,10 +989,12 @@ const LOOP_WARNING =
  * to append to the reflection checkpoint prompt, or an empty string if the
  * file doesn't exist or the feature is off.
  */
-function readExternalMemory(): string {
+function readExternalMemory(filePath: string): string {
   try {
-    const raw = fs.readFileSync(EXTERNAL_MEMORY_PATH, "utf-8");
+    const raw = fs.readFileSync(filePath, "utf-8");
     if (!raw.trim()) return "";
+    // Restrict permissions on agent-written file (owner read/write only)
+    try { fs.chmodSync(filePath, 0o600); } catch { /* best-effort */ }
     const capped = raw.length > EXTERNAL_MEMORY_MAX_CHARS
       ? raw.slice(0, EXTERNAL_MEMORY_MAX_CHARS) + "\n...(truncated)"
       : raw;
@@ -991,13 +1014,13 @@ function buildInitialPrompt(config: NativeAgentConfig): string {
   ].join("\n");
 }
 
-function buildContinuePrompt(config: NativeAgentConfig, turnCount: number): string {
+function buildContinuePrompt(config: NativeAgentConfig, turnCount: number, memPath: string): string {
   const pct = turnCount / config.maxTurns;
   const remaining = config.maxTurns - turnCount;
 
   // Read external memory at reflection checkpoints (30%/50%/70%/85%)
   const memorySuffix = (pct >= 0.3 && features.externalMemory)
-    ? readExternalMemory()
+    ? readExternalMemory(memPath)
     : "";
 
   // Multi-checkpoint budget awareness (inspired by Cyber-AutoAgent)

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -196,6 +196,34 @@ export async function runNativeAgentLoop(
     });
   }
 
+  // ── Cleanup safety net ──
+  // Register signal handlers so resources are freed even on abnormal termination.
+  // SIGINT/SIGTERM allow async cleanup; process 'exit' is synchronous-only.
+  const cleanupOnce = (() => {
+    let cleaned = false;
+    return async () => {
+      if (cleaned) return;
+      cleaned = true;
+      await executor.cleanup();
+    };
+  })();
+
+  const onSignal = async () => {
+    await cleanupOnce();
+    process.exit(1);
+  };
+  const onExit = () => {
+    // process 'exit' callbacks must be synchronous — fire-and-forget cleanup
+    // (the async cleanup may not fully complete, but it kills child processes)
+    void executor.cleanup();
+  };
+
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  process.on("exit", onExit);
+
+  try {
+
   // ── Main loop ──
 
   while (!state.done && state.turnCount < config.maxTurns) {
@@ -580,6 +608,16 @@ export async function runNativeAgentLoop(
       },
       timestamp: Date.now(),
     });
+  }
+
+  } finally {
+    // Clean up browser and PTY resources regardless of how the loop exits
+    await cleanupOnce();
+
+    // Remove signal handlers to avoid leaking listeners across calls
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    process.removeListener("exit", onExit);
   }
 
   return state;

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -61,12 +61,15 @@ export function buildAuthHeaders(auth?: AuthConfig): Record<string, string> {
   }
 }
 
+/** Placeholder replaced at runtime by native-loop with the per-scan path. */
+export const EXTERNAL_MEMORY_PATH_PLACEHOLDER = "{{EXTERNAL_MEMORY_PATH}}";
+
 const EXTERNAL_MEMORY_INSTRUCTION = `
 
 ## Working Memory
 
-Save important discoveries (credentials, endpoints, tokens, attack plans) to /tmp/pwnkit-state.json using bash. This file persists across reflection checkpoints and will be reminded to you. Example:
-\`echo '{"creds":["admin:pass"],"endpoints":["/api/users"],"plan":"try IDOR on /api/users/2"}' > /tmp/pwnkit-state.json\`
+Save important discoveries (credentials, endpoints, tokens, attack plans) to ${EXTERNAL_MEMORY_PATH_PLACEHOLDER} using bash. This file persists across reflection checkpoints and will be reminded to you. Example:
+\`echo '{"creds":["admin:pass"],"endpoints":["/api/users"],"plan":"try IDOR on /api/users/2"}' > ${EXTERNAL_MEMORY_PATH_PLACEHOLDER}\`
 Update it whenever you discover something new.`;
 
 export function discoveryPrompt(target: string, auth?: AuthConfig): string {

--- a/packages/core/src/agent/pty-session.ts
+++ b/packages/core/src/agent/pty-session.ts
@@ -16,11 +16,18 @@ export interface PtySession {
   outputBuffer: string;
   cwd: string;
   createdAt: number;
+  lastActivityAt: number;
   alive: boolean;
 }
 
 export class PtySessionManager {
   private sessions = new Map<string, PtySession>();
+
+  /** Maximum number of concurrent alive sessions. */
+  static readonly MAX_CONCURRENT_SESSIONS = 10;
+
+  /** Idle timeout in milliseconds (10 minutes). Sessions with no I/O are reaped. */
+  static readonly IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 
   /**
    * Create a new interactive session backed by a shell process.
@@ -30,6 +37,19 @@ export class PtySessionManager {
     for (const s of this.sessions.values()) {
       if (s.name === name && s.alive) {
         throw new Error(`Session "${name}" already exists and is alive. Close it first or use a different name.`);
+      }
+    }
+
+    // Enforce maximum concurrent session limit
+    const aliveCount = Array.from(this.sessions.values()).filter((s) => s.alive).length;
+    if (aliveCount >= PtySessionManager.MAX_CONCURRENT_SESSIONS) {
+      // Reap idle sessions first before rejecting
+      this.reapIdleSessions();
+      const aliveAfterReap = Array.from(this.sessions.values()).filter((s) => s.alive).length;
+      if (aliveAfterReap >= PtySessionManager.MAX_CONCURRENT_SESSIONS) {
+        throw new Error(
+          `Maximum concurrent session limit (${PtySessionManager.MAX_CONCURRENT_SESSIONS}) reached. Close existing sessions first.`,
+        );
       }
     }
 
@@ -49,12 +69,14 @@ export class PtySessionManager {
       outputBuffer: "",
       cwd,
       createdAt: Date.now(),
+      lastActivityAt: Date.now(),
       alive: true,
     };
 
     // Accumulate stdout
     proc.stdout?.on("data", (chunk: Buffer) => {
       session.outputBuffer += chunk.toString("utf-8");
+      session.lastActivityAt = Date.now();
       // Cap buffer at 100KB to prevent unbounded growth
       if (session.outputBuffer.length > 100_000) {
         session.outputBuffer = session.outputBuffer.slice(-50_000);
@@ -64,6 +86,7 @@ export class PtySessionManager {
     // Accumulate stderr into same buffer
     proc.stderr?.on("data", (chunk: Buffer) => {
       session.outputBuffer += chunk.toString("utf-8");
+      session.lastActivityAt = Date.now();
       if (session.outputBuffer.length > 100_000) {
         session.outputBuffer = session.outputBuffer.slice(-50_000);
       }
@@ -94,6 +117,7 @@ export class PtySessionManager {
     }
     const data = input.endsWith("\n") ? input : input + "\n";
     session.process.stdin.write(data);
+    session.lastActivityAt = Date.now();
   }
 
   /**
@@ -175,6 +199,22 @@ export class PtySessionManager {
       }
     }
     this.sessions.clear();
+  }
+
+  /**
+   * Reap sessions that have been idle longer than IDLE_TIMEOUT_MS.
+   */
+  reapIdleSessions(): void {
+    const now = Date.now();
+    for (const [id, session] of this.sessions) {
+      if (session.alive && now - session.lastActivityAt > PtySessionManager.IDLE_TIMEOUT_MS) {
+        try {
+          this.close(id);
+        } catch {
+          // Best-effort
+        }
+      }
+    }
   }
 
   /**

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -1059,10 +1059,52 @@ export class ToolExecutor {
     }
   }
 
+  // ── Bash scope enforcement (defense-in-depth) ──
+
+  private static readonly DANGEROUS_COMMANDS: readonly RegExp[] = [
+    /\brm\s+(-\w*)?r\w*\s+(-\w*\s+)*\/\s*$/,    // rm -rf /
+    /\brm\s+(-\w*)?r\w*\s+(-\w*\s+)*\/\s*$/,     // rm variants targeting root
+    /\bmkfs\b/,                                    // format filesystem
+    /\bdd\s+if=/,                                  // raw disk write
+    /:\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/,   // fork bomb
+    /\bchmod\s+(-\w*\s+)*777\s+\//,               // chmod -R 777 /
+    /\bshutdown\b/,                                // shutdown
+    /\breboot\b/,                                  // reboot
+    /\bkill\s+(-\d+\s+)?1\b/,                     // kill init/PID 1
+    /\binit\s+0\b/,                                // init 0 (halt)
+    /\bhalt\b/,                                    // halt
+    /\bsystemctl\s+(poweroff|halt|reboot)\b/,      // systemctl poweroff/halt/reboot
+    />\s*\/dev\/[sh]da/,                           // write to raw disk device
+    /\bformat\s+[cC]:/,                            // Windows format (just in case)
+  ];
+
+  private isCommandBlocked(command: string): string | null {
+    if (process.env.PWNKIT_UNSAFE_BASH === "1") {
+      return null;
+    }
+    for (const pattern of ToolExecutor.DANGEROUS_COMMANDS) {
+      if (pattern.test(command)) {
+        return `Blocked: command matches dangerous pattern (${pattern}). Set PWNKIT_UNSAFE_BASH=1 to override.`;
+      }
+    }
+    return null;
+  }
+
   private async shellExec(args: Record<string, unknown>): Promise<ToolResult> {
     const command = (args.command as string)?.trim();
     if (!command) {
       return { success: false, output: null, error: "Command is required" };
+    }
+
+    // Scope enforcement: block obviously destructive commands
+    const blocked = this.isCommandBlocked(command);
+    if (blocked) {
+      return { success: false, output: null, error: blocked };
+    }
+
+    // Warn when running in native mode (no Docker isolation)
+    if (!process.env.PWNKIT_FEATURE_DOCKER_EXECUTOR || process.env.PWNKIT_FEATURE_DOCKER_EXECUTOR !== "1") {
+      console.error("Warning: bash tool running in native mode without Docker isolation");
     }
 
     const timeoutSec = Math.min((args.timeout as number) ?? 30, 120);

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -602,6 +602,32 @@ export class ToolExecutor {
   }
 
   /**
+   * Return a copy of process.env with sensitive keys (LLM API keys, cloud
+   * tokens) stripped out so they are never leaked to child processes.
+   */
+  private static readonly SENSITIVE_ENV_PATTERNS = [
+    "OPENROUTER_API",
+    "ANTHROPIC_API",
+    "OPENAI_API",
+    "AZURE_OPENAI_API",
+    "PWNKIT_CLOUD_TOKEN",
+    "GEMINI_API",
+  ];
+
+  private sanitizedEnv(): Record<string, string | undefined> {
+    const env: Record<string, string | undefined> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      const isSensitive = ToolExecutor.SENSITIVE_ENV_PATTERNS.some((pat) =>
+        key.toUpperCase().includes(pat),
+      );
+      if (!isSensitive) {
+        env[key] = value;
+      }
+    }
+    return env;
+  }
+
+  /**
    * Build environment variables for auth credentials, making them available
    * to shell commands (curl, python3, etc.) via $AUTH_HEADER / $AUTH_VALUE.
    */
@@ -1048,7 +1074,7 @@ export class ToolExecutor {
         maxBuffer: 1024 * 1024, // 1MB
         encoding: "utf-8",
         shell: "/bin/bash",
-        env: { ...process.env, TARGET: this.ctx.target, ...this.buildAuthEnvVars() },
+        env: { ...this.sanitizedEnv(), TARGET: this.ctx.target, ...this.buildAuthEnvVars() },
         stdio: ["pipe", "pipe", "pipe"],
       });
 

--- a/packages/core/src/scanner.ts
+++ b/packages/core/src/scanner.ts
@@ -16,8 +16,11 @@ async function getDB(dbPath?: string) {
     try {
       const { pwnkitDB } = await import("@pwnkit/db");
       _db = new pwnkitDB(dbPath);
-    } catch {
-      // DB unavailable (native module issue) — continue without persistence
+    } catch (err) {
+      console.error('Warning: database unavailable — scan results will not be persisted');
+      if (err instanceof Error) {
+        console.error(`  Cause: ${err.message}`);
+      }
       _db = null;
     }
   }
@@ -75,123 +78,128 @@ export async function scan(
   // Default runtime for non-auto mode (and stages that don't need per-stage selection)
   const runtime = getRuntimeForStage("attack");
 
-  // Stage 1: Discovery
-  emit({ type: "stage:start", stage: "discovery", message: "Probing target..." });
-  const discovery = await runDiscovery(ctx);
-  emit({
-    type: "stage:end",
-    stage: "discovery",
-    message: discovery.success
-      ? `Target identified as ${ctx.target.type} (${discovery.durationMs}ms)`
-      : `Discovery failed: ${discovery.error}`,
-    data: discovery,
-  });
-  if (!discovery.success && discovery.error) {
-    ctx.warnings.push({
-      stage: "discovery",
-      message: `Initial target validation failed: ${discovery.error}`,
-    });
-  }
-
-  // Stage 1.5: Source Analysis (when --repo is provided with a process runtime)
-  const templates = loadTemplates(config.depth);
-  const sourceRuntime = isAuto ? getRuntimeForStage("source-analysis") : runtime;
-  if (config.repoPath && sourceRuntime.type !== "api") {
-    emit({
-      type: "stage:start",
-      stage: "source-analysis",
-      message: `Analyzing source code in ${config.repoPath}${isAuto ? ` (runtime: ${sourceRuntime.type})` : ""}...`,
-    });
-    const sourceResult = await runSourceAnalysis(ctx, templates, sourceRuntime, config.repoPath);
+  try {
+    // Stage 1: Discovery
+    emit({ type: "stage:start", stage: "discovery", message: "Probing target..." });
+    const discovery = await runDiscovery(ctx);
     emit({
       type: "stage:end",
-      stage: "source-analysis",
-      message: sourceResult.data.findings.length > 0
-        ? `Found ${sourceResult.data.findings.length} source-level issues across ${sourceResult.data.templatesAnalyzed} categories (${sourceResult.durationMs}ms)`
-        : `No source-level issues found across ${sourceResult.data.templatesAnalyzed} categories (${sourceResult.durationMs}ms)`,
-      data: sourceResult,
+      stage: "discovery",
+      message: discovery.success
+        ? `Target identified as ${ctx.target.type} (${discovery.durationMs}ms)`
+        : `Discovery failed: ${discovery.error}`,
+      data: discovery,
     });
-  }
+    if (!discovery.success && discovery.error) {
+      ctx.warnings.push({
+        stage: "discovery",
+        message: `Initial target validation failed: ${discovery.error}`,
+      });
+    }
 
-  // Stage 2: Attack
-  const attackRuntime = isAuto ? getRuntimeForStage("attack") : runtime;
-  emit({
-    type: "stage:start",
-    stage: "attack",
-    message: `Running ${templates.length} templates${isAuto ? ` (runtime: ${attackRuntime.type})` : ""}...`,
-  });
+    // Stage 1.5: Source Analysis (when --repo is provided with a process runtime)
+    const templates = loadTemplates(config.depth);
+    const sourceRuntime = isAuto ? getRuntimeForStage("source-analysis") : runtime;
+    if (config.repoPath && sourceRuntime.type !== "api") {
+      emit({
+        type: "stage:start",
+        stage: "source-analysis",
+        message: `Analyzing source code in ${config.repoPath}${isAuto ? ` (runtime: ${sourceRuntime.type})` : ""}...`,
+      });
+      const sourceResult = await runSourceAnalysis(ctx, templates, sourceRuntime, config.repoPath);
+      emit({
+        type: "stage:end",
+        stage: "source-analysis",
+        message: sourceResult.data.findings.length > 0
+          ? `Found ${sourceResult.data.findings.length} source-level issues across ${sourceResult.data.templatesAnalyzed} categories (${sourceResult.durationMs}ms)`
+          : `No source-level issues found across ${sourceResult.data.templatesAnalyzed} categories (${sourceResult.durationMs}ms)`,
+        data: sourceResult,
+      });
+    }
 
-  const attackResult = await runAttacks(ctx, templates, attackRuntime);
-  emit({
-    type: "stage:end",
-    stage: "attack",
-    message: `Executed ${attackResult.data.payloadsRun} payloads across ${attackResult.data.templatesRun} templates (${attackResult.durationMs}ms)`,
-    data: attackResult,
-  });
-  if (
-    attackResult.data.payloadsRun > 0 &&
-    attackResult.data.results.length > 0 &&
-    attackResult.data.results.every((result) => result.outcome === "error")
-  ) {
-    const firstError = attackResult.data.results.find((result) => result.error)?.error;
-    ctx.warnings.push({
-      stage: "attack",
-      message: firstError
-        ? `All attack probes failed: ${firstError}`
-        : "All attack probes failed before the target could be validated.",
-    });
-  }
-
-  // Stage 3: Verify
-  emit({ type: "stage:start", stage: "verify", message: "Verifying findings..." });
-  const verifyResult = await runVerification(ctx, db);
-  emit({
-    type: "stage:end",
-    stage: "verify",
-    message: `${verifyResult.data.confirmed} confirmed, ${verifyResult.data.findings.length} total findings (${verifyResult.durationMs}ms)`,
-    data: verifyResult,
-  });
-
-  // Persist findings to DB after verification (if DB available)
-  if (db) {
-    db.transaction(() => {
-      db.upsertTarget(ctx.target);
-      for (const finding of verifyResult.data.findings) {
-        db.saveFinding(scanId, finding);
-      }
-      for (const result of ctx.attacks) {
-        db.saveAttackResult(scanId, result);
-      }
-    });
-  }
-
-  // Emit individual findings
-  for (const finding of verifyResult.data.findings) {
+    // Stage 2: Attack
+    const attackRuntime = isAuto ? getRuntimeForStage("attack") : runtime;
     emit({
-      type: "finding",
-      message: `[${finding.severity.toUpperCase()}] ${finding.title}`,
-      data: finding,
+      type: "stage:start",
+      stage: "attack",
+      message: `Running ${templates.length} templates${isAuto ? ` (runtime: ${attackRuntime.type})` : ""}...`,
     });
+
+    const attackResult = await runAttacks(ctx, templates, attackRuntime);
+    emit({
+      type: "stage:end",
+      stage: "attack",
+      message: `Executed ${attackResult.data.payloadsRun} payloads across ${attackResult.data.templatesRun} templates (${attackResult.durationMs}ms)`,
+      data: attackResult,
+    });
+    if (
+      attackResult.data.payloadsRun > 0 &&
+      attackResult.data.results.length > 0 &&
+      attackResult.data.results.every((result) => result.outcome === "error")
+    ) {
+      const firstError = attackResult.data.results.find((result) => result.error)?.error;
+      ctx.warnings.push({
+        stage: "attack",
+        message: firstError
+          ? `All attack probes failed: ${firstError}`
+          : "All attack probes failed before the target could be validated.",
+      });
+    }
+
+    // Stage 3: Verify
+    emit({ type: "stage:start", stage: "verify", message: "Verifying findings..." });
+    const verifyResult = await runVerification(ctx, db);
+    emit({
+      type: "stage:end",
+      stage: "verify",
+      message: `${verifyResult.data.confirmed} confirmed, ${verifyResult.data.findings.length} total findings (${verifyResult.durationMs}ms)`,
+      data: verifyResult,
+    });
+
+    // Persist findings to DB after verification (if DB available)
+    if (db) {
+      db.transaction(() => {
+        db.upsertTarget(ctx.target);
+        for (const finding of verifyResult.data.findings) {
+          db.saveFinding(scanId, finding);
+        }
+        for (const result of ctx.attacks) {
+          db.saveAttackResult(scanId, result);
+        }
+      });
+    }
+
+    // Emit individual findings
+    for (const finding of verifyResult.data.findings) {
+      emit({
+        type: "finding",
+        message: `[${finding.severity.toUpperCase()}] ${finding.title}`,
+        data: finding,
+      });
+    }
+
+    // Stage 4: Report
+    emit({ type: "stage:start", stage: "report", message: "Generating report..." });
+    finalize(ctx);
+    const reportResult = await generateReport(ctx);
+    emit({
+      type: "stage:end",
+      stage: "report",
+      message: `Report generated (${reportResult.durationMs}ms)`,
+      data: reportResult,
+    });
+
+    // Mark scan complete in DB (if available)
+    if (db) {
+      db.completeScan(scanId, reportResult.data.summary as unknown as Record<string, unknown>);
+    }
+
+    return reportResult.data;
+  } finally {
+    if (db) {
+      db.close();
+      // Reset the singleton so subsequent scans open a fresh connection
+      _db = null;
+    }
   }
-
-  // Stage 4: Report
-  emit({ type: "stage:start", stage: "report", message: "Generating report..." });
-  finalize(ctx);
-  const reportResult = await generateReport(ctx);
-  emit({
-    type: "stage:end",
-    stage: "report",
-    message: `Report generated (${reportResult.durationMs}ms)`,
-    data: reportResult,
-  });
-
-  // Mark scan complete in DB (if available)
-  if (db) {
-    db.completeScan(scanId, reportResult.data.summary as unknown as Record<string, unknown>);
-    db.close();
-    // Reset the singleton so subsequent scans open a fresh connection
-    _db = null;
-  }
-
-  return reportResult.data;
 }

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,1 +1,1 @@
-export { loadTemplates, loadTemplateById } from "./loader.js";
+export { loadTemplates, loadTemplateById, clearTemplateCache } from "./loader.js";

--- a/packages/templates/src/loader.ts
+++ b/packages/templates/src/loader.ts
@@ -10,6 +10,8 @@ const TEMPLATES_DIR_CANDIDATES = [
   join(__dirname, "attacks"),
 ];
 
+let _cache: AttackTemplate[] | null = null;
+
 function resolveTemplatesDir(): string {
   for (const candidate of TEMPLATES_DIR_CANDIDATES) {
     if (existsSync(candidate)) {
@@ -21,26 +23,37 @@ function resolveTemplatesDir(): string {
 }
 
 export function loadTemplates(depth?: ScanDepth): AttackTemplate[] {
-  const templates: AttackTemplate[] = [];
-  const dir = resolveTemplatesDir();
+  if (!_cache) {
+    const templates: AttackTemplate[] = [];
+    const dir = resolveTemplatesDir();
 
-  for (const category of readdirSync(dir, { withFileTypes: true })) {
-    if (!category.isDirectory()) continue;
-    const categoryDir = join(dir, category.name);
+    for (const category of readdirSync(dir, { withFileTypes: true })) {
+      if (!category.isDirectory()) continue;
+      const categoryDir = join(dir, category.name);
 
-    for (const file of readdirSync(categoryDir)) {
-      if (extname(file) !== ".yaml" && extname(file) !== ".yml") continue;
-      const raw = readFileSync(join(categoryDir, file), "utf-8");
-      const parsed = parseYaml(raw) as AttackTemplate;
-      if (depth && !parsed.depth.includes(depth)) continue;
-      templates.push(parsed);
+      for (const file of readdirSync(categoryDir)) {
+        if (extname(file) !== ".yaml" && extname(file) !== ".yml") continue;
+        const raw = readFileSync(join(categoryDir, file), "utf-8");
+        const parsed = parseYaml(raw) as AttackTemplate;
+        templates.push(parsed);
+      }
     }
+
+    _cache = templates;
   }
 
-  return templates;
+  if (depth) {
+    return _cache.filter((t) => t.depth.includes(depth));
+  }
+
+  return _cache;
 }
 
 export function loadTemplateById(id: string): AttackTemplate | undefined {
   const all = loadTemplates();
   return all.find((t) => t.id === id);
+}
+
+export function clearTemplateCache(): void {
+  _cache = null;
 }


### PR DESCRIPTION
## Summary

This PR contains 13 fixes identified through a **3-agent consensus audit** (Security Researcher, CTO/Architecture, QA Engineer). Only findings agreed upon by 2/3+ auditors were actioned.

### Security Fixes (Critical)
- **Bash tool blocklist** — dangerous command patterns blocked (rm -rf /, mkfs, fork bomb, etc.) with `PWNKIT_UNSAFE_BASH=1` escape hatch
- **Docker isolation** — replaced `--network host` with bridge network, added `--rm` for auto-cleanup, added exit handlers. `PWNKIT_DOCKER_NETWORK` override for users who need host networking
- **API key filtering** — `sanitizedEnv()` strips LLM API keys from child process environment
- **External memory isolation** — per-scan file paths (`/tmp/pwnkit-state-{scanId}.json`) with `chmod 0600` and cleanup in `finally`

### Reliability Fixes
- **ToolExecutor cleanup** — `cleanup()` now called in `finally` block in both native and legacy loops. Signal handlers for SIGINT/SIGTERM. PTY session limit (10 max) with idle timeout (10min)
- **TOOL_CALL parser** — replaced fragile regex with brace-counting JSON extractor that handles multi-line and nested JSON
- **DockerExecutor cleanup** — exit handlers stop containers on process termination
- **DB singleton** — loud warning on failure instead of silent null. `try/finally` ensures `db.close()` on all paths
- **Template caching** — in-memory cache eliminates redundant YAML re-reads per finding

### Improvements
- **Cost estimation** — expanded from 5 to 27 models with `normalizeModel()` for OpenRouter-style strings
- **Dockerfile** — replaced `curl | bash` NodeSource install with `COPY --from=builder` (supply chain hardening)

### Testing
- **7 integration tests** for the full scan pipeline (quick scan, clean target, MCP mode, stage events, timeout, warnings)

### Verification
All 469 tests pass (468 executed, 1 skipped). `pnpm build` clean. 6-agent verification audit confirmed all fixes effective.

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm --filter @pwnkit/test-targets test` — 35/35 pass
- [x] `pnpm --filter @pwnkit/core test` — 434 tests (433 pass, 1 skip)
- [x] Pipeline integration tests — 7/7 pass
- [x] 6-agent verification audit — all PASS
