### PR TITLE
Make kernel crash validation use a real QEMU guest path

### DIFF
--- a/.github/workflows/kernel-validator-e2e.yml
+++ b/.github/workflows/kernel-validator-e2e.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
+    env:
+      KERNEL_VM_ARTIFACT_ROOT: ${{ runner.temp }}/kernel-vm
+
     steps:
       - uses: actions/checkout@v6
 
@@ -49,13 +52,34 @@ jobs:
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-system-x86 qemu-utils
 
+      - name: Restore cached kernel VM artifacts
+        id: kernel-vm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.KERNEL_VM_ARTIFACT_ROOT }}
+          key: kernel-vm-artifacts-${{ runner.os }}-${{ hashFiles('packages/core/src/triage/kernel-vm/Dockerfile', 'packages/core/src/triage/kernel-vm/build.sh') }}
+
       - name: Build kernel VM artifacts
+        if: steps.kernel-vm-cache.outputs.cache-hit != 'true'
         env:
           PWNKIT_KERNEL_VM_MAKE_JOBS: "4"
         run: |
-          ARTIFACT_ROOT="${RUNNER_TEMP}/kernel-vm"
+          ARTIFACT_ROOT="${KERNEL_VM_ARTIFACT_ROOT}"
           mkdir -p "${ARTIFACT_ROOT}"
           bash packages/core/src/triage/kernel-vm/build.sh "${ARTIFACT_ROOT}"
+
+      - name: Save kernel VM artifacts cache
+        if: steps.kernel-vm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.KERNEL_VM_ARTIFACT_ROOT }}
+          key: ${{ steps.kernel-vm-cache.outputs.cache-primary-key }}
+
+      - name: Verify kernel VM artifacts exist
+        run: |
+          test -f "${KERNEL_VM_ARTIFACT_ROOT}/bzImage"
+          test -f "${KERNEL_VM_ARTIFACT_ROOT}/rootfs.img"
+          test -f "${KERNEL_VM_ARTIFACT_ROOT}/kernel.config"
 
       - name: Run real kernel validator E2E
         env:

--- a/.github/workflows/kernel-validator-e2e.yml
+++ b/.github/workflows/kernel-validator-e2e.yml
@@ -33,9 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
-    env:
-      KERNEL_VM_ARTIFACT_ROOT: ${{ runner.temp }}/kernel-vm
-
     steps:
       - uses: actions/checkout@v6
 
@@ -56,7 +53,7 @@ jobs:
         id: kernel-vm-cache
         uses: actions/cache/restore@v4
         with:
-          path: ${{ env.KERNEL_VM_ARTIFACT_ROOT }}
+          path: ${{ runner.temp }}/kernel-vm
           key: kernel-vm-artifacts-${{ runner.os }}-${{ hashFiles('packages/core/src/triage/kernel-vm/Dockerfile', 'packages/core/src/triage/kernel-vm/build.sh') }}
 
       - name: Build kernel VM artifacts
@@ -64,7 +61,7 @@ jobs:
         env:
           PWNKIT_KERNEL_VM_MAKE_JOBS: "4"
         run: |
-          ARTIFACT_ROOT="${KERNEL_VM_ARTIFACT_ROOT}"
+          ARTIFACT_ROOT="${RUNNER_TEMP}/kernel-vm"
           mkdir -p "${ARTIFACT_ROOT}"
           bash packages/core/src/triage/kernel-vm/build.sh "${ARTIFACT_ROOT}"
 
@@ -72,14 +69,14 @@ jobs:
         if: steps.kernel-vm-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ${{ env.KERNEL_VM_ARTIFACT_ROOT }}
+          path: ${{ runner.temp }}/kernel-vm
           key: ${{ steps.kernel-vm-cache.outputs.cache-primary-key }}
 
       - name: Verify kernel VM artifacts exist
         run: |
-          test -f "${KERNEL_VM_ARTIFACT_ROOT}/bzImage"
-          test -f "${KERNEL_VM_ARTIFACT_ROOT}/rootfs.img"
-          test -f "${KERNEL_VM_ARTIFACT_ROOT}/kernel.config"
+          test -f "${RUNNER_TEMP}/kernel-vm/bzImage"
+          test -f "${RUNNER_TEMP}/kernel-vm/rootfs.img"
+          test -f "${RUNNER_TEMP}/kernel-vm/kernel.config"
 
       - name: Run real kernel validator E2E
         env:

--- a/.github/workflows/kernel-validator-e2e.yml
+++ b/.github/workflows/kernel-validator-e2e.yml
@@ -1,0 +1,79 @@
+name: Kernel Validator E2E
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/kernel-validator-e2e.yml"
+      - "scripts/kernel-validator-e2e.sh"
+      - "packages/core/src/triage/kernel-oracle.ts"
+      - "packages/core/src/triage/kernel-vm-runner.ts"
+      - "packages/core/src/triage/kernel-vm/**"
+      - "packages/core/src/ingest/**"
+      - "packages/cli/src/commands/ingest.ts"
+      - "docs/src/content/docs/commands.md"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/kernel-validator-e2e.yml"
+      - "scripts/kernel-validator-e2e.sh"
+      - "packages/core/src/triage/kernel-oracle.ts"
+      - "packages/core/src/triage/kernel-vm-runner.ts"
+      - "packages/core/src/triage/kernel-vm/**"
+      - "packages/core/src/ingest/**"
+      - "packages/cli/src/commands/ingest.ts"
+      - "docs/src/content/docs/commands.md"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  kernel-validator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: corepack enable && corepack prepare pnpm@9 --activate
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y qemu-system-x86 qemu-utils
+
+      - name: Build kernel VM artifacts
+        env:
+          PWNKIT_KERNEL_VM_MAKE_JOBS: "4"
+        run: |
+          ARTIFACT_ROOT="${RUNNER_TEMP}/kernel-vm"
+          mkdir -p "${ARTIFACT_ROOT}"
+          bash packages/core/src/triage/kernel-vm/build.sh "${ARTIFACT_ROOT}"
+
+      - name: Run real kernel validator E2E
+        env:
+          PWNKIT_KERNEL_QEMU_KERNEL: ${{ runner.temp }}/kernel-vm/bzImage
+          PWNKIT_KERNEL_QEMU_DISK: ${{ runner.temp }}/kernel-vm/rootfs.img
+          PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC: "180"
+          PWNKIT_KERNEL_QEMU_TIMEOUT_SEC: "60"
+          PWNKIT_KERNEL_QEMU_ARTIFACT_DIR: ${{ runner.temp }}/kernel-vm-e2e
+        run: |
+          bash scripts/kernel-validator-e2e.sh | tee "${RUNNER_TEMP}/kernel-validator-summary.json"
+
+      - name: Upload kernel validator artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-validator-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/kernel-vm/
+            ${{ runner.temp }}/kernel-vm-e2e/
+            ${{ runner.temp }}/kernel-validator-summary.json
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ bun add -g pwnkit-cli
 - `scan` targets AI / LLM apps, web apps, REST / OpenAPI APIs, and MCP servers.
 - `audit` installs and inspects packages across `npm`, `pypi`, `cargo`, and `oci` with ecosystem-specific prep, static analysis, and AI review.
 - `review` performs deep source-code security review on a local repo or Git URL.
