### PR TITLE
docs: reduce PwnKit Labs mentions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@
 
 > Fully autonomous agentic pentesting for web apps, AI/LLM apps, package ecosystems, and source code.
 
-> **A PwnKit Labs product.**
-
 This README is the fast path. The detailed command reference, configuration, architecture notes, recipes, and benchmark breakdowns live in the docs site.
 
 ## Quick Start
@@ -162,4 +160,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-[Apache 2.0](LICENSE) — built by [PwnKit Labs](https://github.com/PwnKit-Labs) and [Doruk Tan Ozturk](https://doruk.ch).
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
## Summary

Matches the cleanup landed in PwnKit-Labs/foxguard#57. Drops two redundant PwnKit Labs mentions from this README, leaving only the bottom \"Part of PwnKit Labs\" umbrella section as the single source of umbrella branding.

## Changes

- **Dropped** \`> **A PwnKit Labs product.**\` blockquote near the top (under the main tagline)
- **Dropped** \`built by PwnKit Labs and Doruk Tan Ozturk\` from the License section — open-source projects attribute via LICENSE and the GitHub contributor list, not a marketing line

## Result

**PwnKit Labs mention count: 4 → 2** (both in the same bottom umbrella section). Same shape the foxguard README now has after #57.

## Refs

- PwnKit-Labs/foxguard#57 (the equivalent cleanup in foxguard)
- PwnKit-Labs/pwnkit#118 (the original umbrella section addition)