### PR TITLE
fix: call ToolExecutor.cleanup() in finally, add PTY session limits

### DIFF
--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -116,8 +116,17 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
     });
   }
 
+  // ── Graceful cleanup on signals ──
+  const signalCleanup = () => {
+    executor.cleanup();
+    process.exit(1);
+  };
+  process.on("SIGINT", signalCleanup);
+  process.on("SIGTERM", signalCleanup);
+
   // ── Main loop ──
 
+  try {
   while (!state.done && state.turnCount < config.maxTurns) {
     state.turnCount++;
 
@@ -295,6 +304,11 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
   }
 
   return state;
+  } finally {
+    executor.cleanup();
+    process.removeListener("SIGINT", signalCleanup);
+    process.removeListener("SIGTERM", signalCleanup);
+  }
 }
 
 // ── Parse tool calls from assistant response ──

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -196,8 +196,17 @@ export async function runNativeAgentLoop(
     });
   }
 
+  // ── Graceful cleanup on signals ──
+  const signalCleanup = () => {
+    executor.cleanup();
+    process.exit(1);
+  };
+  process.on("SIGINT", signalCleanup);
+  process.on("SIGTERM", signalCleanup);
+
   // ── Main loop ──
 
+  try {
   while (!state.done && state.turnCount < config.maxTurns) {
     state.turnCount++;
 
@@ -583,6 +592,11 @@ export async function runNativeAgentLoop(
   }
 
   return state;
+  } finally {
+    executor.cleanup();
+    process.removeListener("SIGINT", signalCleanup);
+    process.removeListener("SIGTERM", signalCleanup);
+  }
 }
 
 // ── Context Window Compaction (BoxPwnr-style) ──

--- a/packages/core/src/agent/pty-session.ts
+++ b/packages/core/src/agent/pty-session.ts
@@ -19,6 +19,9 @@ export interface PtySession {
   alive: boolean;
 }
 
+export const MAX_CONCURRENT_SESSIONS = 10;
+export const IDLE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
 export class PtySessionManager {
   private sessions = new Map<string, PtySession>();
 
@@ -26,6 +29,12 @@ export class PtySessionManager {
    * Create a new interactive session backed by a shell process.
    */
   createSession(name: string, opts?: { cwd?: string; env?: Record<string, string> }): PtySession {
+    // Enforce concurrent session limit
+    const aliveSessions = Array.from(this.sessions.values()).filter((s) => s.alive);
+    if (aliveSessions.length >= MAX_CONCURRENT_SESSIONS) {
+      throw new Error(`Maximum concurrent sessions (${MAX_CONCURRENT_SESSIONS}) reached. Close an existing session first.`);
+    }
+
     // Prevent duplicate session names
     for (const s of this.sessions.values()) {
       if (s.name === name && s.alive) {
@@ -189,6 +198,25 @@ export class PtySessionManager {
       if (s.name === name) return s;
     }
     return undefined;
+  }
+
+  /**
+   * Close sessions that have been idle (no output) longer than IDLE_TIMEOUT_MS.
+   */
+  reapIdleSessions(): number {
+    const now = Date.now();
+    let reaped = 0;
+    for (const [id, session] of this.sessions) {
+      if (session.alive && now - session.createdAt >= IDLE_TIMEOUT_MS) {
+        try {
+          this.close(id);
+          reaped++;
+        } catch {
+          // Best-effort
+        }
+      }
+    }
+    return reaped;
   }
 
   private getSession(sessionId: string): PtySession {


### PR DESCRIPTION
- cleanup() in try/finally for both native and legacy loops
- Signal handlers for graceful teardown
- PTY: max 10 sessions, 10min idle timeout, reapIdleSessions()