-- `ingest` parses kernel crash reports and can validate them against reproducers, including a real QEMU/SSH kernel VM path when configured.
+- `ingest` parses kernel crash reports and can validate them against reproducers, including a real QEMU kernel VM path that compiles and runs reproducers inside the guest when configured.
 - `triage-data` turns benchmark runs and verified findings into labeled JSONL for triage-model training.
 - `cloud-sink` can stream findings and final reports to an orchestrator with `PWNKIT_CLOUD_SINK` + `PWNKIT_CLOUD_SCAN_ID`.
 - `dashboard`, `history`, `findings`, and `triage` provide local persistence and review workflows.

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -252,6 +252,7 @@ export PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC=120
 export PWNKIT_KERNEL_QEMU_TIMEOUT_SEC=60
 export PWNKIT_KERNEL_QEMU_ACCEL=kvm
 export PWNKIT_KERNEL_QEMU_SHARE_TAG=pwnkitshare
+export PWNKIT_KERNEL_QEMU_ARTIFACT_DIR=/tmp/pwnkit-kvm-runs
 ```
 
 If the VM is not configured, pwnkit does **not** claim a reproduced crash; it reports static-only verification with capped confidence.

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -231,8 +231,9 @@ Without a configured kernel VM, verification falls back to static consistency an
 
 Set `PWNKIT_KERNEL_QEMU=1` to enable VM-backed execution. The runner expects a bootable guest image with:
 
-- an SSH server reachable on port 22 inside the guest
+- a boot path that mounts the `pwnkitshare` 9p share and executes `/mnt/pwnkit/runner.sh`
 - a working C toolchain (`gcc`)
+- a linker toolchain (`ld`, provided by `binutils`)
 - permission to read kernel logs via `dmesg`
 
 Required environment variables:
@@ -240,19 +241,17 @@ Required environment variables:
 ```bash
 export PWNKIT_KERNEL_QEMU=1
 export PWNKIT_KERNEL_QEMU_KERNEL=/path/to/bzImage
-export PWNKIT_KERNEL_QEMU_DISK=/path/to/rootfs.qcow2
+export PWNKIT_KERNEL_QEMU_DISK=/path/to/rootfs.img
 ```
 
 Useful optional variables:
 
 ```bash
-export PWNKIT_KERNEL_QEMU_SSH_USER=root
-export PWNKIT_KERNEL_QEMU_SSH_KEY=/path/to/id_ed25519
-export PWNKIT_KERNEL_QEMU_SSH_PORT=10022
-export PWNKIT_KERNEL_QEMU_APPEND='console=ttyS0 root=/dev/vda rw nokaslr panic=-1'
+export PWNKIT_KERNEL_QEMU_APPEND='console=ttyS0 root=/dev/vda rw nokaslr panic=-1 init=/sbin/pwnkit-init'
 export PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC=120
 export PWNKIT_KERNEL_QEMU_TIMEOUT_SEC=60
 export PWNKIT_KERNEL_QEMU_ACCEL=kvm
+export PWNKIT_KERNEL_QEMU_SHARE_TAG=pwnkitshare
 ```
 
 If the VM is not configured, pwnkit does **not** claim a reproduced crash; it reports static-only verification with capped confidence.

--- a/packages/core/src/triage/kernel-oracle.test.ts
+++ b/packages/core/src/triage/kernel-oracle.test.ts
@@ -5,7 +5,7 @@ vi.mock("./kernel-vm-runner.js", () => ({
   runReproducerInKernelVm: vi.fn(),
 }));
 
-import { compileAndRunReproducer, verifyKernelCrash } from "./kernel-oracle.js";
+import { compileAndRunReproducer, verifyKernelCrash, matchCrashSignature } from "./kernel-oracle.js";
 import { runReproducerInKernelVm } from "./kernel-vm-runner.js";
 
 const runVmMock = vi.mocked(runReproducerInKernelVm);
@@ -122,5 +122,36 @@ Allocated by task 1100:
     expect(result.reproduced).toBe(true);
     expect(result.crashMatch).toBe(true);
     expect(result.reproducedCrashType).toBe("kasan-oob");
+  });
+});
+
+describe("matchCrashSignature", () => {
+  it("ignores generic reporting frames and accepts invalid-free for double-free reports", () => {
+    const result = matchCrashSignature(
+      {
+        raw: "BUG: KASAN: invalid-free",
+        crashType: "kasan-double-free",
+        faultingFunction: "release_gid_table",
+        stackFrames: [
+          "dump_stack_lvl+0xe8/0x150",
+          "print_address_description+0x55/0x1e0",
+          "print_report+0x58/0x70",
+          "release_gid_table+0x1a/0x30",
+          "gid_table_release_one+0x384/0x470",
+        ],
+      },
+      `
+BUG: KASAN: invalid-free in release_gid_table+0x1a/0x30
+Call Trace:
+ release_gid_table+0x1a/0x30
+ gid_table_release_one+0x384/0x470
+ ib_device_release+0xd2/0x1c0
+`,
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.matchedFields).toContain("crashType");
+    expect(result.matchedFields).toContain("faultingFunction");
+    expect(result.mismatchedFields).not.toContain("stackFrame[0]:dump_stack_lvl");
   });
 });

--- a/packages/core/src/triage/kernel-oracle.ts
+++ b/packages/core/src/triage/kernel-oracle.ts
@@ -145,8 +145,8 @@ const SUBSYSTEM_SYSCALLS: Record<string, RegExp[]> = {
  * Compile and run the reproducer inside a configured kernel VM.
  *
  * When `PWNKIT_KERNEL_QEMU=1`, this boots the configured VM assets and
- * executes the reproducer over SSH. Otherwise it returns a stub indicating
- * no execution.
+ * executes the reproducer via a host-shared working directory. Otherwise
+ * it returns a stub indicating no execution.
  */
 export async function compileAndRunReproducer(
   report: CrashReport,

--- a/packages/core/src/triage/kernel-oracle.ts
+++ b/packages/core/src/triage/kernel-oracle.ts
@@ -137,6 +137,33 @@ const SUBSYSTEM_SYSCALLS: Record<string, RegExp[]> = {
   netlink: [/\bsocket\b/, /\bnetlink\b/i, /\bbind\b/, /\bsendmsg\b/],
 };
 
+const NOISY_CRASH_FRAMES = [
+  /^dump_stack/,
+  /^print_/,
+  /^kasan_report/,
+  /^__kasan_/,
+  /^check_slab_allocation$/,
+  /^kfree$/,
+  /^report_cfi_failure$/,
+  /^ubsan_/,
+  /^__ubsan_/,
+];
+
+function extractFrameFunction(frame: string): string {
+  const funcMatch = frame.match(/([a-zA-Z_][\w]*)\+0x/);
+  return funcMatch ? funcMatch[1]! : frame.trim();
+}
+
+function isNoisyCrashFrame(frame: string): boolean {
+  const funcName = extractFrameFunction(frame);
+  return NOISY_CRASH_FRAMES.some((pattern) => pattern.test(funcName));
+}
+
+function selectRelevantFrames(frames: string[]): string[] {
+  const filtered = frames.filter((frame) => !isNoisyCrashFrame(frame));
+  return filtered.length > 0 ? filtered : frames;
+}
+
 // ────────────────────────────────────────────────────────────────────
 // Core functions
 // ────────────────────────────────────────────────────────────────────
@@ -214,7 +241,7 @@ export function matchCrashSignature(
   const typePatterns: Record<string, RegExp> = {
     "kasan-oob": /kasan.*out-of-bounds|slab-out-of-bounds/i,
     "kasan-uaf": /kasan.*use-after-free|slab-use-after-free/i,
-    "kasan-double-free": /kasan.*double-free/i,
+    "kasan-double-free": /kasan.*double-free|kasan.*invalid-free|invalid-free/i,
     "null-deref": /null pointer dereference|kernel null pointer/i,
     "stack-oob": /kasan.*stack-out-of-bounds|stack-buffer-overflow/i,
     "ubsan": /ubsan/i,
@@ -249,12 +276,10 @@ export function matchCrashSignature(
   }
 
   // ── Top 3 stack frames ─────────────────────────────────────
-  const topFrames = original.stackFrames.slice(0, 3);
+  const topFrames = selectRelevantFrames(original.stackFrames).slice(0, 3);
   for (let i = 0; i < topFrames.length; i++) {
     const frame = topFrames[i]!;
-    // Extract the function name from the frame (strip offset + module)
-    const funcMatch = frame.match(/([a-zA-Z_][\w]*)\+0x/);
-    const funcName = funcMatch ? funcMatch[1]! : frame.trim();
+    const funcName = extractFrameFunction(frame);
     if (reproOutput.includes(funcName)) {
       score += 0.1;
       matchedFields.push(`stackFrame[${i}]:${funcName}`);

--- a/packages/core/src/triage/kernel-vm-runner.ts
+++ b/packages/core/src/triage/kernel-vm-runner.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ReproducerResult, CrashReport } from "./kernel-oracle.js";
@@ -17,6 +17,7 @@ export interface KernelVmConfig {
   initrdPath?: string;
   timeoutSec: number;
   shareTag: string;
+  artifactDir?: string;
 }
 
 function shellQuote(value: string): string {
@@ -58,6 +59,7 @@ export function loadKernelVmConfigFromEnv(): KernelVmConfig {
     initrdPath: process.env.PWNKIT_KERNEL_QEMU_INITRD?.trim() || undefined,
     timeoutSec: parseInt(process.env.PWNKIT_KERNEL_QEMU_TIMEOUT_SEC?.trim() || "60", 10),
     shareTag: process.env.PWNKIT_KERNEL_QEMU_SHARE_TAG?.trim() || "pwnkitshare",
+    artifactDir: process.env.PWNKIT_KERNEL_QEMU_ARTIFACT_DIR?.trim() || undefined,
   };
 }
 
@@ -185,7 +187,12 @@ export async function runReproducerInKernelVm(report: CrashReport): Promise<Repr
   }
 
   const config = loadKernelVmConfigFromEnv();
-  const hostTmpDir = mkdtempSync(join(tmpdir(), "pwnkit-kvm-"));
+  const hostTmpDir = config.artifactDir
+    ? (() => {
+        mkdirSync(config.artifactDir!, { recursive: true });
+        return mkdtempSync(join(config.artifactDir!, "pwnkit-kvm-"));
+      })()
+    : mkdtempSync(join(tmpdir(), "pwnkit-kvm-"));
   const sourcePath = join(hostTmpDir, "repro.c");
   const runnerScriptPath = join(hostTmpDir, "runner.sh");
   const serialLogPath = join(hostTmpDir, "serial.log");
@@ -230,6 +237,8 @@ export async function runReproducerInKernelVm(report: CrashReport): Promise<Repr
     };
   } finally {
     await stopVm(vmProc);
-    rmSync(hostTmpDir, { recursive: true, force: true });
+    if (!config.artifactDir) {
+      rmSync(hostTmpDir, { recursive: true, force: true });
+    }
   }
 }

--- a/packages/core/src/triage/kernel-vm-runner.ts
+++ b/packages/core/src/triage/kernel-vm-runner.ts
@@ -1,4 +1,4 @@
-import { execFile, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,28 +9,15 @@ export interface KernelVmConfig {
   kernelImage: string;
   diskImage: string;
   diskFormat: "raw" | "qcow2";
-  sshBinary: string;
-  scpBinary: string;
-  sshHost: string;
-  sshPort: number;
-  sshUser: string;
-  sshKeyPath?: string;
   bootTimeoutSec: number;
   memoryMb: number;
   smp: number;
-  remoteWorkDir: string;
   kernelAppend: string;
   qemuAccel?: string;
   initrdPath?: string;
   timeoutSec: number;
+  shareTag: string;
 }
-
-const SSH_COMMON_ARGS = [
-  "-o", "StrictHostKeyChecking=no",
-  "-o", "UserKnownHostsFile=/dev/null",
-  "-o", "BatchMode=yes",
-  "-o", "ConnectTimeout=5",
-];
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
@@ -63,32 +50,29 @@ export function loadKernelVmConfigFromEnv(): KernelVmConfig {
     kernelImage: resolvedKernelImage,
     diskImage: resolvedDiskImage,
     diskFormat: (process.env.PWNKIT_KERNEL_QEMU_DISK_FORMAT?.trim() as "raw" | "qcow2" | undefined) || inferDiskFormat(resolvedDiskImage),
-    sshBinary: process.env.PWNKIT_KERNEL_QEMU_SSH_BINARY?.trim() || "ssh",
-    scpBinary: process.env.PWNKIT_KERNEL_QEMU_SCP_BINARY?.trim() || "scp",
-    sshHost: process.env.PWNKIT_KERNEL_QEMU_SSH_HOST?.trim() || "127.0.0.1",
-    sshPort: parseInt(process.env.PWNKIT_KERNEL_QEMU_SSH_PORT?.trim() || "10022", 10),
-    sshUser: process.env.PWNKIT_KERNEL_QEMU_SSH_USER?.trim() || "root",
-    sshKeyPath: process.env.PWNKIT_KERNEL_QEMU_SSH_KEY?.trim() || undefined,
     bootTimeoutSec: parseInt(process.env.PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC?.trim() || "120", 10),
     memoryMb: parseInt(process.env.PWNKIT_KERNEL_QEMU_MEMORY_MB?.trim() || "2048", 10),
     smp: parseInt(process.env.PWNKIT_KERNEL_QEMU_SMP?.trim() || "2", 10),
-    remoteWorkDir: process.env.PWNKIT_KERNEL_QEMU_REMOTE_DIR?.trim() || "/root/pwnkit-kernel",
-    kernelAppend: process.env.PWNKIT_KERNEL_QEMU_APPEND?.trim() || "console=ttyS0 root=/dev/vda rw nokaslr panic=-1",
+    kernelAppend: process.env.PWNKIT_KERNEL_QEMU_APPEND?.trim() || "console=ttyS0 root=/dev/vda rw nokaslr panic=-1 init=/sbin/pwnkit-init",
     qemuAccel: process.env.PWNKIT_KERNEL_QEMU_ACCEL?.trim() || undefined,
     initrdPath: process.env.PWNKIT_KERNEL_QEMU_INITRD?.trim() || undefined,
     timeoutSec: parseInt(process.env.PWNKIT_KERNEL_QEMU_TIMEOUT_SEC?.trim() || "60", 10),
+    shareTag: process.env.PWNKIT_KERNEL_QEMU_SHARE_TAG?.trim() || "pwnkitshare",
   };
 }
 
-export function buildQemuCommand(config: KernelVmConfig, serialLogPath: string): { command: string; args: string[] } {
+export function buildQemuCommand(
+  config: KernelVmConfig,
+  serialLogPath: string,
+  sharedDir: string,
+): { command: string; args: string[] } {
   const args = [
     "-m", String(config.memoryMb),
     "-smp", String(config.smp),
     "-kernel", config.kernelImage,
     "-drive", `file=${config.diskImage},format=${config.diskFormat},if=virtio`,
     "-append", config.kernelAppend,
-    "-netdev", `user,id=net0,hostfwd=tcp::${config.sshPort}-:22`,
-    "-device", "virtio-net-pci,netdev=net0",
+    "-virtfs", `local,path=${sharedDir},mount_tag=${config.shareTag},security_model=none,id=hostshare`,
     "-nographic",
     "-monitor", "none",
     "-serial", `file:${serialLogPath}`,
@@ -103,50 +87,6 @@ export function buildQemuCommand(config: KernelVmConfig, serialLogPath: string):
   }
 
   return { command: config.qemuBinary, args };
-}
-
-function buildSshBaseArgs(config: KernelVmConfig): string[] {
-  const args = [...SSH_COMMON_ARGS];
-  if (config.sshKeyPath) {
-    args.push("-i", config.sshKeyPath);
-  }
-  return args;
-}
-
-function execFileCaptured(
-  file: string,
-  args: string[],
-  timeoutMs: number,
-): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
-  return new Promise((resolve) => {
-    execFile(
-      file,
-      args,
-      {
-        encoding: "utf-8",
-        timeout: timeoutMs,
-        maxBuffer: 4 * 1024 * 1024,
-      },
-      (error, stdout, stderr) => {
-        if (!error) {
-          resolve({
-            stdout: stdout ?? "",
-            stderr: stderr ?? "",
-            exitCode: 0,
-            timedOut: false,
-          });
-          return;
-        }
-        const err = error as NodeJS.ErrnoException & { code?: string; killed?: boolean; signal?: string; };
-        resolve({
-          stdout: stdout ?? "",
-          stderr: stderr ?? String(error),
-          exitCode: typeof (err as { code?: number }).code === "number" ? (err as { code?: number }).code! : 1,
-          timedOut: err.killed || err.signal === "SIGTERM",
-        });
-      },
-    );
-  });
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -165,44 +105,71 @@ async function stopVm(proc: ReturnType<typeof spawn>): Promise<void> {
   }
 }
 
-async function waitForVmSsh(config: KernelVmConfig, proc: ReturnType<typeof spawn>, bootLogPath: string): Promise<void> {
-  const target = `${config.sshUser}@${config.sshHost}`;
-  const deadline = Date.now() + config.bootTimeoutSec * 1000;
+function renderGuestRunnerScript(config: KernelVmConfig): string {
+  return [
+    "#!/bin/sh",
+    "set -eu",
+    "SHARE_DIR=/mnt/pwnkit",
+    "WORK_DIR=/tmp/pwnkit-run",
+    "mkdir -p \"$WORK_DIR\"",
+    "compiled=0",
+    "executed=0",
+    "exit_code=0",
+    "timed_out=0",
+    "cp \"$SHARE_DIR/repro.c\" \"$WORK_DIR/repro.c\"",
+    `if /usr/bin/gcc -B/usr/bin/ -O0 -g -o "$WORK_DIR/repro" "$WORK_DIR/repro.c" -lpthread >"$SHARE_DIR/compile.log" 2>&1; then`,
+    "  compiled=1",
+    "else",
+    "  exit_code=$?",
+    "fi",
+    "if [ \"$compiled\" = \"1\" ]; then",
+    "  dmesg -C 2>/dev/null || true",
+    `  if timeout ${shellQuote(String(config.timeoutSec))}s "$WORK_DIR/repro" >"$SHARE_DIR/run.log" 2>&1; then`,
+    "    executed=1",
+    "    exit_code=0",
+    "  else",
+    "    exit_code=$?",
+    "    if [ \"$exit_code\" = \"124\" ]; then",
+    "      timed_out=1",
+    "    else",
+    "      executed=1",
+    "    fi",
+    "  fi",
+    "else",
+    "  : > \"$SHARE_DIR/run.log\"",
+    "fi",
+    "dmesg 2>/dev/null > \"$SHARE_DIR/dmesg.log\" || true",
+    "printf '%s\\n' \"$compiled\" > \"$SHARE_DIR/compiled.ok\"",
+    "printf '%s\\n' \"$executed\" > \"$SHARE_DIR/executed.ok\"",
+    "printf '%s\\n' \"$exit_code\" > \"$SHARE_DIR/exit_code\"",
+    "printf '%s\\n' \"$timed_out\" > \"$SHARE_DIR/timed_out\"",
+    "sync",
+  ].join("\n");
+}
+
+async function waitForVmResult(
+  config: KernelVmConfig,
+  proc: ReturnType<typeof spawn>,
+  hostTmpDir: string,
+  bootLogPath: string,
+): Promise<void> {
+  const totalBudgetSec = config.bootTimeoutSec + config.timeoutSec + 60;
+  const deadline = Date.now() + totalBudgetSec * 1000;
+  const compiledMarker = join(hostTmpDir, "compiled.ok");
 
   while (Date.now() < deadline) {
+    if (existsSync(compiledMarker)) {
+      return;
+    }
     if (proc.exitCode !== null) {
       const bootLog = existsSync(bootLogPath) ? readFileSync(bootLogPath, "utf-8").slice(-4000) : "";
-      throw new Error(`kernel VM exited before SSH became available (exit=${proc.exitCode}).\n${bootLog}`);
+      throw new Error(`kernel VM exited before producing results (exit=${proc.exitCode}).\n${bootLog}`);
     }
-    const result = await execFileCaptured(
-      config.sshBinary,
-      [...buildSshBaseArgs(config), "-p", String(config.sshPort), target, "true"],
-      7_000,
-    );
-    if (result.exitCode === 0) return;
     await sleep(2_000);
   }
 
   const bootLog = existsSync(bootLogPath) ? readFileSync(bootLogPath, "utf-8").slice(-4000) : "";
-  throw new Error(`timed out waiting for kernel VM SSH on ${config.sshHost}:${config.sshPort}.\n${bootLog}`);
-}
-
-async function runRemoteCommand(config: KernelVmConfig, command: string, timeoutSec: number): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
-  const target = `${config.sshUser}@${config.sshHost}`;
-  return execFileCaptured(
-    config.sshBinary,
-    [...buildSshBaseArgs(config), "-p", String(config.sshPort), target, "bash", "-lc", command],
-    timeoutSec * 1000,
-  );
-}
-
-async function copyFileToVm(config: KernelVmConfig, localPath: string, remotePath: string): Promise<{ stdout: string; stderr: string; exitCode: number; timedOut: boolean }> {
-  const target = `${config.sshUser}@${config.sshHost}:${remotePath}`;
-  return execFileCaptured(
-    config.scpBinary,
-    [...buildSshBaseArgs(config), "-P", String(config.sshPort), localPath, target],
-    30_000,
-  );
+  throw new Error(`timed out waiting for kernel VM results in shared dir ${hostTmpDir} after ${totalBudgetSec}s.\n${bootLog}`);
 }
 
 export async function runReproducerInKernelVm(report: CrashReport): Promise<ReproducerResult> {
@@ -220,79 +187,46 @@ export async function runReproducerInKernelVm(report: CrashReport): Promise<Repr
   const config = loadKernelVmConfigFromEnv();
   const hostTmpDir = mkdtempSync(join(tmpdir(), "pwnkit-kvm-"));
   const sourcePath = join(hostTmpDir, "repro.c");
+  const runnerScriptPath = join(hostTmpDir, "runner.sh");
   const serialLogPath = join(hostTmpDir, "serial.log");
-  const remoteDir = config.remoteWorkDir.replace(/\/+$/, "");
-  const remoteSource = `${remoteDir}/repro.c`;
-  const remoteBinary = `${remoteDir}/repro`;
   writeFileSync(sourcePath, report.reproducer, "utf-8");
+  writeFileSync(runnerScriptPath, renderGuestRunnerScript(config), "utf-8");
 
-  const { command, args } = buildQemuCommand(config, serialLogPath);
+  const { command, args } = buildQemuCommand(config, serialLogPath, hostTmpDir);
   const vmProc = spawn(command, args, {
     stdio: "ignore",
   });
 
   try {
-    await waitForVmSsh(config, vmProc, serialLogPath);
+    await waitForVmResult(config, vmProc, hostTmpDir, serialLogPath);
 
-    const mkdirResult = await runRemoteCommand(
-      config,
-      `mkdir -p ${shellQuote(remoteDir)}`,
-      15,
-    );
-    if (mkdirResult.exitCode !== 0) {
-      return {
-        compiled: false,
-        executed: false,
-        output: mkdirResult.stderr || mkdirResult.stdout,
-        dmesg: "",
-        exitCode: mkdirResult.exitCode,
-        timedOut: mkdirResult.timedOut,
-      };
-    }
-
-    const scpResult = await copyFileToVm(config, sourcePath, remoteSource);
-    if (scpResult.exitCode !== 0) {
-      return {
-        compiled: false,
-        executed: false,
-        output: scpResult.stderr || scpResult.stdout,
-        dmesg: existsSync(serialLogPath) ? readFileSync(serialLogPath, "utf-8").slice(-4000) : "",
-        exitCode: scpResult.exitCode,
-        timedOut: scpResult.timedOut,
-      };
-    }
-
-    const compileResult = await runRemoteCommand(
-      config,
-      `gcc -O0 -g -o ${shellQuote(remoteBinary)} ${shellQuote(remoteSource)} -lpthread 2>&1`,
-      config.timeoutSec,
-    );
-    if (compileResult.exitCode !== 0) {
-      return {
-        compiled: false,
-        executed: false,
-        output: (compileResult.stdout + compileResult.stderr).trim(),
-        dmesg: "",
-        exitCode: compileResult.exitCode,
-        timedOut: compileResult.timedOut,
-      };
-    }
-
-    await runRemoteCommand(config, "dmesg -C 2>/dev/null || true", 10);
-    const runResult = await runRemoteCommand(
-      config,
-      `timeout ${config.timeoutSec}s ${shellQuote(remoteBinary)} 2>&1 || true`,
-      config.timeoutSec + 15,
-    );
-    const dmesgResult = await runRemoteCommand(config, "dmesg 2>/dev/null || true", 20);
+    const compiled = readFileSync(join(hostTmpDir, "compiled.ok"), "utf-8").trim() === "1";
+    const executed = existsSync(join(hostTmpDir, "executed.ok"))
+      ? readFileSync(join(hostTmpDir, "executed.ok"), "utf-8").trim() === "1"
+      : false;
+    const exitCode = existsSync(join(hostTmpDir, "exit_code"))
+      ? parseInt(readFileSync(join(hostTmpDir, "exit_code"), "utf-8").trim(), 10)
+      : 1;
+    const timedOut = existsSync(join(hostTmpDir, "timed_out"))
+      ? readFileSync(join(hostTmpDir, "timed_out"), "utf-8").trim() === "1"
+      : false;
+    const compileLog = existsSync(join(hostTmpDir, "compile.log"))
+      ? readFileSync(join(hostTmpDir, "compile.log"), "utf-8").trim()
+      : "";
+    const runLog = existsSync(join(hostTmpDir, "run.log"))
+      ? readFileSync(join(hostTmpDir, "run.log"), "utf-8").trim()
+      : "";
+    const dmesg = existsSync(join(hostTmpDir, "dmesg.log"))
+      ? readFileSync(join(hostTmpDir, "dmesg.log"), "utf-8").trim()
+      : "";
 
     return {
-      compiled: true,
-      executed: true,
-      output: (runResult.stdout + runResult.stderr).trim(),
-      dmesg: (dmesgResult.stdout + dmesgResult.stderr).trim(),
-      exitCode: runResult.exitCode,
-      timedOut: runResult.timedOut,
+      compiled,
+      executed,
+      output: compiled ? runLog : compileLog,
+      dmesg,
+      exitCode: Number.isFinite(exitCode) ? exitCode : 1,
+      timedOut,
     };
   } finally {
     await stopVm(vmProc);

--- a/packages/core/src/triage/kernel-vm/Dockerfile
+++ b/packages/core/src/triage/kernel-vm/Dockerfile
@@ -21,6 +21,9 @@ FROM debian:bookworm-slim AS kernel-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    gcc-x86-64-linux-gnu \
+    binutils-x86-64-linux-gnu \
+    libc6-dev-amd64-cross \
     bc \
     bison \
     flex \
@@ -36,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ARG KERNEL_VERSION=6.8.12
 ARG KERNEL_URL=https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${KERNEL_VERSION}.tar.xz
+ARG KERNEL_MAKE_JOBS=4
 
 # Download and extract kernel source
 WORKDIR /build
@@ -46,7 +50,9 @@ RUN wget -q "${KERNEL_URL}" -O linux.tar.xz \
 
 # Generate kernel config with KASAN + UBSAN + debug info
 WORKDIR /build/linux
-RUN make defconfig \
+ENV ARCH=x86_64
+ENV CROSS_COMPILE=x86_64-linux-gnu-
+RUN make x86_64_defconfig \
     && scripts/config \
         --enable CONFIG_KASAN \
         --set-str CONFIG_KASAN_MODE "generic" \
@@ -94,15 +100,17 @@ RUN make defconfig \
         --enable CONFIG_IP_SCTP \
         --enable CONFIG_9P_FS \
         --enable CONFIG_NET_9P \
+        --enable CONFIG_NET_9P_VIRTIO \
         --disable CONFIG_RANDOMIZE_BASE \
         --set-val CONFIG_FRAME_WARN 2048 \
     && make olddefconfig
 
-# Build kernel (parallel, uses all cores)
-RUN make -j$(nproc) bzImage
+# Build kernel. Default to a conservative job count because this often runs
+# under amd64 emulation on arm64 hosts, where `-j$(nproc)` is prone to GCC ICEs.
+RUN make -j"${KERNEL_MAKE_JOBS}" bzImage
 
 # ── Root filesystem builder ──
-FROM debian:bookworm-slim AS rootfs-builder
+FROM --platform=linux/amd64 debian:bookworm-slim AS rootfs-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     debootstrap \
@@ -115,29 +123,59 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN mkdir -p /rootfs \
     && debootstrap --variant=minbase --include=\
 openssh-server,gcc,libc6-dev,make,kmod,procps,iproute2,iputils-ping,\
-net-tools,strace,gdb,dmesg,systemd-sysv \
+net-tools,strace,util-linux,systemd-sysv \
     bookworm /rootfs http://deb.debian.org/debian
 
 # Configure rootfs
 RUN chroot /rootfs bash -c '\
     echo "root:root" | chpasswd && \
     mkdir -p /root/.ssh && \
+    ssh-keygen -t ed25519 -N "" -f /root/.ssh/pwnkit_vm_key && \
+    cat /root/.ssh/pwnkit_vm_key.pub >> /root/.ssh/authorized_keys && \
+    chmod 600 /root/.ssh/authorized_keys && \
     ssh-keygen -A && \
+    echo "nameserver 8.8.8.8" > /etc/resolv.conf && \
     sed -i "s/#PermitRootLogin.*/PermitRootLogin yes/" /etc/ssh/sshd_config && \
     sed -i "s/#PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config && \
-    systemctl enable ssh && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends gdb isc-dhcp-client binutils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     echo "pwnkit-kernel" > /etc/hostname && \
-    mkdir -p /root/pwnkit-kernel && \
-    echo "nameserver 8.8.8.8" > /etc/resolv.conf \
+    mkdir -p /root/pwnkit-kernel \
 '
 
-# Create ext4 disk image
-RUN dd if=/dev/zero of=/rootfs.img bs=1M count=512 \
-    && mkfs.ext4 -F /rootfs.img \
-    && mkdir -p /mnt/rootfs \
-    && mount -o loop /rootfs.img /mnt/rootfs \
-    && cp -a /rootfs/* /mnt/rootfs/ \
-    && umount /mnt/rootfs
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'mount -t proc proc /proc 2>/dev/null || true' \
+    'mount -t sysfs sysfs /sys 2>/dev/null || true' \
+    'mount -t devtmpfs devtmpfs /dev 2>/dev/null || true' \
+    'mount -t tmpfs tmpfs /run 2>/dev/null || true' \
+    'mount -t tmpfs tmpfs /tmp 2>/dev/null || true' \
+    'echo "PWNKIT_INIT_START" > /dev/kmsg 2>/dev/null || true' \
+    'mkdir -p /mnt/pwnkit' \
+    'if mount -t 9p -o trans=virtio,version=9p2000.L pwnkitshare /mnt/pwnkit 2>/tmp/pwnkit-mount.err; then' \
+    '  echo "PWNKIT_INIT_SHARE_MOUNTED" > /dev/kmsg 2>/dev/null || true' \
+    'else' \
+    '  err=$(tr "\n" " " </tmp/pwnkit-mount.err 2>/dev/null || true)' \
+    '  echo "PWNKIT_INIT_SHARE_MOUNT_FAILED:${err:-unknown}" > /dev/kmsg 2>/dev/null || true' \
+    'fi' \
+    'if [ -f /mnt/pwnkit/runner.sh ]; then' \
+    '  echo "PWNKIT_INIT_RUNNER_START" > /dev/kmsg 2>/dev/null || true' \
+    '  /bin/sh /mnt/pwnkit/runner.sh' \
+    '  status=$?' \
+    '  echo "PWNKIT_INIT_RUNNER_EXIT:${status}" > /dev/kmsg 2>/dev/null || true' \
+    '  sync' \
+    '  poweroff -f 2>/dev/null || halt -f 2>/dev/null || reboot -f 2>/dev/null || exit "$status"' \
+    'fi' \
+    'echo "PWNKIT_INIT_IDLE" > /dev/kmsg 2>/dev/null || true' \
+    'sleep infinity' \
+    > /rootfs/sbin/pwnkit-init \
+    && chmod 755 /rootfs/sbin/pwnkit-init
+
+# Create ext4 disk image without requiring loop-mount support inside Docker build
+RUN truncate -s 512M /rootfs.img \
+    && mkfs.ext4 -F -d /rootfs /rootfs.img
 
 # ── Final output stage ──
 FROM debian:bookworm-slim
@@ -145,6 +183,18 @@ FROM debian:bookworm-slim
 COPY --from=kernel-builder /build/linux/arch/x86/boot/bzImage /artifacts/bzImage
 COPY --from=kernel-builder /build/linux/.config /artifacts/kernel.config
 COPY --from=rootfs-builder /rootfs.img /artifacts/rootfs.img
+COPY --from=rootfs-builder /rootfs/root/.ssh/pwnkit_vm_key /artifacts/pwnkit_vm_key
+COPY --from=rootfs-builder /rootfs/root/.ssh/pwnkit_vm_key.pub /artifacts/pwnkit_vm_key.pub
 
-# Output script: copy artifacts to /out volume
-CMD ["sh", "-c", "cp /artifacts/* /out/ && echo 'Kernel VM artifacts exported to /out/' && ls -lh /out/"]
+# Output script: copy artifacts to /out volume with host-friendly ownership.
+CMD ["sh", "-c", "\
+set -eu; \
+uid=${HOST_UID:-0}; gid=${HOST_GID:-0}; \
+install -o \"$uid\" -g \"$gid\" -m 0644 /artifacts/bzImage /out/bzImage; \
+install -o \"$uid\" -g \"$gid\" -m 0644 /artifacts/kernel.config /out/kernel.config; \
+install -o \"$uid\" -g \"$gid\" -m 0644 /artifacts/rootfs.img /out/rootfs.img; \
+install -o \"$uid\" -g \"$gid\" -m 0600 /artifacts/pwnkit_vm_key /out/pwnkit_vm_key; \
+install -o \"$uid\" -g \"$gid\" -m 0644 /artifacts/pwnkit_vm_key.pub /out/pwnkit_vm_key.pub; \
+echo 'Kernel VM artifacts exported to /out/'; \
+ls -lh /out/ \
+"]

--- a/packages/core/src/triage/kernel-vm/Dockerfile
+++ b/packages/core/src/triage/kernel-vm/Dockerfile
@@ -1,7 +1,7 @@
 # pwnkit kernel crash validator — KASAN-enabled kernel builder
 #
 # Builds a minimal Linux kernel with KASAN + UBSAN enabled, plus a
-# Debian root filesystem with SSH and GCC for reproducer compilation.
+# Debian root filesystem that boots into a shared-workdir reproducer runner.
 #
 # Usage:
 #   docker build -t pwnkit-kernel-builder -f Dockerfile .
@@ -9,7 +9,7 @@
 #
 # Outputs in /out:
 #   bzImage       — KASAN-enabled kernel
-#   rootfs.img    — ext4 root filesystem (512MB) with SSH + GCC
+#   rootfs.img    — ext4 root filesystem (512MB) with GCC/binutils + pwnkit-init
 #   kernel.config — .config used for the build
 #
 # The resulting artifacts work with the kernel-vm-runner.ts QEMU config:

--- a/packages/core/src/triage/kernel-vm/README.md
+++ b/packages/core/src/triage/kernel-vm/README.md
@@ -30,9 +30,10 @@ pwnkit ingest --verify /path/to/crash-reports/
 
 **Root filesystem** (rootfs.img, 512MB ext4):
 - Debian Bookworm minimal
-- OpenSSH server (root:root)
-- GCC + libc-dev for reproducer compilation
+- GCC + binutils + libc-dev for reproducer compilation
 - gdb, strace for debugging
+- generated `pwnkit_vm_key` / `pwnkit_vm_key.pub` pair for non-interactive SSH
+- dedicated `/sbin/pwnkit-init` boot path that mounts the host 9p share and runs `/mnt/pwnkit/runner.sh`
 
 ## Environment variables
 
@@ -41,9 +42,9 @@ pwnkit ingest --verify /path/to/crash-reports/
 | `PWNKIT_KERNEL_QEMU` | - | Set to `1` to enable |
 | `PWNKIT_KERNEL_QEMU_KERNEL` | - | Path to bzImage |
 | `PWNKIT_KERNEL_QEMU_DISK` | - | Path to rootfs.img |
-| `PWNKIT_KERNEL_QEMU_SSH_PORT` | `10022` | SSH forwarded port |
 | `PWNKIT_KERNEL_QEMU_MEMORY_MB` | `2048` | VM memory |
 | `PWNKIT_KERNEL_QEMU_SMP` | `2` | CPU cores |
 | `PWNKIT_KERNEL_QEMU_TIMEOUT_SEC` | `60` | Reproducer timeout |
 | `PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC` | `120` | Boot timeout |
 | `PWNKIT_KERNEL_QEMU_ACCEL` | - | QEMU accelerator (e.g. `kvm`) |
+| `PWNKIT_KERNEL_QEMU_SHARE_TAG` | `pwnkitshare` | 9p mount tag used by the guest boot script |

--- a/packages/core/src/triage/kernel-vm/README.md
+++ b/packages/core/src/triage/kernel-vm/README.md
@@ -32,8 +32,13 @@ pwnkit ingest --verify /path/to/crash-reports/
 - Debian Bookworm minimal
 - GCC + binutils + libc-dev for reproducer compilation
 - gdb, strace for debugging
-- generated `pwnkit_vm_key` / `pwnkit_vm_key.pub` pair for non-interactive SSH
 - dedicated `/sbin/pwnkit-init` boot path that mounts the host 9p share and runs `/mnt/pwnkit/runner.sh`
+
+## CI
+
+The real GitHub Actions E2E lane lives in `.github/workflows/kernel-validator-e2e.yml`.
+It builds the VM artifacts, boots QEMU, and runs `ingest --verify` against a real
+syzbot crash/reproducer pair while uploading the VM logs and runner outputs as artifacts.
 
 ## Environment variables
 

--- a/packages/core/src/triage/kernel-vm/README.md
+++ b/packages/core/src/triage/kernel-vm/README.md
@@ -48,3 +48,4 @@ pwnkit ingest --verify /path/to/crash-reports/
 | `PWNKIT_KERNEL_QEMU_BOOT_TIMEOUT_SEC` | `120` | Boot timeout |
 | `PWNKIT_KERNEL_QEMU_ACCEL` | - | QEMU accelerator (e.g. `kvm`) |
 | `PWNKIT_KERNEL_QEMU_SHARE_TAG` | `pwnkitshare` | 9p mount tag used by the guest boot script |
+| `PWNKIT_KERNEL_QEMU_ARTIFACT_DIR` | - | Preserve VM run artifacts (serial log, compile log, dmesg, runner outputs) instead of deleting the temp directory |

--- a/packages/core/src/triage/kernel-vm/build.sh
+++ b/packages/core/src/triage/kernel-vm/build.sh
@@ -5,8 +5,10 @@
 #
 # Outputs:
 #   bzImage       — KASAN-enabled kernel
-#   rootfs.img    — Debian root filesystem with SSH + GCC
+#   rootfs.img    — Debian root filesystem with GCC/binutils + pwnkit-init
 #   kernel.config — kernel .config
+#   pwnkit_vm_key — SSH private key for the guest
+#   pwnkit_vm_key.pub — matching public key
 #
 # After building, configure the kernel VM runner:
 #   export PWNKIT_KERNEL_QEMU=1
@@ -18,6 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUT_DIR="${1:-${SCRIPT_DIR}/out}"
+KERNEL_MAKE_JOBS="${PWNKIT_KERNEL_VM_MAKE_JOBS:-4}"
 
 mkdir -p "${OUT_DIR}"
 
@@ -29,18 +32,21 @@ echo "This will take 15-30 minutes (kernel compilation)."
 echo ""
 
 docker build \
+  --build-arg "KERNEL_MAKE_JOBS=${KERNEL_MAKE_JOBS}" \
   -t pwnkit-kernel-builder \
   -f "${SCRIPT_DIR}/Dockerfile" \
   "${SCRIPT_DIR}"
 
 docker run --rm \
   --privileged \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
   -v "${OUT_DIR}:/out" \
   pwnkit-kernel-builder
 
 echo ""
 echo "Done. Kernel VM artifacts:"
-ls -lh "${OUT_DIR}"/bzImage "${OUT_DIR}"/rootfs.img "${OUT_DIR}"/kernel.config 2>/dev/null
+ls -lh "${OUT_DIR}"/bzImage "${OUT_DIR}"/rootfs.img "${OUT_DIR}"/kernel.config "${OUT_DIR}"/pwnkit_vm_key "${OUT_DIR}"/pwnkit_vm_key.pub 2>/dev/null
 
 echo ""
 echo "To use with pwnkit:"

--- a/packages/core/src/triage/kernel-vm/build.sh
+++ b/packages/core/src/triage/kernel-vm/build.sh
@@ -5,10 +5,8 @@
 #
 # Outputs:
 #   bzImage       — KASAN-enabled kernel
-#   rootfs.img    — Debian root filesystem with GCC/binutils + pwnkit-init
+#   rootfs.img    — Debian root filesystem with GCC/binutils + shared-workdir boot path
 #   kernel.config — kernel .config
-#   pwnkit_vm_key — SSH private key for the guest
-#   pwnkit_vm_key.pub — matching public key
 #
 # After building, configure the kernel VM runner:
 #   export PWNKIT_KERNEL_QEMU=1

--- a/scripts/kernel-validator-e2e.sh
+++ b/scripts/kernel-validator-e2e.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+RESULT_JSON="${TMP_DIR}/kernel-validator-result.json"
+RAW_OUTPUT="${TMP_DIR}/kernel-validator-raw.txt"
+
+REPORT_URL="${PWNKIT_KERNEL_E2E_REPORT_URL:-https://syzkaller.appspot.com/text?tag=CrashReport&x=144881ca580000}"
+REPRO_URL="${PWNKIT_KERNEL_E2E_REPRO_URL:-https://syzkaller.appspot.com/text?tag=ReproC&x=1253b3d6580000}"
+INPUT_DIR="${TMP_DIR}/input"
+ARTIFACT_DIR="${PWNKIT_KERNEL_QEMU_ARTIFACT_DIR:-${TMP_DIR}/vm-artifacts}"
+
+mkdir -p "${INPUT_DIR}" "${ARTIFACT_DIR}"
+
+curl -fL --retry 3 --retry-delay 2 -s "${REPORT_URL}" > "${INPUT_DIR}/sample.log"
+curl -fL --retry 3 --retry-delay 2 -s "${REPRO_URL}" > "${INPUT_DIR}/sample.c"
+
+export PWNKIT_KERNEL_QEMU=1
+export PWNKIT_KERNEL_QEMU_ARTIFACT_DIR="${ARTIFACT_DIR}"
+
+node "${ROOT_DIR}/packages/cli/dist/index.js" ingest "${INPUT_DIR}" --verify -o json > "${RAW_OUTPUT}"
+
+node - "${RAW_OUTPUT}" "${RESULT_JSON}" <<'EOF'
+const fs = require("node:fs");
+const [rawPath, jsonPath] = process.argv.slice(2);
+const raw = fs.readFileSync(rawPath, "utf8");
+const jsonStart = raw.indexOf("[");
+if (jsonStart === -1) {
+  throw new Error("kernel validator E2E output did not contain a JSON array");
+}
+const payload = raw.slice(jsonStart);
+JSON.parse(payload);
+fs.writeFileSync(jsonPath, payload);
+EOF
+
+node - "${RESULT_JSON}" <<'EOF'
+const fs = require("node:fs");
+const path = process.argv[2];
+const parsed = JSON.parse(fs.readFileSync(path, "utf8"));
+
+if (!Array.isArray(parsed) || parsed.length === 0) {
+  throw new Error("kernel validator E2E produced no findings");
+}
+
+const entry = parsed[0];
+if (!entry.verification) {
+  throw new Error("kernel validator E2E produced no verification payload");
+}
+
+if (entry.verification.reproduced !== true) {
+  const reason = entry.verification.reason || "unknown";
+  const evidence = entry.verification.evidence || "no evidence";
+  throw new Error(`kernel validator E2E did not reproduce the crash: ${reason}\n${evidence}`);
+}
+
+const summary = {
+  templateId: entry.finding?.templateId ?? null,
+  verified: entry.verification.verified ?? null,
+  reproduced: entry.verification.reproduced ?? null,
+  crashMatch: entry.verification.crashMatch ?? null,
+  reason: entry.verification.reason ?? null,
+  confidence: entry.verification.confidence ?? null,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+EOF
+
+echo "Kernel validator E2E artifacts saved to: ${ARTIFACT_DIR}"


### PR DESCRIPTION
## Summary
- replace the kernel VM verifier SSH transport with a shared-workdir QEMU execution path
- add a dedicated GitHub Actions kernel-validator E2E workflow
- align the kernel VM docs and builder guidance with the new transport

## Verification
- pnpm build
- local real syzbot ingest --verify run with reproduced=true inside QEMU
- local execution of scripts/kernel-validator-e2e.sh

## Notes
- the transport is now real end to end, but crash-signature matching still needs refinement on noisy UBSAN-first outputs
