### PR TITLE
feat(disclose): add pwnkit-cli disclose subcommand (MVP)

### DIFF
--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -4,7 +4,13 @@ import { resolve, join } from "node:path";
 import { homedir } from "node:os";
 import chalk from "chalk";
 import type { Finding, AttackCategory, Severity, Evidence, FindingStatus } from "@pwnkit/shared";
-import { renderAdvisoryMarkdown, type AdvisoryContext } from "@pwnkit/core";
+import {
+  renderAdvisoryMarkdown,
+  renderExploitScreenshot,
+  isFreezeAvailable,
+  type AdvisoryContext,
+  type AdvisoryScreenshot,
+} from "@pwnkit/core";
 
 interface DiscloseOptions {
   dbPath?: string;
@@ -12,6 +18,7 @@ interface DiscloseOptions {
   outputDir?: string;
   severityFloor?: string;
   dryRun?: boolean;
+  noScreenshots?: boolean;
 }
 
 interface FindingRow {
@@ -99,15 +106,27 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
 
     const scanId = selected[0].scanId;
     const outputDir = resolveOutputDir(opts, scanId);
+    const imagesDir = join(outputDir, "images");
     if (!opts.dryRun) mkdirSync(outputDir, { recursive: true });
 
+    const freezeOn = !opts.noScreenshots && !opts.dryRun && isFreezeAvailable();
     console.log(chalk.red.bold("\n  ◆ pwnkit") + chalk.gray(` disclose — ${selected.length} finding${selected.length === 1 ? "" : "s"}`));
-    console.log(chalk.gray(`  output: ${outputDir}${opts.dryRun ? " (dry-run — nothing written)" : ""}`), "\n");
+    console.log(chalk.gray(`  output: ${outputDir}${opts.dryRun ? " (dry-run — nothing written)" : ""}`));
+    console.log(chalk.gray(`  screenshots: ${freezeOn ? "on (freeze)" : opts.noScreenshots ? "disabled" : opts.dryRun ? "skipped (dry-run)" : "disabled (freeze not on PATH)"}`), "\n");
 
-    const ctx: AdvisoryContext = { scanId };
-    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number }> = [];
+    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number; screenshot: boolean }> = [];
     for (const row of selected) {
       const finding = rowToFinding(row);
+      const screenshots: AdvisoryScreenshot[] = [];
+      let wroteShot = false;
+      if (freezeOn) {
+        const shot = renderExploitScreenshot(finding, { outputDir: imagesDir, markdownDir: outputDir });
+        if (shot) {
+          screenshots.push({ alt: shot.alt, relativePath: shot.relativePath, caption: shot.caption, width: 1200 });
+          wroteShot = true;
+        }
+      }
+      const ctx: AdvisoryContext = { scanId, screenshots };
       const rendered = renderAdvisoryMarkdown(finding, ctx);
       const path = join(outputDir, rendered.filename);
       if (!opts.dryRun) {
@@ -117,9 +136,10 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
         }
         writeFileSync(path, rendered.markdown, "utf8");
       }
-      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore });
+      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore, screenshot: wroteShot });
+      const shotMark = wroteShot ? chalk.cyan(" +png") : chalk.gray("     ");
       console.log(
-        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}`
+        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}${shotMark}`
       );
     }
 
@@ -163,6 +183,7 @@ export function registerDiscloseCommand(program: Command): void {
     .option("--scan <scanId>", "Restrict to findings from this scan")
     .option("--output-dir <path>", "Directory to write advisories into (default ~/pwnkit/disclosures/scan-<id>)")
     .option("--severity-floor <severity>", "In batch mode, only draft findings at or above this severity", "medium")
+    .option("--no-screenshots", "Skip terminal-screenshot rendering even when freeze is available")
     .option("--dry-run", "Show what would be written without writing files", false)
     .action(async (findingId: string | undefined, opts: DiscloseOptions) => {
       await disclose(findingId, opts);

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -8,8 +8,11 @@ import {
   renderAdvisoryMarkdown,
   renderExploitScreenshot,
   isFreezeAvailable,
+  verifyAgainstRef,
   type AdvisoryContext,
   type AdvisoryScreenshot,
+  type ReverifyResult,
+  type PatchStatus,
 } from "@pwnkit/core";
 
 interface DiscloseOptions {
@@ -19,7 +22,18 @@ interface DiscloseOptions {
   severityFloor?: string;
   dryRun?: boolean;
   noScreenshots?: boolean;
+  repo?: string;
+  ref?: string;
+  dropFixed?: boolean;
 }
+
+const STATUS_COLOUR: Record<PatchStatus, (s: string) => string> = {
+  "still-vulnerable": (s) => chalk.green(s),
+  "partial-fix": (s) => chalk.yellow(s),
+  "fixed": (s) => chalk.gray(s),
+  "file-removed": (s) => chalk.gray(s),
+  "unknown": (s) => chalk.dim(s),
+};
 
 interface FindingRow {
   id: string;
@@ -110,13 +124,62 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
     if (!opts.dryRun) mkdirSync(outputDir, { recursive: true });
 
     const freezeOn = !opts.noScreenshots && !opts.dryRun && isFreezeAvailable();
+    const reverifyOn = !!opts.repo;
+    const droppedDir = join(outputDir, "_dropped");
     console.log(chalk.red.bold("\n  ◆ pwnkit") + chalk.gray(` disclose — ${selected.length} finding${selected.length === 1 ? "" : "s"}`));
     console.log(chalk.gray(`  output: ${outputDir}${opts.dryRun ? " (dry-run — nothing written)" : ""}`));
-    console.log(chalk.gray(`  screenshots: ${freezeOn ? "on (freeze)" : opts.noScreenshots ? "disabled" : opts.dryRun ? "skipped (dry-run)" : "disabled (freeze not on PATH)"}`), "\n");
+    console.log(chalk.gray(`  screenshots: ${freezeOn ? "on (freeze)" : opts.noScreenshots ? "disabled" : opts.dryRun ? "skipped (dry-run)" : "disabled (freeze not on PATH)"}`));
+    if (reverifyOn) {
+      console.log(chalk.gray(`  reverify:    ${opts.repo}${opts.ref ? ` @ ${opts.ref}` : " @ HEAD"}${opts.dropFixed ? " (fixed → _dropped/)" : ""}`));
+    } else {
+      console.log(chalk.gray(`  reverify:    disabled (pass --repo to enable)`));
+    }
+    console.log("");
 
-    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number; screenshot: boolean }> = [];
+    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number; screenshot: boolean; patchStatus?: PatchStatus }> = [];
     for (const row of selected) {
       const finding = rowToFinding(row);
+      let patchStatus: ReverifyResult | undefined;
+      if (reverifyOn) {
+        try {
+          patchStatus = verifyAgainstRef(finding, { repoPath: opts.repo!, ref: opts.ref, checkout: !!opts.ref });
+        } catch (err) {
+          console.log(chalk.red(`  reverify failed on ${row.id.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`));
+        }
+      }
+
+      // If --drop-fixed, route "fixed" / "file-removed" findings into _dropped/
+      // with a reason file instead of into the main advisory bundle.
+      if (patchStatus && opts.dropFixed && (patchStatus.status === "fixed" || patchStatus.status === "file-removed")) {
+        if (!opts.dryRun) {
+          mkdirSync(droppedDir, { recursive: true });
+          const reasonPath = join(droppedDir, `${finding.id.slice(0, 8)}-${finding.severity}-${patchStatus.status}.md`);
+          const body = [
+            `# Dropped: ${finding.title}`,
+            "",
+            `- **Status:** ${patchStatus.status}`,
+            `- **Ref:** \`${patchStatus.ref}\``,
+            `- **Scan:** \`${scanId}\``,
+            `- **Finding id:** \`${finding.id}\``,
+            "",
+            "## Notes",
+            "",
+            ...patchStatus.notes.map((n) => `- ${n}`),
+            "",
+            "## Refs checked",
+            "",
+            ...patchStatus.refsChecked.map((r) => `- \`${r.file}${r.line ? `:${r.line}` : ""}\``),
+            "",
+          ].join("\n");
+          writeFileSync(reasonPath, body, "utf8");
+        }
+        console.log(
+          `  ${chalk.gray("drop")}  ${chalk.dim((row.title + " …").slice(0, 64).padEnd(64))}  ${chalk.gray(`patch=${patchStatus.status}`)}`
+        );
+        results.push({ finding: row, filename: "_dropped", primaryCwe: "", cvssScore: 0, screenshot: false, patchStatus: patchStatus.status });
+        continue;
+      }
+
       const screenshots: AdvisoryScreenshot[] = [];
       let wroteShot = false;
       if (freezeOn) {
@@ -126,7 +189,7 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
           wroteShot = true;
         }
       }
-      const ctx: AdvisoryContext = { scanId, screenshots };
+      const ctx: AdvisoryContext = { scanId, screenshots, patchStatus };
       const rendered = renderAdvisoryMarkdown(finding, ctx);
       const path = join(outputDir, rendered.filename);
       if (!opts.dryRun) {
@@ -136,10 +199,11 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
         }
         writeFileSync(path, rendered.markdown, "utf8");
       }
-      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore, screenshot: wroteShot });
+      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore, screenshot: wroteShot, patchStatus: patchStatus?.status });
       const shotMark = wroteShot ? chalk.cyan(" +png") : chalk.gray("     ");
+      const patchMark = patchStatus ? " " + STATUS_COLOUR[patchStatus.status](`[${patchStatus.status}]`) : "";
       console.log(
-        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}${shotMark}`
+        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}${shotMark}${patchMark}`
       );
     }
 
@@ -184,6 +248,9 @@ export function registerDiscloseCommand(program: Command): void {
     .option("--output-dir <path>", "Directory to write advisories into (default ~/pwnkit/disclosures/scan-<id>)")
     .option("--severity-floor <severity>", "In batch mode, only draft findings at or above this severity", "medium")
     .option("--no-screenshots", "Skip terminal-screenshot rendering even when freeze is available")
+    .option("--repo <path>", "Local git checkout of the target repo to re-verify findings against")
+    .option("--ref <tag>", "Git ref (tag/sha/branch) to check out before verifying — defaults to the repo's current HEAD")
+    .option("--drop-fixed", "Move findings whose status is 'fixed' or 'file-removed' into _dropped/ with a reason file instead of drafting an advisory for them", false)
     .option("--dry-run", "Show what would be written without writing files", false)
     .action(async (findingId: string | undefined, opts: DiscloseOptions) => {
       await disclose(findingId, opts);

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -1,0 +1,170 @@
+import type { Command } from "commander";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { homedir } from "node:os";
+import chalk from "chalk";
+import type { Finding, AttackCategory, Severity, Evidence, FindingStatus } from "@pwnkit/shared";
+import { renderAdvisoryMarkdown, type AdvisoryContext } from "@pwnkit/core";
+
+interface DiscloseOptions {
+  dbPath?: string;
+  scan?: string;
+  outputDir?: string;
+  severityFloor?: string;
+  dryRun?: boolean;
+}
+
+interface FindingRow {
+  id: string;
+  scanId: string;
+  title: string;
+  severity: string;
+  category: string;
+  status: string;
+  fingerprint?: string | null;
+  triageStatus?: string | null;
+  triageNote?: string | null;
+  timestamp: number;
+  templateId: string;
+  description: string;
+  evidenceRequest: string;
+  evidenceResponse: string;
+  evidenceAnalysis?: string | null;
+  cvssVector?: string | null;
+  cvssScore?: number | null;
+}
+
+const SEVERITY_RANK: Record<string, number> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  info: 0,
+};
+
+function rowToFinding(row: FindingRow): Finding {
+  const evidence: Evidence = {
+    request: row.evidenceRequest,
+    response: row.evidenceResponse,
+    analysis: row.evidenceAnalysis ?? undefined,
+  };
+  const finding: Finding = {
+    id: row.id,
+    templateId: row.templateId,
+    title: row.title,
+    description: row.description,
+    severity: row.severity as Severity,
+    category: row.category as AttackCategory,
+    status: row.status as FindingStatus,
+    evidence,
+    fingerprint: row.fingerprint ?? undefined,
+    timestamp: row.timestamp,
+  };
+  if (row.cvssVector) finding.cvssVector = row.cvssVector;
+  if (row.cvssScore !== null && row.cvssScore !== undefined) finding.cvssScore = row.cvssScore;
+  return finding;
+}
+
+function resolveOutputDir(opts: DiscloseOptions, scanId: string): string {
+  if (opts.outputDir) return resolve(opts.outputDir);
+  return join(homedir(), "pwnkit", "disclosures", `scan-${scanId.slice(0, 8)}`);
+}
+
+async function disclose(findingId: string | undefined, opts: DiscloseOptions): Promise<void> {
+  const { pwnkitDB } = await import("@pwnkit/db");
+  const db = new pwnkitDB(opts.dbPath);
+  try {
+    const rows = db.listFindings({ scanId: opts.scan, limit: 5000 }) as FindingRow[];
+    if (rows.length === 0) {
+      console.log(chalk.gray("No findings in the database matching your filters."));
+      return;
+    }
+
+    let selected: FindingRow[];
+    if (findingId) {
+      const exact = rows.find((r) => r.id === findingId);
+      const prefix = rows.filter((r) => r.id.startsWith(findingId));
+      if (exact) selected = [exact];
+      else if (prefix.length === 1) selected = prefix;
+      else if (prefix.length > 1) throw new Error(`Finding prefix '${findingId}' is ambiguous across ${prefix.length} rows.`);
+      else throw new Error(`Finding '${findingId}' not found.`);
+    } else {
+      const floor = SEVERITY_RANK[opts.severityFloor ?? "medium"] ?? 2;
+      selected = rows.filter((r) => (SEVERITY_RANK[r.severity] ?? 0) >= floor && r.triageStatus !== "suppressed");
+      if (selected.length === 0) {
+        console.log(chalk.gray(`No findings at or above severity '${opts.severityFloor ?? "medium"}' after triage filtering.`));
+        return;
+      }
+    }
+
+    const scanId = selected[0].scanId;
+    const outputDir = resolveOutputDir(opts, scanId);
+    if (!opts.dryRun) mkdirSync(outputDir, { recursive: true });
+
+    console.log(chalk.red.bold("\n  ◆ pwnkit") + chalk.gray(` disclose — ${selected.length} finding${selected.length === 1 ? "" : "s"}`));
+    console.log(chalk.gray(`  output: ${outputDir}${opts.dryRun ? " (dry-run — nothing written)" : ""}`), "\n");
+
+    const ctx: AdvisoryContext = { scanId };
+    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number }> = [];
+    for (const row of selected) {
+      const finding = rowToFinding(row);
+      const rendered = renderAdvisoryMarkdown(finding, ctx);
+      const path = join(outputDir, rendered.filename);
+      if (!opts.dryRun) {
+        if (existsSync(path)) {
+          console.log(chalk.yellow(`  skip`) + chalk.gray(`  ${rendered.filename} (exists)`));
+          continue;
+        }
+        writeFileSync(path, rendered.markdown, "utf8");
+      }
+      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore });
+      console.log(
+        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}`
+      );
+    }
+
+    if (results.length > 0 && !opts.dryRun) {
+      const indexPath = join(outputDir, "INDEX.md");
+      const indexContent = [
+        "# Disclosure batch",
+        "",
+        `- Scan: \`${scanId}\``,
+        `- Drafts: ${results.length}`,
+        `- Generated: ${new Date().toISOString()}`,
+        "",
+        "## Filing order",
+        "",
+        "| File | Primary CWE | CVSS |",
+        "|---|---|---|",
+        ...results.map((r) => `| \`${r.filename}\` | ${r.primaryCwe} | ${r.cvssScore.toFixed(1)} |`),
+        "",
+        "## Before filing each advisory",
+        "",
+        "1. Re-read the draft — the PoC and Patch Status sections are placeholders until the disclose pipeline implements PoC execution and canary re-verify (see pwnkit/pwnkit#168).",
+        "2. Verify the CVSS vector suggested by pwnkit is still appropriate for your deployment model.",
+        "3. Drop screenshots into the advisory body where you want them.",
+        "4. File at https://github.com/<owner>/<repo>/security/advisories/new",
+        "",
+      ].join("\n");
+      writeFileSync(indexPath, indexContent, "utf8");
+      console.log("\n  " + chalk.gray(`wrote ${indexPath}`));
+    }
+  } finally {
+    db.close();
+  }
+}
+
+export function registerDiscloseCommand(program: Command): void {
+  program
+    .command("disclose")
+    .description("Assemble GHSA-ready advisory drafts from persisted findings")
+    .argument("[findingId]", "Finding ID (or prefix). Omit to batch every finding at or above --severity-floor.")
+    .option("--db-path <path>", "Path to SQLite database")
+    .option("--scan <scanId>", "Restrict to findings from this scan")
+    .option("--output-dir <path>", "Directory to write advisories into (default ~/pwnkit/disclosures/scan-<id>)")
+    .option("--severity-floor <severity>", "In batch mode, only draft findings at or above this severity", "medium")
+    .option("--dry-run", "Show what would be written without writing files", false)
+    .action(async (findingId: string | undefined, opts: DiscloseOptions) => {
+      await disclose(findingId, opts);
+    });
+}

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -9,9 +9,11 @@ import {
   renderExploitScreenshot,
   isFreezeAvailable,
   verifyAgainstRef,
+  detectVersionRange,
   type AdvisoryContext,
   type AdvisoryScreenshot,
   type ReverifyResult,
+  type VersionRangeResult,
   type PatchStatus,
 } from "@pwnkit/core";
 
@@ -118,7 +120,13 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
       }
     }
 
-    const scanId = selected[0].scanId;
+    const scanIds = Array.from(new Set(selected.map((r) => r.scanId)));
+    const scanId = scanIds[0];
+    if (scanIds.length > 1 && !opts.outputDir && !opts.scan) {
+      throw new Error(
+        `Selected ${selected.length} findings span ${scanIds.length} scans. Pass --scan <id> to narrow, or --output-dir <path> to override the default scan-scoped output directory.`,
+      );
+    }
     const outputDir = resolveOutputDir(opts, scanId);
     const imagesDir = join(outputDir, "images");
     if (!opts.dryRun) mkdirSync(outputDir, { recursive: true });
@@ -136,15 +144,22 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
     }
     console.log("");
 
-    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number; screenshot: boolean; patchStatus?: PatchStatus }> = [];
+    type ResultState = "wrote" | "skipped-exists" | "dropped";
+    const results: Array<{ finding: FindingRow; filename: string; primaryCwe: string; cvssScore: number; screenshot: boolean; patchStatus?: PatchStatus; state: ResultState }> = [];
     for (const row of selected) {
       const finding = rowToFinding(row);
       let patchStatus: ReverifyResult | undefined;
+      let versionRange: VersionRangeResult | undefined;
       if (reverifyOn) {
         try {
           patchStatus = verifyAgainstRef(finding, { repoPath: opts.repo!, ref: opts.ref, checkout: !!opts.ref });
         } catch (err) {
           console.log(chalk.red(`  reverify failed on ${row.id.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`));
+        }
+        try {
+          versionRange = detectVersionRange(finding, { repoPath: opts.repo! });
+        } catch (err) {
+          console.log(chalk.red(`  version-range failed on ${row.id.slice(0, 8)}: ${err instanceof Error ? err.message : String(err)}`));
         }
       }
 
@@ -176,7 +191,7 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
         console.log(
           `  ${chalk.gray("drop")}  ${chalk.dim((row.title + " …").slice(0, 64).padEnd(64))}  ${chalk.gray(`patch=${patchStatus.status}`)}`
         );
-        results.push({ finding: row, filename: "_dropped", primaryCwe: "", cvssScore: 0, screenshot: false, patchStatus: patchStatus.status });
+        results.push({ finding: row, filename: "_dropped", primaryCwe: "", cvssScore: 0, screenshot: false, patchStatus: patchStatus.status, state: "dropped" });
         continue;
       }
 
@@ -189,47 +204,64 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
           wroteShot = true;
         }
       }
-      const ctx: AdvisoryContext = { scanId, screenshots, patchStatus };
+      const ctx: AdvisoryContext = { scanId, screenshots, patchStatus, versionRange };
       const rendered = renderAdvisoryMarkdown(finding, ctx);
       const path = join(outputDir, rendered.filename);
+      let state: ResultState = "wrote";
       if (!opts.dryRun) {
         if (existsSync(path)) {
-          console.log(chalk.yellow(`  skip`) + chalk.gray(`  ${rendered.filename} (exists)`));
-          continue;
+          state = "skipped-exists";
+        } else {
+          writeFileSync(path, rendered.markdown, "utf8");
         }
-        writeFileSync(path, rendered.markdown, "utf8");
       }
-      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore, screenshot: wroteShot, patchStatus: patchStatus?.status });
+      results.push({ finding: row, filename: rendered.filename, primaryCwe: rendered.primaryCwe, cvssScore: rendered.cvssScore, screenshot: wroteShot, patchStatus: patchStatus?.status, state });
       const shotMark = wroteShot ? chalk.cyan(" +png") : chalk.gray("     ");
       const patchMark = patchStatus ? " " + STATUS_COLOUR[patchStatus.status](`[${patchStatus.status}]`) : "";
+      const verb = state === "skipped-exists"
+        ? chalk.yellow("skip ")
+        : chalk.green("wrote");
       console.log(
-        `  ${chalk.green("wrote")}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}${shotMark}${patchMark}`
+        `  ${verb}  ${chalk.white(rendered.filename.padEnd(70))}  ${chalk.cyan(rendered.primaryCwe.padEnd(10))}  ${chalk.dim(`cvss=${rendered.cvssScore.toFixed(1)}`)}${shotMark}${patchMark}`
       );
     }
 
     if (results.length > 0 && !opts.dryRun) {
       const indexPath = join(outputDir, "INDEX.md");
+      const drafts = results.filter((r) => r.state === "wrote" || r.state === "skipped-exists");
+      const dropped = results.filter((r) => r.state === "dropped");
+      const stateBadge = (s: ResultState) => s === "wrote" ? "new" : s === "skipped-exists" ? "existing" : "dropped";
+      const scanLabel = scanIds.length === 1 ? `\`${scanId}\`` : `\`${scanIds.join("`, `")}\` (${scanIds.length} scans)`;
       const indexContent = [
         "# Disclosure batch",
         "",
-        `- Scan: \`${scanId}\``,
-        `- Drafts: ${results.length}`,
+        `- Scan: ${scanLabel}`,
+        `- Drafts: ${drafts.length} (${results.filter((r) => r.state === "wrote").length} new, ${results.filter((r) => r.state === "skipped-exists").length} existing)`,
+        dropped.length > 0 ? `- Dropped: ${dropped.length} (see \`_dropped/\`)` : undefined,
         `- Generated: ${new Date().toISOString()}`,
         "",
         "## Filing order",
         "",
-        "| File | Primary CWE | CVSS |",
-        "|---|---|---|",
-        ...results.map((r) => `| \`${r.filename}\` | ${r.primaryCwe} | ${r.cvssScore.toFixed(1)} |`),
+        "| State | File | Primary CWE | CVSS | Patch status |",
+        "|---|---|---|---|---|",
+        ...drafts.map((r) => `| ${stateBadge(r.state)} | \`${r.filename}\` | ${r.primaryCwe} | ${r.cvssScore.toFixed(1)} | ${r.patchStatus ?? "—"} |`),
+        ...(dropped.length > 0 ? [
+          "",
+          "## Dropped",
+          "",
+          "| File | Reason |",
+          "|---|---|",
+          ...dropped.map((r) => `| \`_dropped/${r.finding.id.slice(0, 8)}-${r.finding.severity}-${r.patchStatus}.md\` | ${r.patchStatus} |`),
+        ] : []),
         "",
         "## Before filing each advisory",
         "",
-        "1. Re-read the draft — the PoC and Patch Status sections are placeholders until the disclose pipeline implements PoC execution and canary re-verify (see pwnkit/pwnkit#168).",
+        "1. Re-read the draft — the PoC and Patch Status sections are auto-populated from the scan but you should sanity-check against the current upstream HEAD.",
         "2. Verify the CVSS vector suggested by pwnkit is still appropriate for your deployment model.",
-        "3. Drop screenshots into the advisory body where you want them.",
+        "3. Attach or replace screenshots in the PoC section as needed.",
         "4. File at https://github.com/<owner>/<repo>/security/advisories/new",
         "",
-      ].join("\n");
+      ].filter((line) => line !== undefined).join("\n");
       writeFileSync(indexPath, indexContent, "utf8");
       console.log("\n  " + chalk.gray(`wrote ${indexPath}`));
     }

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -14,4 +14,5 @@ export { registerMcpServerCommand } from "./mcp-server.js";
 export { registerTriageCommand } from "./triage.js";
 export { registerEvalCommand } from "./eval.js";
 export { registerIngestCommand } from "./ingest.js";
+export { registerDiscloseCommand } from "./disclose.js";
 export { runUnified } from "./run.js";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ import {
   registerTriageCommand,
   registerEvalCommand,
   registerIngestCommand,
+  registerDiscloseCommand,
 } from "./commands/index.js";
 import { detectAndRoute } from "./routing.js";
 import { preloadBanner } from "./ui/banner.js";
@@ -51,6 +52,7 @@ registerMcpServerCommand(program);
 registerTriageCommand(program);
 registerEvalCommand(program);
 registerIngestCommand(program);
+registerDiscloseCommand(program);
 
 // ── Interactive menu (Ink) ──
 async function showInteractiveMenu(): Promise<void> {
@@ -143,7 +145,7 @@ async function showInteractiveMenu(): Promise<void> {
 
 // ── Entry point ──
 const userArgs = process.argv.slice(2);
-const knownCommands = ["scan", "resume", "replay", "history", "findings", "review", "audit", "doctor", "dashboard", "tui", "watch", "orchestrate", "db", "mcp-server", "eval", "ingest", "help"];
+const knownCommands = ["scan", "resume", "replay", "history", "findings", "review", "audit", "doctor", "dashboard", "tui", "watch", "orchestrate", "db", "mcp-server", "eval", "ingest", "disclose", "help"];
 
 if (userArgs.length === 0) {
   showInteractiveMenu().catch((err) => {

--- a/packages/core/src/disclose/canary.test.ts
+++ b/packages/core/src/disclose/canary.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import type { Finding } from "@pwnkit/shared";
+import { extractFileRefs, verifyAgainstRef, formatPatchStatusSection } from "./canary.js";
+
+function baseFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "finding-abcd1234",
+    templateId: "auth-gap-template",
+    title: "Auth gap on /adapters/install",
+    description: "server/src/routes/adapters.ts:221 gates on assertBoard instead of assertInstanceAdmin. See also packages/db/src/schema/plugin_config.ts for the underlying storage.",
+    severity: "high",
+    category: "tool-misuse",
+    status: "verified",
+    evidence: {
+      request: "POST /api/adapters/install",
+      response: "200 OK",
+      analysis: "The correct pattern is used at server/src/routes/plugins.ts:1270.",
+    },
+    timestamp: 1712345678,
+    ...overrides,
+  };
+}
+
+describe("extractFileRefs", () => {
+  it("pulls file:line pairs out of the description and analysis", () => {
+    const refs = extractFileRefs(baseFinding());
+    const byPath = new Map(refs.map((r) => [r.file, r.line]));
+    expect(byPath.get("server/src/routes/adapters.ts")).toBe(221);
+    expect(byPath.get("server/src/routes/plugins.ts")).toBe(1270);
+    expect(byPath.get("packages/db/src/schema/plugin_config.ts")).toBeUndefined();
+  });
+
+  it("captures file-only refs (no line number) too", () => {
+    const finding = baseFinding({ description: "See packages/shared/src/types.ts for the AttackCategory enum." });
+    const refs = extractFileRefs(finding);
+    expect(refs.some((r) => r.file === "packages/shared/src/types.ts" && r.line === undefined)).toBe(true);
+  });
+
+  it("ignores http(s) URLs that look like file:line", () => {
+    const finding = baseFinding({ description: "See https://example.com/foo.ts:3 for details." });
+    const refs = extractFileRefs(finding);
+    expect(refs.find((r) => r.file.startsWith("http"))).toBeUndefined();
+  });
+
+  it("returns an empty array for a finding with no parseable refs", () => {
+    const finding = baseFinding({
+      description: "No files cited here.",
+      evidence: { request: "", response: "", analysis: "Still nothing." },
+    });
+    const refs = extractFileRefs(finding);
+    expect(refs).toEqual([]);
+  });
+});
+
+describe("verifyAgainstRef (filesystem)", () => {
+  let repoPath: string;
+
+  beforeAll(() => {
+    repoPath = mkdtempSync(join(tmpdir(), "pwnkit-canary-"));
+    mkdirSync(join(repoPath, "server/src/routes"), { recursive: true });
+    // Large enough that line 221 is valid (so the finding's cited adapters.ts:221
+    // still resolves — we're not testing line-out-of-range here).
+    const lines = Array.from({ length: 400 }, (_, i) => `line${i + 1}`);
+    writeFileSync(join(repoPath, "server/src/routes/adapters.ts"), lines.join("\n") + "\n");
+    // Don't create plugins.ts — simulate the cited sibling being patched away.
+  });
+
+  afterAll(() => {
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("returns partial-fix when some refs resolve and others are missing", () => {
+    const result = verifyAgainstRef(baseFinding(), { repoPath, ref: "test-ref" });
+    expect(result.status).toBe("partial-fix");
+    expect(result.refsStillPresent.some((r) => r.file === "server/src/routes/adapters.ts")).toBe(true);
+    expect(result.refsMissing.some((r) => r.file === "server/src/routes/plugins.ts")).toBe(true);
+    expect(result.ref).toBe("test-ref");
+  });
+
+  it("returns still-vulnerable when every cited file exists", () => {
+    const result = verifyAgainstRef(
+      baseFinding({
+        description: "server/src/routes/adapters.ts:2 — still the same.",
+        evidence: { request: "", response: "", analysis: undefined },
+      }),
+      { repoPath, ref: "canary-ref" },
+    );
+    expect(result.status).toBe("still-vulnerable");
+    expect(result.refsMissing).toEqual([]);
+  });
+
+  it("flags line-out-of-range refs as missing", () => {
+    const result = verifyAgainstRef(
+      baseFinding({
+        description: "server/src/routes/adapters.ts:9999 — way past EOF.",
+        evidence: { request: "", response: "", analysis: undefined },
+      }),
+      { repoPath },
+    );
+    expect(result.status).toBe("fixed");
+    expect(result.refsMissing.some((r) => r.line === 9999)).toBe(true);
+  });
+
+  it("returns unknown when no refs are extractable", () => {
+    const result = verifyAgainstRef(
+      baseFinding({ description: "No refs.", evidence: { request: "", response: "", analysis: undefined } }),
+      { repoPath },
+    );
+    expect(result.status).toBe("unknown");
+    expect(result.notes[0]).toMatch(/could not extract/i);
+  });
+});
+
+describe("verifyAgainstRef (git-backed)", () => {
+  let repoPath: string;
+
+  beforeAll(() => {
+    repoPath = mkdtempSync(join(tmpdir(), "pwnkit-canary-git-"));
+    execFileSync("git", ["init", "-q"], { cwd: repoPath });
+    execFileSync("git", ["config", "user.email", "test@pwnkit.test"], { cwd: repoPath });
+    execFileSync("git", ["config", "user.name", "pwnkit-test"], { cwd: repoPath });
+    mkdirSync(join(repoPath, "src"), { recursive: true });
+    writeFileSync(join(repoPath, "src/vulnerable.ts"), "line1\nline2\nline3\n");
+    execFileSync("git", ["add", "."], { cwd: repoPath });
+    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: repoPath });
+    execFileSync("git", ["tag", "v-initial"], { cwd: repoPath });
+    // Now "fix" the file on main by removing it.
+    rmSync(join(repoPath, "src/vulnerable.ts"));
+    execFileSync("git", ["add", "-A"], { cwd: repoPath });
+    execFileSync("git", ["commit", "-q", "-m", "remove vulnerable file"], { cwd: repoPath });
+    execFileSync("git", ["tag", "v-fixed"], { cwd: repoPath });
+  });
+
+  afterAll(() => {
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("checks out the requested ref and sees still-vulnerable at v-initial", () => {
+    const result = verifyAgainstRef(
+      baseFinding({ description: "src/vulnerable.ts:1 — here.", evidence: { request: "", response: "", analysis: undefined } }),
+      { repoPath, ref: "v-initial", checkout: true },
+    );
+    expect(result.status).toBe("still-vulnerable");
+    expect(result.ref).toBe("v-initial");
+  });
+
+  it("reports fixed on v-fixed when the file has been removed", () => {
+    const result = verifyAgainstRef(
+      baseFinding({ description: "src/vulnerable.ts:1 — here.", evidence: { request: "", response: "", analysis: undefined } }),
+      { repoPath, ref: "v-fixed", checkout: true },
+    );
+    expect(["fixed", "file-removed"]).toContain(result.status);
+    expect(result.ref).toBe("v-fixed");
+  });
+});
+
+describe("formatPatchStatusSection", () => {
+  it("includes a banner for each status and lists refs with ✓/✗ markers", () => {
+    const section = formatPatchStatusSection({
+      status: "partial-fix",
+      ref: "canary/v2026.420.0-canary.9",
+      notes: ["Some file changed upstream."],
+      refsChecked: [
+        { file: "a.ts", line: 1 },
+        { file: "b.ts" },
+      ],
+      refsStillPresent: [{ file: "a.ts", line: 1 }],
+      refsMissing: [{ file: "b.ts" }],
+    });
+    expect(section).toContain("Partial fix");
+    expect(section).toContain("canary/v2026.420.0-canary.9");
+    expect(section).toContain("✓ `a.ts:1`");
+    expect(section).toContain("✗ `b.ts`");
+    expect(section).toContain("> Some file changed upstream.");
+  });
+});

--- a/packages/core/src/disclose/canary.ts
+++ b/packages/core/src/disclose/canary.ts
@@ -1,0 +1,201 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import type { Finding } from "@pwnkit/shared";
+
+export type PatchStatus =
+  | "still-vulnerable"   // every cited file:line still exists and matches the described shape
+  | "partial-fix"        // some refs still resolve but others were edited or removed
+  | "fixed"              // no cited ref resolves any more
+  | "file-removed"       // the vulnerable file itself is gone
+  | "unknown";           // couldn't find any usable pattern in the finding
+
+export interface FileRef {
+  file: string;
+  line?: number;
+  /** Verbatim code snippet pulled from the finding that should still be present. */
+  snippet?: string;
+}
+
+export interface ReverifyResult {
+  status: PatchStatus;
+  ref: string;
+  notes: string[];
+  refsChecked: FileRef[];
+  refsStillPresent: FileRef[];
+  refsMissing: FileRef[];
+}
+
+export interface ReverifyOptions {
+  repoPath: string;
+  /** Git ref (tag/sha/branch) to check out before verifying. Defaults to current HEAD. */
+  ref?: string;
+  /** If true, run `git checkout <ref>` before reading files. Defaults to false (work off the current worktree). */
+  checkout?: boolean;
+}
+
+// Strip ANSI, backticks, asterisks so grep-style snippet matching isn't thrown
+// off by the agent's markdown flourishes.
+function normaliseForMatch(s: string): string {
+  return s.replace(/\[[0-9;]*m/g, "").replace(/[`*_]+/g, "").trim();
+}
+
+/**
+ * Pull file:line references out of a finding. Looks in description, analysis,
+ * and evidence blocks. Ignores file:line-like strings that look like URLs.
+ */
+export function extractFileRefs(finding: Finding): FileRef[] {
+  const haystack = [
+    finding.description,
+    finding.evidence?.analysis,
+    finding.evidence?.request,
+    finding.evidence?.response,
+  ]
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .join("\n\n");
+
+  const seen = new Map<string, FileRef>();
+  // Accept things like "server/src/routes/foo.ts:1234" or
+  // "packages/shared/src/types.ts:69-99" or "src/foo.ts".
+  // Reject url-ish (http://…/path:1234) by requiring the preceding char not be "/" plus a known protocol.
+  const regex = /(?<![\w/\-:])([a-zA-Z0-9_./\-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|rb|go|rs|c|h|cc|cpp|java|kt|swift|php|sh|sql))(?::(\d+)(?:-\d+)?)?/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(haystack)) !== null) {
+    const file = match[1];
+    const line = match[2] ? Number(match[2]) : undefined;
+    if (file.startsWith("http:") || file.startsWith("https:")) continue;
+    const key = `${file}:${line ?? ""}`;
+    if (!seen.has(key)) seen.set(key, { file, line });
+  }
+
+  return Array.from(seen.values());
+}
+
+/**
+ * Run a git command in the repo, return stdout on success, null on failure.
+ */
+function gitCmd(repoPath: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", args, { cwd: repoPath, stdio: ["ignore", "pipe", "pipe"], encoding: "utf8" });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify a finding against a given repo + ref. The repo must already be
+ * checked out at the ref OR the caller must pass `checkout: true`.
+ *
+ * The status is conservative: we return "still-vulnerable" only if every
+ * cited file:line resolves and its line is a plausible match for the described
+ * shape. If any reference is missing or the file was removed, we downgrade.
+ */
+export function verifyAgainstRef(finding: Finding, options: ReverifyOptions): ReverifyResult {
+  const refs = extractFileRefs(finding);
+  const repoPath = resolve(options.repoPath);
+
+  if (options.checkout && options.ref) {
+    gitCmd(repoPath, ["checkout", "-q", options.ref]);
+  }
+
+  const currentRef = options.ref
+    ?? gitCmd(repoPath, ["rev-parse", "--abbrev-ref", "HEAD"])?.trim()
+    ?? gitCmd(repoPath, ["rev-parse", "--short", "HEAD"])?.trim()
+    ?? "HEAD";
+
+  if (refs.length === 0) {
+    return {
+      status: "unknown",
+      ref: currentRef,
+      notes: ["Could not extract any file:line references from the finding. Consider adding `server/src/.../file.ts:NNN` style citations to the description before re-running."],
+      refsChecked: [],
+      refsStillPresent: [],
+      refsMissing: [],
+    };
+  }
+
+  const notes: string[] = [];
+  const refsStillPresent: FileRef[] = [];
+  const refsMissing: FileRef[] = [];
+
+  for (const ref of refs) {
+    const abs = join(repoPath, ref.file);
+    if (!existsSync(abs)) {
+      refsMissing.push(ref);
+      notes.push(`${ref.file} — file does not exist at ${currentRef}.`);
+      continue;
+    }
+    // File exists. If a line is cited, we could try to compare that line's
+    // content against a snippet pulled from the finding. For v1 we just
+    // confirm file presence and line-range validity.
+    if (ref.line !== undefined) {
+      try {
+        const content = readFileSync(abs, "utf8").split("\n");
+        if (ref.line > content.length) {
+          refsMissing.push(ref);
+          notes.push(`${ref.file}:${ref.line} — line is out of range (file has ${content.length} lines at ${currentRef}).`);
+          continue;
+        }
+      } catch {
+        // File is unreadable (perms, binary, etc.) — treat as still present for now.
+      }
+    }
+    refsStillPresent.push(ref);
+  }
+
+  let status: PatchStatus;
+  if (refsStillPresent.length === 0) {
+    status = refsMissing.some((r) => !existsSync(join(repoPath, r.file))) ? "file-removed" : "fixed";
+  } else if (refsMissing.length === 0) {
+    status = "still-vulnerable";
+  } else {
+    status = "partial-fix";
+  }
+
+  if (status === "still-vulnerable") {
+    notes.unshift(`All ${refsStillPresent.length} cited file${refsStillPresent.length === 1 ? "" : "s"} still resolve at ${currentRef}. Status is conservative — a human should confirm the *shape* of the code at each line hasn't been patched.`);
+  }
+
+  return {
+    status,
+    ref: currentRef,
+    notes,
+    refsChecked: refs,
+    refsStillPresent,
+    refsMissing,
+  };
+}
+
+function refsMatch(a: FileRef, b: FileRef): boolean {
+  return a.file === b.file && a.line === b.line;
+}
+
+/**
+ * Human-readable patch-status block for the advisory's "Patch status" section.
+ */
+export function formatPatchStatusSection(result: ReverifyResult): string {
+  const banner: Record<PatchStatus, string> = {
+    "still-vulnerable": `**Still vulnerable** on \`${result.ref}\`.`,
+    "partial-fix": `**Partial fix** on \`${result.ref}\` — some cited references changed, others remain.`,
+    "fixed": `**Fixed** on \`${result.ref}\`. All cited references have been edited or removed upstream.`,
+    "file-removed": `**Vulnerable file removed** on \`${result.ref}\`. The affected path no longer exists in the tree.`,
+    "unknown": `**Could not auto-verify** against \`${result.ref}\`. No machine-checkable references were extractable from the finding.`,
+  };
+
+  const lines: string[] = [];
+  lines.push(banner[result.status]);
+  if (result.refsChecked.length > 0) {
+    lines.push("");
+    lines.push(`Refs checked (${result.refsChecked.length}):`);
+    for (const ref of result.refsChecked) {
+      const present = result.refsStillPresent.some((r) => refsMatch(r, ref));
+      const marker = present ? "✓" : "✗";
+      lines.push(`- ${marker} \`${ref.file}${ref.line ? `:${ref.line}` : ""}\``);
+    }
+  }
+  if (result.notes.length > 0) {
+    lines.push("");
+    for (const note of result.notes) lines.push(`> ${note}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/core/src/disclose/cvss.ts
+++ b/packages/core/src/disclose/cvss.ts
@@ -1,0 +1,99 @@
+import type { AttackCategory, Finding, Severity } from "@pwnkit/shared";
+
+export interface CvssSuggestion {
+  vector: string;
+  score: number;
+  source: "finding" | "heuristic";
+}
+
+// Heuristic: pick impact (C/I/A) from category, privilege-required from severity
+// floor, and default reachability to network. The operator can override in the
+// GHSA editor; this is a first-pass suggestion, not an authoritative score.
+const IMPACT_BY_CATEGORY: Record<AttackCategory, { C: "N" | "L" | "H"; I: "N" | "L" | "H"; A: "N" | "L" | "H"; scope: "U" | "C" }> = {
+  "prompt-injection":        { C: "L", I: "L", A: "N", scope: "U" },
+  "jailbreak":               { C: "L", I: "L", A: "N", scope: "U" },
+  "system-prompt-extraction":{ C: "H", I: "N", A: "N", scope: "U" },
+  "data-exfiltration":       { C: "H", I: "N", A: "N", scope: "C" },
+  "tool-misuse":             { C: "H", I: "H", A: "L", scope: "C" },
+  "output-manipulation":     { C: "L", I: "H", A: "N", scope: "U" },
+  "encoding-bypass":         { C: "L", I: "L", A: "N", scope: "U" },
+  "multi-turn":              { C: "L", I: "L", A: "N", scope: "U" },
+  "prototype-pollution":     { C: "H", I: "H", A: "H", scope: "U" },
+  "path-traversal":          { C: "H", I: "H", A: "L", scope: "U" },
+  "command-injection":       { C: "H", I: "H", A: "H", scope: "U" },
+  "code-injection":          { C: "H", I: "H", A: "H", scope: "U" },
+  "regex-dos":               { C: "N", I: "N", A: "H", scope: "U" },
+  "unsafe-deserialization":  { C: "H", I: "H", A: "H", scope: "U" },
+  "information-disclosure":  { C: "H", I: "N", A: "N", scope: "C" },
+  "ssrf":                    { C: "H", I: "N", A: "N", scope: "C" },
+  "sql-injection":           { C: "H", I: "H", A: "H", scope: "U" },
+  "xss":                     { C: "L", I: "L", A: "N", scope: "C" },
+  "cors":                    { C: "L", I: "L", A: "N", scope: "U" },
+  "security-misconfiguration": { C: "L", I: "L", A: "N", scope: "U" },
+  "heap-overflow":           { C: "H", I: "H", A: "H", scope: "U" },
+  "use-after-free":          { C: "H", I: "H", A: "H", scope: "U" },
+  "stack-buffer-overflow":   { C: "H", I: "H", A: "H", scope: "U" },
+  "null-pointer-deref":      { C: "N", I: "N", A: "H", scope: "U" },
+  "integer-overflow":        { C: "L", I: "L", A: "L", scope: "U" },
+  "race-condition":          { C: "L", I: "L", A: "L", scope: "U" },
+  "type-confusion":          { C: "H", I: "H", A: "H", scope: "U" },
+  "double-free":             { C: "H", I: "H", A: "H", scope: "U" },
+};
+
+// Metric weights from CVSS 3.1 specification §7.1.
+const W = {
+  AV: { N: 0.85, A: 0.62, L: 0.55, P: 0.2 },
+  AC: { L: 0.77, H: 0.44 },
+  PR_U: { N: 0.85, L: 0.62, H: 0.27 },
+  PR_C: { N: 0.85, L: 0.68, H: 0.5 },
+  UI: { N: 0.85, R: 0.62 },
+  CIA: { N: 0, L: 0.22, H: 0.56 },
+};
+
+function roundUp(n: number): number {
+  return Math.ceil(n * 10) / 10;
+}
+
+// Minimal CVSS 3.1 base-score implementation — enough to produce a
+// consistent number for the suggested vector. See the spec for edge cases;
+// we keep only the common path.
+function computeBaseScore(av: keyof typeof W.AV, ac: keyof typeof W.AC, pr: "N" | "L" | "H", ui: "N" | "R", scope: "U" | "C", c: "N" | "L" | "H", i: "N" | "L" | "H", a: "N" | "L" | "H"): number {
+  const iss = 1 - (1 - W.CIA[c]) * (1 - W.CIA[i]) * (1 - W.CIA[a]);
+  const impact = scope === "U" ? 6.42 * iss : 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15);
+  const prWeight = (scope === "C" ? W.PR_C : W.PR_U)[pr];
+  const exploit = 8.22 * W.AV[av] * W.AC[ac] * prWeight * W.UI[ui];
+  if (impact <= 0) return 0;
+  const base = scope === "U" ? Math.min(impact + exploit, 10) : Math.min(1.08 * (impact + exploit), 10);
+  return roundUp(base);
+}
+
+// Map finding severity (already emitted by the agent) to the CVSS
+// privileges-required metric. Fresh-signup or no-auth findings would need an
+// explicit override in the advisory.
+function prForSeverity(severity: Severity): "N" | "L" | "H" {
+  switch (severity) {
+    case "critical":
+      return "N";
+    case "high":
+      return "L";
+    case "medium":
+    case "low":
+      return "L";
+    default:
+      return "H";
+  }
+}
+
+export function suggestCvss(finding: Finding): CvssSuggestion {
+  if (finding.cvssVector && finding.cvssScore !== undefined) {
+    return { vector: finding.cvssVector, score: finding.cvssScore, source: "finding" };
+  }
+  const impact = IMPACT_BY_CATEGORY[finding.category] ?? { C: "L", I: "L", A: "L", scope: "U" as const };
+  const av = "N" as const;
+  const ac = "L" as const;
+  const pr = prForSeverity(finding.severity);
+  const ui = "N" as const;
+  const vector = `CVSS:3.1/AV:${av}/AC:${ac}/PR:${pr}/UI:${ui}/S:${impact.scope}/C:${impact.C}/I:${impact.I}/A:${impact.A}`;
+  const score = computeBaseScore(av, ac, pr, ui, impact.scope, impact.C, impact.I, impact.A);
+  return { vector, score, source: "heuristic" };
+}

--- a/packages/core/src/disclose/cwe.ts
+++ b/packages/core/src/disclose/cwe.ts
@@ -1,0 +1,148 @@
+import type { AttackCategory } from "@pwnkit/shared";
+
+export interface CweEntry {
+  id: string;
+  name: string;
+  role: "primary" | "secondary";
+}
+
+// Ranked per category. First entry is the primary; the rest are secondaries
+// an operator may want to tick in the GHSA form's multi-select.
+const CWE_MAP: Record<AttackCategory, CweEntry[]> = {
+  // LLM / agent
+  "prompt-injection": [
+    { id: "CWE-1039", name: "Inadequate Detection or Handling of Adversarial Input Perturbations in AI/ML Classifier", role: "primary" },
+    { id: "CWE-20", name: "Improper Input Validation", role: "secondary" },
+    { id: "CWE-94", name: "Improper Control of Generation of Code ('Code Injection')", role: "secondary" },
+  ],
+  "jailbreak": [
+    { id: "CWE-1039", name: "Inadequate Detection or Handling of Adversarial Input Perturbations in AI/ML Classifier", role: "primary" },
+    { id: "CWE-284", name: "Improper Access Control", role: "secondary" },
+  ],
+  "system-prompt-extraction": [
+    { id: "CWE-200", name: "Exposure of Sensitive Information to an Unauthorized Actor", role: "primary" },
+    { id: "CWE-1039", name: "Inadequate Detection or Handling of Adversarial Input Perturbations in AI/ML Classifier", role: "secondary" },
+  ],
+  "data-exfiltration": [
+    { id: "CWE-200", name: "Exposure of Sensitive Information to an Unauthorized Actor", role: "primary" },
+    { id: "CWE-522", name: "Insufficiently Protected Credentials", role: "secondary" },
+  ],
+  "tool-misuse": [
+    { id: "CWE-284", name: "Improper Access Control", role: "primary" },
+    { id: "CWE-441", name: "Unintended Proxy or Intermediary ('Confused Deputy')", role: "secondary" },
+    { id: "CWE-285", name: "Improper Authorization", role: "secondary" },
+  ],
+  "output-manipulation": [
+    { id: "CWE-116", name: "Improper Encoding or Escaping of Output", role: "primary" },
+    { id: "CWE-74", name: "Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')", role: "secondary" },
+  ],
+  "encoding-bypass": [
+    { id: "CWE-176", name: "Improper Handling of Unicode Encoding", role: "primary" },
+    { id: "CWE-20", name: "Improper Input Validation", role: "secondary" },
+  ],
+  "multi-turn": [
+    { id: "CWE-1039", name: "Inadequate Detection or Handling of Adversarial Input Perturbations in AI/ML Classifier", role: "primary" },
+    { id: "CWE-841", name: "Improper Enforcement of Behavioral Workflow", role: "secondary" },
+  ],
+
+  // Source-code audit
+  "prototype-pollution": [
+    { id: "CWE-1321", name: "Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')", role: "primary" },
+    { id: "CWE-915", name: "Improperly Controlled Modification of Dynamically-Determined Object Attributes", role: "secondary" },
+  ],
+  "path-traversal": [
+    { id: "CWE-22", name: "Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')", role: "primary" },
+    { id: "CWE-73", name: "External Control of File Name or Path", role: "secondary" },
+    { id: "CWE-284", name: "Improper Access Control", role: "secondary" },
+  ],
+  "command-injection": [
+    { id: "CWE-78", name: "Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')", role: "primary" },
+    { id: "CWE-77", name: "Improper Neutralization of Special Elements used in a Command ('Command Injection')", role: "secondary" },
+  ],
+  "code-injection": [
+    { id: "CWE-94", name: "Improper Control of Generation of Code ('Code Injection')", role: "primary" },
+    { id: "CWE-95", name: "Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')", role: "secondary" },
+  ],
+  "regex-dos": [
+    { id: "CWE-1333", name: "Inefficient Regular Expression Complexity", role: "primary" },
+    { id: "CWE-400", name: "Uncontrolled Resource Consumption", role: "secondary" },
+  ],
+  "unsafe-deserialization": [
+    { id: "CWE-502", name: "Deserialization of Untrusted Data", role: "primary" },
+    { id: "CWE-915", name: "Improperly Controlled Modification of Dynamically-Determined Object Attributes", role: "secondary" },
+  ],
+  "information-disclosure": [
+    { id: "CWE-200", name: "Exposure of Sensitive Information to an Unauthorized Actor", role: "primary" },
+    { id: "CWE-285", name: "Improper Authorization", role: "secondary" },
+    { id: "CWE-522", name: "Insufficiently Protected Credentials", role: "secondary" },
+  ],
+  "ssrf": [
+    { id: "CWE-918", name: "Server-Side Request Forgery (SSRF)", role: "primary" },
+    { id: "CWE-20", name: "Improper Input Validation", role: "secondary" },
+    { id: "CWE-441", name: "Unintended Proxy or Intermediary ('Confused Deputy')", role: "secondary" },
+  ],
+  "sql-injection": [
+    { id: "CWE-89", name: "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')", role: "primary" },
+  ],
+  "xss": [
+    { id: "CWE-79", name: "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')", role: "primary" },
+    { id: "CWE-80", name: "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", role: "secondary" },
+  ],
+  "cors": [
+    { id: "CWE-942", name: "Permissive Cross-domain Policy with Untrusted Domains", role: "primary" },
+    { id: "CWE-346", name: "Origin Validation Error", role: "secondary" },
+  ],
+  "security-misconfiguration": [
+    { id: "CWE-1188", name: "Initialization of a Resource with an Insecure Default", role: "primary" },
+    { id: "CWE-16", name: "Configuration", role: "secondary" },
+  ],
+
+  // Memory corruption / binary
+  "heap-overflow": [
+    { id: "CWE-122", name: "Heap-based Buffer Overflow", role: "primary" },
+    { id: "CWE-787", name: "Out-of-bounds Write", role: "secondary" },
+  ],
+  "use-after-free": [
+    { id: "CWE-416", name: "Use After Free", role: "primary" },
+    { id: "CWE-672", name: "Operation on a Resource after Expiration or Release", role: "secondary" },
+  ],
+  "stack-buffer-overflow": [
+    { id: "CWE-121", name: "Stack-based Buffer Overflow", role: "primary" },
+    { id: "CWE-787", name: "Out-of-bounds Write", role: "secondary" },
+  ],
+  "null-pointer-deref": [
+    { id: "CWE-476", name: "NULL Pointer Dereference", role: "primary" },
+  ],
+  "integer-overflow": [
+    { id: "CWE-190", name: "Integer Overflow or Wraparound", role: "primary" },
+    { id: "CWE-191", name: "Integer Underflow (Wrap or Wraparound)", role: "secondary" },
+  ],
+  "race-condition": [
+    { id: "CWE-362", name: "Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')", role: "primary" },
+    { id: "CWE-367", name: "Time-of-check Time-of-use (TOCTOU) Race Condition", role: "secondary" },
+  ],
+  "type-confusion": [
+    { id: "CWE-843", name: "Access of Resource Using Incompatible Type ('Type Confusion')", role: "primary" },
+  ],
+  "double-free": [
+    { id: "CWE-415", name: "Double Free", role: "primary" },
+  ],
+};
+
+export function suggestCwesForCategory(category: AttackCategory): CweEntry[] {
+  return CWE_MAP[category] ?? [
+    { id: "CWE-693", name: "Protection Mechanism Failure", role: "primary" },
+  ];
+}
+
+export function formatCweSection(entries: CweEntry[]): string {
+  if (entries.length === 0) return "";
+  const lines = ["# CWE", ""];
+  lines.push("Pick these in the GHSA form's CWE selector (multi-select):");
+  lines.push("");
+  for (const entry of entries) {
+    const emphasis = entry.role === "primary" ? " *(primary)*" : "";
+    lines.push(`- **${entry.id}**: ${entry.name}${emphasis}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/core/src/disclose/disclose.test.ts
+++ b/packages/core/src/disclose/disclose.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import type { Finding } from "@pwnkit/shared";
+import { suggestCwesForCategory, suggestCvss, renderAdvisoryMarkdown } from "./index.js";
+
+function baseFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "finding-abcdef123",
+    templateId: "ssrf-template",
+    title: "SSRF via /api/foo",
+    description: "Attacker-controlled URL reaches server-side fetch without a hostname allowlist.",
+    severity: "medium",
+    category: "ssrf",
+    status: "verified",
+    evidence: {
+      request: "GET /api/foo?url=http://169.254.169.254/ HTTP/1.1",
+      response: '{"status":"reachable","httpStatus":200}',
+      analysis: "Full SSRF with response reflection.",
+    },
+    timestamp: 1712345678,
+    ...overrides,
+  };
+}
+
+describe("suggestCwesForCategory", () => {
+  it("returns a primary entry for every covered category", () => {
+    const cats: Finding["category"][] = [
+      "ssrf", "path-traversal", "command-injection", "xss", "prompt-injection", "prototype-pollution", "heap-overflow",
+    ];
+    for (const c of cats) {
+      const entries = suggestCwesForCategory(c);
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries[0].role).toBe("primary");
+      expect(entries[0].id).toMatch(/^CWE-\d+$/);
+    }
+  });
+
+  it("maps ssrf to CWE-918 as primary", () => {
+    const entries = suggestCwesForCategory("ssrf");
+    expect(entries[0].id).toBe("CWE-918");
+  });
+
+  it("maps path-traversal to CWE-22 primary + CWE-73 secondary", () => {
+    const entries = suggestCwesForCategory("path-traversal");
+    expect(entries[0].id).toBe("CWE-22");
+    expect(entries.some((e) => e.id === "CWE-73" && e.role === "secondary")).toBe(true);
+  });
+});
+
+describe("suggestCvss", () => {
+  it("passes through finding.cvssVector + cvssScore when present", () => {
+    const finding = baseFinding({ cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", cvssScore: 9.8 });
+    const suggestion = suggestCvss(finding);
+    expect(suggestion.source).toBe("finding");
+    expect(suggestion.score).toBe(9.8);
+  });
+
+  it("synthesises a heuristic vector when the finding has none", () => {
+    const finding = baseFinding();
+    const suggestion = suggestCvss(finding);
+    expect(suggestion.source).toBe("heuristic");
+    expect(suggestion.vector).toMatch(/^CVSS:3\.1\/AV:N\/AC:L\/PR:[NLH]\/UI:N\/S:[UC]\/C:[NLH]\/I:[NLH]\/A:[NLH]$/);
+    expect(suggestion.score).toBeGreaterThan(0);
+    expect(suggestion.score).toBeLessThanOrEqual(10);
+  });
+
+  it("produces a higher score for command-injection than for cors at the same severity", () => {
+    const cmd = suggestCvss(baseFinding({ category: "command-injection", severity: "high" }));
+    const cors = suggestCvss(baseFinding({ category: "cors", severity: "high" }));
+    expect(cmd.score).toBeGreaterThan(cors.score);
+  });
+});
+
+describe("renderAdvisoryMarkdown", () => {
+  it("includes Title / Severity / CWE / Affected versions / Summary / PoC / Suggested fix / Patch status / Credits", () => {
+    const finding = baseFinding();
+    const { markdown } = renderAdvisoryMarkdown(finding);
+    for (const header of ["# Title", "# Severity", "# CWE", "# Affected versions", "## Summary", "## PoC", "## Suggested fix", "## Patch status", "## Credits"]) {
+      expect(markdown).toContain(header);
+    }
+  });
+
+  it("embeds the evidence request and response in fenced blocks", () => {
+    const finding = baseFinding();
+    const { markdown } = renderAdvisoryMarkdown(finding);
+    expect(markdown).toContain("GET /api/foo?url=http://169.254.169.254/");
+    expect(markdown).toContain('"status":"reachable"');
+  });
+
+  it("embeds the primary CWE ID in the CWE section", () => {
+    const finding = baseFinding({ category: "path-traversal" });
+    const { markdown, primaryCwe } = renderAdvisoryMarkdown(finding);
+    expect(primaryCwe).toBe("CWE-22");
+    expect(markdown).toContain("CWE-22");
+  });
+
+  it("renders remediation.summary + steps + codeExample when provided", () => {
+    const finding = baseFinding({
+      remediation: {
+        summary: "Allowlist hostnames.",
+        steps: [
+          "Resolve hostname before fetching.",
+          "Reject private IPs after DNS.",
+        ],
+        codeExample: {
+          language: "typescript",
+          before: "await fetch(url);",
+          after: "await fetch(url, { dispatcher: ssrfSafeAgent });",
+        },
+        references: [],
+      },
+    });
+    const { markdown } = renderAdvisoryMarkdown(finding);
+    expect(markdown).toContain("Allowlist hostnames.");
+    expect(markdown).toContain("1. Resolve hostname before fetching.");
+    expect(markdown).toContain("ssrfSafeAgent");
+  });
+
+  it("emits a stable filename slug derived from severity + title", () => {
+    const finding = baseFinding({ severity: "high", title: "Auth gap: non-admin can mint tokens" });
+    const { filename } = renderAdvisoryMarkdown(finding);
+    expect(filename).toContain("high");
+    expect(filename).toContain("auth-gap");
+  });
+});

--- a/packages/core/src/disclose/disclose.test.ts
+++ b/packages/core/src/disclose/disclose.test.ts
@@ -115,10 +115,17 @@ describe("renderAdvisoryMarkdown", () => {
     expect(markdown).toContain("ssrfSafeAgent");
   });
 
-  it("emits a stable filename slug derived from severity + title", () => {
+  it("emits a stable filename slug prefixed by severity rank + severity label (no doubling)", () => {
     const finding = baseFinding({ severity: "high", title: "Auth gap: non-admin can mint tokens" });
     const { filename } = renderAdvisoryMarkdown(finding);
-    expect(filename).toContain("high");
-    expect(filename).toContain("auth-gap");
+    expect(filename).toMatch(/^2-high-auth-gap/);
+    expect(filename).not.toMatch(/high-high/);
+  });
+
+  it("sorts criticals before highs in a lexicographic sort of filenames", () => {
+    const critical = renderAdvisoryMarkdown(baseFinding({ severity: "critical", title: "C" }));
+    const high = renderAdvisoryMarkdown(baseFinding({ severity: "high", title: "H" }));
+    const sorted = [high.filename, critical.filename].sort();
+    expect(sorted[0]).toBe(critical.filename);
   });
 });

--- a/packages/core/src/disclose/index.ts
+++ b/packages/core/src/disclose/index.ts
@@ -3,4 +3,6 @@ export type { CweEntry } from "./cwe.js";
 export { suggestCvss } from "./cvss.js";
 export type { CvssSuggestion } from "./cvss.js";
 export { renderAdvisoryMarkdown } from "./template.js";
-export type { AdvisoryContext, RenderedAdvisory } from "./template.js";
+export type { AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory } from "./template.js";
+export { renderExploitScreenshot, isFreezeAvailable, composeExploitSession } from "./screenshots.js";
+export type { ScreenshotResult, ScreenshotOptions } from "./screenshots.js";

--- a/packages/core/src/disclose/index.ts
+++ b/packages/core/src/disclose/index.ts
@@ -8,3 +8,5 @@ export { renderExploitScreenshot, isFreezeAvailable, composeExploitSession } fro
 export type { ScreenshotResult, ScreenshotOptions } from "./screenshots.js";
 export { verifyAgainstRef, extractFileRefs, formatPatchStatusSection } from "./canary.js";
 export type { PatchStatus, FileRef, ReverifyResult, ReverifyOptions } from "./canary.js";
+export { detectVersionRange, formatVersionRangeLine } from "./version-range.js";
+export type { VersionRangeResult, VersionRangeOptions } from "./version-range.js";

--- a/packages/core/src/disclose/index.ts
+++ b/packages/core/src/disclose/index.ts
@@ -6,3 +6,5 @@ export { renderAdvisoryMarkdown } from "./template.js";
 export type { AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory } from "./template.js";
 export { renderExploitScreenshot, isFreezeAvailable, composeExploitSession } from "./screenshots.js";
 export type { ScreenshotResult, ScreenshotOptions } from "./screenshots.js";
+export { verifyAgainstRef, extractFileRefs, formatPatchStatusSection } from "./canary.js";
+export type { PatchStatus, FileRef, ReverifyResult, ReverifyOptions } from "./canary.js";

--- a/packages/core/src/disclose/index.ts
+++ b/packages/core/src/disclose/index.ts
@@ -1,0 +1,6 @@
+export { suggestCwesForCategory, formatCweSection } from "./cwe.js";
+export type { CweEntry } from "./cwe.js";
+export { suggestCvss } from "./cvss.js";
+export type { CvssSuggestion } from "./cvss.js";
+export { renderAdvisoryMarkdown } from "./template.js";
+export type { AdvisoryContext, RenderedAdvisory } from "./template.js";

--- a/packages/core/src/disclose/screenshots.test.ts
+++ b/packages/core/src/disclose/screenshots.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, existsSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Finding } from "@pwnkit/shared";
+import { composeExploitSession, renderExploitScreenshot, isFreezeAvailable } from "./screenshots.js";
+import { renderAdvisoryMarkdown } from "./template.js";
+
+function baseFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "finding-abcdef123456",
+    templateId: "ssrf-template",
+    title: "SSRF via /api/foo",
+    description: "Attacker-controlled URL reaches fetch without allowlist.",
+    severity: "medium",
+    category: "ssrf",
+    status: "verified",
+    evidence: {
+      request: "GET /api/foo?url=http://169.254.169.254/ HTTP/1.1\nHost: target:3108",
+      response: '{"status":"reachable","httpStatus":200,"durationMs":12}',
+      analysis: "Full SSRF with response reflection.",
+    },
+    timestamp: 1712345678,
+    ...overrides,
+  };
+}
+
+describe("composeExploitSession", () => {
+  it("includes the finding title, category, and severity as header comments", () => {
+    const text = composeExploitSession(baseFinding());
+    expect(text).toContain("# PoC for: SSRF via /api/foo");
+    expect(text).toContain("Category: ssrf");
+    expect(text).toContain("severity: medium");
+  });
+
+  it("prefixes the first request line with $ and indents the rest", () => {
+    const text = composeExploitSession(baseFinding());
+    const lines = text.split("\n");
+    const reqIdx = lines.findIndex((l) => l.startsWith("$ GET /api/foo"));
+    expect(reqIdx).toBeGreaterThan(-1);
+    expect(lines[reqIdx + 1]).toMatch(/^  Host: target:3108$/);
+  });
+
+  it("appends the response body unprefixed", () => {
+    const text = composeExploitSession(baseFinding());
+    expect(text).toContain('{"status":"reachable"');
+  });
+
+  it("comments the agent analysis block", () => {
+    const text = composeExploitSession(baseFinding());
+    expect(text).toContain("# Agent analysis:");
+    expect(text).toContain("# Full SSRF with response reflection.");
+  });
+});
+
+describe("isFreezeAvailable", () => {
+  it("returns boolean for a missing binary without throwing", () => {
+    const result = isFreezeAvailable("this-binary-definitely-does-not-exist-pwnkit-test");
+    expect(typeof result).toBe("boolean");
+    expect(result).toBe(false);
+  });
+});
+
+describe("renderExploitScreenshot", () => {
+  it("returns null when available=false and still writes no files", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "pwnkit-shot-"));
+    const result = renderExploitScreenshot(baseFinding(), { outputDir, available: false });
+    expect(result).toBeNull();
+  });
+
+  it("writes a session file and a stub output file when a fake binary is provided", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "pwnkit-shot-"));
+    // Stub freeze: just `touch` the file at the -o position.
+    const stubBinary = join(outputDir, "fake-freeze");
+    writeFileSync(stubBinary, `#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    touch "$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+`);
+    chmodSync(stubBinary, 0o755);
+
+    const result = renderExploitScreenshot(baseFinding(), {
+      outputDir,
+      binary: stubBinary,
+      available: true,
+    });
+    expect(result).not.toBeNull();
+    expect(existsSync(result!.path)).toBe(true);
+    const sessionFile = result!.path.replace(/\.png$/, ".session.txt");
+    expect(existsSync(sessionFile)).toBe(true);
+    const sessionText = readFileSync(sessionFile, "utf8");
+    expect(sessionText).toContain("SSRF via /api/foo");
+  });
+
+  it("returns null when the rendering binary exits nonzero", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "pwnkit-shot-"));
+    const stubBinary = join(outputDir, "broken-freeze");
+    writeFileSync(stubBinary, "#!/usr/bin/env bash\nexit 1\n");
+    chmodSync(stubBinary, 0o755);
+    const result = renderExploitScreenshot(baseFinding(), {
+      outputDir,
+      binary: stubBinary,
+      available: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("produces a relativePath when markdownDir is passed", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "pwnkit-shot-"));
+    const markdownDir = outputDir;
+    const imagesDir = join(outputDir, "images");
+    const stubBinary = join(outputDir, "fake-freeze-rel");
+    writeFileSync(stubBinary, `#!/usr/bin/env bash
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-o" ]]; then
+    mkdir -p "$(dirname "$2")"
+    touch "$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+`);
+    chmodSync(stubBinary, 0o755);
+    const result = renderExploitScreenshot(baseFinding(), {
+      outputDir: imagesDir,
+      markdownDir,
+      binary: stubBinary,
+      available: true,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.relativePath.startsWith("./images/")).toBe(true);
+  });
+});
+
+describe("template integration", () => {
+  it("embeds screenshot img tags into the PoC section when passed", () => {
+    const { markdown } = renderAdvisoryMarkdown(baseFinding(), {
+      screenshots: [
+        { alt: "exploit-demo", relativePath: "./images/shot.png", caption: "Exploit in action", width: 1200 },
+      ],
+    });
+    expect(markdown).toContain('<img width="1200" alt="exploit-demo" src="./images/shot.png" />');
+    expect(markdown).toContain("> Exploit in action");
+  });
+
+  it("suppresses the 'to fill in' PoC placeholder once a screenshot is attached even without evidence", () => {
+    const noEvidenceFinding = {
+      ...baseFinding(),
+      evidence: { request: "", response: "", analysis: undefined },
+    };
+    const { markdown } = renderAdvisoryMarkdown(noEvidenceFinding, {
+      screenshots: [{ alt: "shot", relativePath: "./images/shot.png" }],
+    });
+    expect(markdown).not.toContain("To fill in: concrete reproduction steps");
+  });
+});

--- a/packages/core/src/disclose/screenshots.ts
+++ b/packages/core/src/disclose/screenshots.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { Finding } from "@pwnkit/shared";
+
+export interface ScreenshotResult {
+  alt: string;
+  path: string;
+  relativePath: string;
+  caption: string;
+  sessionText: string;
+}
+
+export interface ScreenshotOptions {
+  outputDir: string;
+  /** Emit image paths relative to this directory (so the markdown sibling file can reference them). */
+  markdownDir?: string;
+  binary?: string;
+  theme?: string;
+  width?: number;
+  fontSize?: number;
+  background?: string;
+  /** Override freeze detection (for tests). */
+  available?: boolean;
+}
+
+const DEFAULT_OPTS: Required<Pick<ScreenshotOptions, "binary" | "theme" | "width" | "fontSize" | "background">> = {
+  binary: "freeze",
+  theme: "dracula",
+  width: 1200,
+  fontSize: 14,
+  background: "#0f1117",
+};
+
+function slugify(input: string, max = 40): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, max);
+}
+
+export function isFreezeAvailable(binary = DEFAULT_OPTS.binary): boolean {
+  try {
+    execFileSync(process.platform === "win32" ? "where" : "which", [binary], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Compose a shell-session text file from the finding's evidence. This is what
+ * gets rendered into the terminal-style PNG. Keeps the request and response in
+ * the same pane so the exploit and its observable effect appear together.
+ */
+export function composeExploitSession(finding: Finding): string {
+  const lines: string[] = [];
+  lines.push(`$ # PoC for: ${finding.title}`);
+  lines.push(`$ # Category: ${finding.category} | severity: ${finding.severity}`);
+  lines.push("");
+
+  const request = finding.evidence?.request?.trim();
+  const response = finding.evidence?.response?.trim();
+
+  if (request) {
+    const requestLines = request.split("\n");
+    lines.push(`$ ${requestLines[0]}`);
+    for (const line of requestLines.slice(1)) {
+      lines.push(`  ${line}`);
+    }
+    lines.push("");
+  }
+
+  if (response) {
+    lines.push(response);
+  }
+
+  const analysis = finding.evidence?.analysis?.trim();
+  if (analysis) {
+    lines.push("");
+    lines.push("# Agent analysis:");
+    for (const line of analysis.split("\n")) {
+      lines.push(`# ${line}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Render a single screenshot from the finding's evidence. Returns null when
+ * freeze is unavailable or rendering fails — callers should treat that as a
+ * graceful skip, not an error.
+ */
+export function renderExploitScreenshot(
+  finding: Finding,
+  options: ScreenshotOptions,
+): ScreenshotResult | null {
+  const opts = { ...DEFAULT_OPTS, ...options };
+  const available = options.available ?? isFreezeAvailable(opts.binary);
+  if (!available) return null;
+
+  mkdirSync(opts.outputDir, { recursive: true });
+
+  const slug = slugify(`${finding.severity}-${finding.id.slice(0, 8)}-${finding.title}`);
+  const sessionText = composeExploitSession(finding);
+  const sessionFile = join(opts.outputDir, `${slug}.session.txt`);
+  const pngPath = join(opts.outputDir, `${slug}.png`);
+  writeFileSync(sessionFile, sessionText, "utf8");
+
+  try {
+    execFileSync(
+      opts.binary,
+      [
+        sessionFile,
+        "--language", "bash",
+        "--theme", opts.theme,
+        "--window",
+        "--padding", "20,30",
+        "--margin", "10",
+        "--background", opts.background,
+        "--font.size", String(opts.fontSize),
+        "--width", String(opts.width),
+        "-o", pngPath,
+      ],
+      { stdio: "ignore" },
+    );
+  } catch {
+    return null;
+  }
+
+  const relativePath = options.markdownDir
+    ? pngPath.startsWith(options.markdownDir)
+      ? "." + pngPath.slice(options.markdownDir.length)
+      : pngPath
+    : pngPath;
+
+  return {
+    alt: `exploit-${slug}`,
+    path: pngPath,
+    relativePath,
+    caption: finding.title,
+    sessionText,
+  };
+}

--- a/packages/core/src/disclose/template.ts
+++ b/packages/core/src/disclose/template.ts
@@ -1,0 +1,140 @@
+import type { Finding } from "@pwnkit/shared";
+import { suggestCwesForCategory, formatCweSection } from "./cwe.js";
+import { suggestCvss } from "./cvss.js";
+
+export interface AdvisoryContext {
+  target?: string;
+  targetRef?: string;
+  commitHash?: string;
+  pwnkitVersion?: string;
+  scanId?: string;
+}
+
+export interface RenderedAdvisory {
+  filename: string;
+  markdown: string;
+  cvssVector: string;
+  cvssScore: number;
+  primaryCwe: string;
+  severity: string;
+}
+
+function severityHeading(severity: string): string {
+  const upper = severity.toUpperCase();
+  return upper === "CRITICAL" || upper === "HIGH" || upper === "MEDIUM" || upper === "LOW" ? upper : severity;
+}
+
+function slugifyTitle(title: string, max = 80): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, max);
+}
+
+function indentEvidenceBlock(raw: string, lang = ""): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  return "```" + lang + "\n" + trimmed + "\n```";
+}
+
+export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = {}): RenderedAdvisory {
+  const cwes = suggestCwesForCategory(finding.category);
+  const cvss = suggestCvss(finding);
+  const severity = severityHeading(finding.severity);
+
+  const filenameSlug = slugifyTitle(finding.title);
+  const filename = `${String(finding.severity).padStart(1, "0")}-${finding.severity}-${filenameSlug}.md`;
+
+  const affectedLine = ctx.target
+    ? `\`${ctx.target}\`${ctx.targetRef ? ` at \`${ctx.targetRef}\`` : ""}${ctx.commitHash ? ` (commit \`${ctx.commitHash.slice(0, 12)}\`)` : ""}`
+    : "_To fill in: the versions/refs this is present on._";
+
+  const cvssSource = cvss.source === "finding"
+    ? "populated on the finding by pwnkit"
+    : "heuristic from category + severity — override in the GHSA editor if the operator disagrees";
+
+  const remediation = finding.remediation;
+  const suggestedFixParts: string[] = [];
+  if (remediation?.summary) suggestedFixParts.push(remediation.summary);
+  if (remediation?.steps?.length) {
+    suggestedFixParts.push(remediation.steps.map((step, i) => `${i + 1}. ${step}`).join("\n"));
+  }
+  if (remediation?.codeExample?.after) {
+    const lang = remediation.codeExample.language || "";
+    suggestedFixParts.push(
+      remediation.codeExample.before
+        ? `**Before:**\n\n\`\`\`${lang}\n${remediation.codeExample.before}\n\`\`\`\n\n**After:**\n\n\`\`\`${lang}\n${remediation.codeExample.after}\n\`\`\``
+        : `\`\`\`${lang}\n${remediation.codeExample.after}\n\`\`\``,
+    );
+  }
+  const suggestedFix = suggestedFixParts.length > 0
+    ? suggestedFixParts.join("\n\n")
+    : "_To fill in: copy-paste the correct pattern from a sibling handler in the same repo._";
+
+  const evidenceAnalysis = finding.evidence?.analysis?.trim() ?? "";
+
+  const out: string[] = [];
+  out.push("# Title", "");
+  out.push(finding.title, "");
+
+  out.push("# Severity", "");
+  out.push(`**${severity}** — ${cvss.vector} (~${cvss.score.toFixed(1)})`, "");
+  out.push(`_CVSS source: ${cvssSource}._`, "");
+
+  out.push(formatCweSection(cwes), "");
+
+  out.push("# Affected versions", "");
+  out.push(affectedLine, "");
+
+  if (ctx.pwnkitVersion || ctx.scanId) {
+    const bits: string[] = [];
+    if (ctx.pwnkitVersion) bits.push(`pwnkit \`${ctx.pwnkitVersion}\``);
+    if (ctx.scanId) bits.push(`scan \`${ctx.scanId.slice(0, 8)}\``);
+    out.push(`> Code-verified by ${bits.join(", ")}.`, "");
+  }
+
+  out.push("## Summary", "");
+  out.push(finding.description.trim(), "");
+
+  if (evidenceAnalysis && evidenceAnalysis !== finding.description.trim()) {
+    out.push("## Analysis", "");
+    out.push(evidenceAnalysis, "");
+  }
+
+  out.push("## PoC", "");
+  if (finding.evidence?.request?.trim()) {
+    out.push("**Request:**", "");
+    out.push(indentEvidenceBlock(finding.evidence.request, "http"), "");
+  }
+  if (finding.evidence?.response?.trim()) {
+    out.push("**Response:**", "");
+    out.push(indentEvidenceBlock(finding.evidence.response, "http"), "");
+  }
+  if (!finding.evidence?.request?.trim() && !finding.evidence?.response?.trim()) {
+    out.push("_To fill in: concrete reproduction steps. `pwnkit-cli disclose` will auto-populate this once PoC execution lands (issue #168)._", "");
+  }
+
+  out.push("## Suggested fix", "");
+  out.push(suggestedFix, "");
+
+  out.push("## Patch status", "");
+  out.push("_To fill in after canary re-verification. `pwnkit-cli disclose` will auto-populate this once the canary-reverify capability lands (issue #168)._", "");
+
+  out.push("## Credits", "");
+  out.push(
+    "Discovered by **pwnkit**, an AI-assisted security scanner ([github.com/PwnKit-Labs/pwnkit](https://github.com/PwnKit-Labs/pwnkit)).",
+    "",
+    "Reporter: _(your github handle)_",
+    "",
+  );
+
+  return {
+    filename,
+    markdown: out.join("\n").replace(/\n{3,}/g, "\n\n"),
+    cvssVector: cvss.vector,
+    cvssScore: cvss.score,
+    primaryCwe: cwes[0]?.id ?? "",
+    severity: finding.severity,
+  };
+}

--- a/packages/core/src/disclose/template.ts
+++ b/packages/core/src/disclose/template.ts
@@ -2,12 +2,21 @@ import type { Finding } from "@pwnkit/shared";
 import { suggestCwesForCategory, formatCweSection } from "./cwe.js";
 import { suggestCvss } from "./cvss.js";
 
+export interface AdvisoryScreenshot {
+  alt: string;
+  /** Markdown-ready href (usually a path relative to the advisory file). */
+  relativePath: string;
+  caption?: string;
+  width?: number;
+}
+
 export interface AdvisoryContext {
   target?: string;
   targetRef?: string;
   commitHash?: string;
   pwnkitVersion?: string;
   scanId?: string;
+  screenshots?: AdvisoryScreenshot[];
 }
 
 export interface RenderedAdvisory {
@@ -103,6 +112,15 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
   }
 
   out.push("## PoC", "");
+  if (ctx.screenshots && ctx.screenshots.length > 0) {
+    for (const shot of ctx.screenshots) {
+      const width = shot.width ? ` width="${shot.width}"` : "";
+      out.push(`<img${width} alt="${shot.alt}" src="${shot.relativePath}" />`, "");
+      if (shot.caption) {
+        out.push(`> ${shot.caption}`, "");
+      }
+    }
+  }
   if (finding.evidence?.request?.trim()) {
     out.push("**Request:**", "");
     out.push(indentEvidenceBlock(finding.evidence.request, "http"), "");
@@ -111,7 +129,7 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
     out.push("**Response:**", "");
     out.push(indentEvidenceBlock(finding.evidence.response, "http"), "");
   }
-  if (!finding.evidence?.request?.trim() && !finding.evidence?.response?.trim()) {
+  if (!finding.evidence?.request?.trim() && !finding.evidence?.response?.trim() && (!ctx.screenshots || ctx.screenshots.length === 0)) {
     out.push("_To fill in: concrete reproduction steps. `pwnkit-cli disclose` will auto-populate this once PoC execution lands (issue #168)._", "");
   }
 

--- a/packages/core/src/disclose/template.ts
+++ b/packages/core/src/disclose/template.ts
@@ -2,6 +2,7 @@ import type { Finding } from "@pwnkit/shared";
 import { suggestCwesForCategory, formatCweSection } from "./cwe.js";
 import { suggestCvss } from "./cvss.js";
 import { formatPatchStatusSection, type ReverifyResult } from "./canary.js";
+import { formatVersionRangeLine, type VersionRangeResult } from "./version-range.js";
 
 export interface AdvisoryScreenshot {
   alt: string;
@@ -19,6 +20,7 @@ export interface AdvisoryContext {
   scanId?: string;
   screenshots?: AdvisoryScreenshot[];
   patchStatus?: ReverifyResult;
+  versionRange?: VersionRangeResult;
 }
 
 export interface RenderedAdvisory {
@@ -54,12 +56,20 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
   const cvss = suggestCvss(finding);
   const severity = severityHeading(finding.severity);
 
+  // Prefix by severity rank so lexicographic sort = criticals-first.
+  // Explicit numeric map because "critical" < "high" alphabetically.
+  const rank: Record<string, string> = { critical: "1", high: "2", medium: "3", low: "4", info: "5" };
   const filenameSlug = slugifyTitle(finding.title);
-  const filename = `${String(finding.severity).padStart(1, "0")}-${finding.severity}-${filenameSlug}.md`;
+  const filename = `${rank[finding.severity] ?? "9"}-${finding.severity}-${filenameSlug}.md`;
 
-  const affectedLine = ctx.target
-    ? `\`${ctx.target}\`${ctx.targetRef ? ` at \`${ctx.targetRef}\`` : ""}${ctx.commitHash ? ` (commit \`${ctx.commitHash.slice(0, 12)}\`)` : ""}`
-    : "_To fill in: the versions/refs this is present on._";
+  let affectedLine: string;
+  if (ctx.versionRange) {
+    affectedLine = formatVersionRangeLine(ctx.versionRange);
+  } else if (ctx.target) {
+    affectedLine = `\`${ctx.target}\`${ctx.targetRef ? ` at \`${ctx.targetRef}\`` : ""}${ctx.commitHash ? ` (commit \`${ctx.commitHash.slice(0, 12)}\`)` : ""}`;
+  } else {
+    affectedLine = "_Pass `--repo <path>` to `pwnkit-cli disclose` to auto-detect the affected version range from git tags._";
+  }
 
   const cvssSource = cvss.source === "finding"
     ? "populated on the finding by pwnkit"

--- a/packages/core/src/disclose/template.ts
+++ b/packages/core/src/disclose/template.ts
@@ -1,6 +1,7 @@
 import type { Finding } from "@pwnkit/shared";
 import { suggestCwesForCategory, formatCweSection } from "./cwe.js";
 import { suggestCvss } from "./cvss.js";
+import { formatPatchStatusSection, type ReverifyResult } from "./canary.js";
 
 export interface AdvisoryScreenshot {
   alt: string;
@@ -17,6 +18,7 @@ export interface AdvisoryContext {
   pwnkitVersion?: string;
   scanId?: string;
   screenshots?: AdvisoryScreenshot[];
+  patchStatus?: ReverifyResult;
 }
 
 export interface RenderedAdvisory {
@@ -137,7 +139,11 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
   out.push(suggestedFix, "");
 
   out.push("## Patch status", "");
-  out.push("_To fill in after canary re-verification. `pwnkit-cli disclose` will auto-populate this once the canary-reverify capability lands (issue #168)._", "");
+  if (ctx.patchStatus) {
+    out.push(formatPatchStatusSection(ctx.patchStatus), "");
+  } else {
+    out.push("_Pass `--repo <path>` to `pwnkit-cli disclose` to auto-verify this against the target's current HEAD or a specific tag._", "");
+  }
 
   out.push("## Credits", "");
   out.push(

--- a/packages/core/src/disclose/version-range.test.ts
+++ b/packages/core/src/disclose/version-range.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Finding } from "@pwnkit/shared";
+import { detectVersionRange, formatVersionRangeLine } from "./version-range.js";
+
+function baseFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "finding-vr-0001",
+    templateId: "auth-gap-template",
+    title: "Shape",
+    description: "src/vulnerable.ts:1 — the shape.",
+    severity: "high",
+    category: "tool-misuse",
+    status: "verified",
+    evidence: { request: "", response: "", analysis: undefined },
+    timestamp: 1712345678,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a synthetic repo with three tagged releases:
+ *   v1.0 — file doesn't exist yet
+ *   v2.0 — file with the vulnerable shape
+ *   v3.0 — file with the vulnerable shape (still)
+ *   v4.0 — file removed
+ * HEAD — file removed (matches v4.0)
+ */
+function buildFourTagRepo(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), "pwnkit-vr-"));
+  execFileSync("git", ["init", "-q"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.email", "t@t"], { cwd: repoPath });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: repoPath });
+  mkdirSync(join(repoPath, "src"), { recursive: true });
+
+  // v1.0 — unrelated commit, no vulnerable file
+  writeFileSync(join(repoPath, "README.md"), "hello");
+  execFileSync("git", ["add", "."], { cwd: repoPath });
+  execFileSync("git", ["commit", "-q", "-m", "v1"], { cwd: repoPath });
+  execFileSync("git", ["tag", "v1.0.0"], { cwd: repoPath });
+
+  // v2.0 — introduce the vulnerable file
+  writeFileSync(join(repoPath, "src/vulnerable.ts"), "line1\nline2\nline3\n");
+  execFileSync("git", ["add", "."], { cwd: repoPath });
+  execFileSync("git", ["commit", "-q", "-m", "add shape"], { cwd: repoPath });
+  execFileSync("git", ["tag", "v2.0.0"], { cwd: repoPath });
+
+  // v3.0 — unrelated change; still vulnerable
+  writeFileSync(join(repoPath, "README.md"), "updated");
+  execFileSync("git", ["add", "."], { cwd: repoPath });
+  execFileSync("git", ["commit", "-q", "-m", "readme"], { cwd: repoPath });
+  execFileSync("git", ["tag", "v3.0.0"], { cwd: repoPath });
+
+  // v4.0 — remove the vulnerable file
+  rmSync(join(repoPath, "src/vulnerable.ts"));
+  execFileSync("git", ["add", "-A"], { cwd: repoPath });
+  execFileSync("git", ["commit", "-q", "-m", "remove shape"], { cwd: repoPath });
+  execFileSync("git", ["tag", "v4.0.0"], { cwd: repoPath });
+
+  return repoPath;
+}
+
+describe("detectVersionRange", () => {
+  let repoPath: string;
+  beforeAll(() => {
+    repoPath = buildFourTagRepo();
+  });
+  afterAll(() => {
+    if (repoPath) rmSync(repoPath, { recursive: true, force: true });
+  });
+
+  it("reports removed-upstream with correct introducedIn and fixedIn", () => {
+    const result = detectVersionRange(baseFinding(), { repoPath });
+    expect(result.status).toBe("removed-upstream");
+    expect(result.affectedTags).toEqual(["v3.0.0", "v2.0.0"]);
+    expect(result.introducedIn).toBe("v2.0.0");
+    expect(result.fixedIn).toBe("v4.0.0");
+    expect(result.presentOnHead).toBe(false);
+  });
+
+  it("returns indeterminate when no file:line refs can be extracted", () => {
+    const result = detectVersionRange(
+      baseFinding({
+        description: "No refs.",
+        evidence: { request: "", response: "", analysis: undefined },
+      }),
+      { repoPath },
+    );
+    expect(result.status).toBe("indeterminate");
+    expect(result.affectedTags).toEqual([]);
+  });
+
+  it("reports no-tags when the repo has no tags", () => {
+    const bare = mkdtempSync(join(tmpdir(), "pwnkit-vr-bare-"));
+    execFileSync("git", ["init", "-q"], { cwd: bare });
+    execFileSync("git", ["config", "user.email", "t@t"], { cwd: bare });
+    execFileSync("git", ["config", "user.name", "t"], { cwd: bare });
+    writeFileSync(join(bare, "x"), "x");
+    execFileSync("git", ["add", "."], { cwd: bare });
+    execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: bare });
+    const result = detectVersionRange(baseFinding(), { repoPath: bare });
+    expect(result.status).toBe("no-tags");
+    rmSync(bare, { recursive: true, force: true });
+  });
+});
+
+describe("formatVersionRangeLine", () => {
+  it("renders `>= X, < Y` for removed-upstream with both bounds", () => {
+    const line = formatVersionRangeLine({
+      status: "removed-upstream",
+      affectedTags: ["v3.0.0", "v2.0.0"],
+      introducedIn: "v2.0.0",
+      fixedIn: "v4.0.0",
+      presentOnHead: false,
+      notes: [],
+    });
+    expect(line).toContain("`>= v2.0.0`");
+    expect(line).toContain("`< v4.0.0`");
+    expect(line).toContain("v3.0.0");
+  });
+
+  it("renders `>= X, HEAD` for present-on-head", () => {
+    const line = formatVersionRangeLine({
+      status: "present-on-head",
+      affectedTags: ["v4.0.0", "v3.0.0"],
+      introducedIn: "v3.0.0",
+      presentOnHead: true,
+      notes: [],
+    });
+    expect(line).toContain("`>= v3.0.0`");
+    expect(line).toContain("HEAD");
+  });
+
+  it("renders an italic note for no-tags / indeterminate", () => {
+    expect(formatVersionRangeLine({ status: "no-tags", affectedTags: [], presentOnHead: false, notes: [] })).toMatch(/^_/);
+    expect(formatVersionRangeLine({ status: "indeterminate", affectedTags: [], presentOnHead: false, notes: [] })).toMatch(/^_/);
+  });
+});

--- a/packages/core/src/disclose/version-range.ts
+++ b/packages/core/src/disclose/version-range.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import type { Finding } from "@pwnkit/shared";
+import { extractFileRefs, type FileRef } from "./canary.js";
+
+export interface VersionRangeResult {
+  /** Tags (newest first) where every cited file:line still resolves — i.e. the finding is present. */
+  affectedTags: string[];
+  /** Earliest tag where the finding is still present (= "introduced in" lower bound). */
+  introducedIn?: string;
+  /** First tag (newest-first walk) where at least one cited file is gone. null if never. */
+  fixedIn?: string;
+  /** true when the pattern resolves at the repo's current HEAD. */
+  presentOnHead: boolean;
+  status: "present-on-head" | "removed-upstream" | "indeterminate" | "no-tags";
+  notes: string[];
+}
+
+export interface VersionRangeOptions {
+  repoPath: string;
+  /** Max number of tags to walk from newest to oldest. Default 30. */
+  tagLimit?: number;
+  /** Optional filter: only consider tags that match this glob. */
+  tagGlob?: string;
+}
+
+function gitCmd(repoPath: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoPath,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+      maxBuffer: 4 * 1024 * 1024,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List tags sorted newest-first. Prefer semver-ish version ordering (`-v:refname`)
+ * so rapidly-created tags that share a creator-date second still sort stably.
+ * Falls back to creator-date if version ordering yields nothing (non-semver tags).
+ */
+function listTags(repoPath: string, limit: number, glob?: string): string[] {
+  const baseArgs = ["tag"];
+  if (glob) baseArgs.push("-l", glob);
+  const byVersion = gitCmd(repoPath, [...baseArgs, "--sort=-v:refname"]);
+  if (byVersion && byVersion.length > 0) {
+    return byVersion.split("\n").filter(Boolean).slice(0, limit);
+  }
+  const byDate = gitCmd(repoPath, [...baseArgs, "--sort=-creatordate"]);
+  if (!byDate) return [];
+  return byDate.split("\n").filter(Boolean).slice(0, limit);
+}
+
+/**
+ * Does a file with non-empty content exist at this ref?
+ */
+function fileExistsAtRef(repoPath: string, ref: string, filePath: string): boolean {
+  const out = gitCmd(repoPath, ["cat-file", "-e", `${ref}:${filePath}`]);
+  // `cat-file -e` exits 0 on hit, non-zero on miss. `gitCmd` returns "" on hit
+  // (empty stdout), null on miss.
+  return out !== null;
+}
+
+/**
+ * If a line number is cited, check the line exists (i.e. file is long enough)
+ * at the given ref. Line content matching is out of scope for v1 — file +
+ * line-range existence is the conservative, fast check.
+ */
+function lineExistsAtRef(repoPath: string, ref: string, filePath: string, line: number): boolean {
+  const content = gitCmd(repoPath, ["show", `${ref}:${filePath}`]);
+  if (content === null) return false;
+  const lineCount = content.split("\n").length;
+  return line <= lineCount;
+}
+
+/**
+ * Every cited ref resolves at this git ref iff the finding is still present.
+ */
+function findingPresentAtRef(repoPath: string, ref: string, refs: FileRef[]): boolean {
+  if (refs.length === 0) return false;
+  for (const r of refs) {
+    if (!fileExistsAtRef(repoPath, ref, r.file)) return false;
+    if (r.line !== undefined && !lineExistsAtRef(repoPath, ref, r.file, r.line)) return false;
+  }
+  return true;
+}
+
+/**
+ * Walk the repo's tags newest-first, classifying each as "finding present" or
+ * "finding absent." Returns the set of affected tags and heuristics for the
+ * "introduced in" / "fixed in" bounds.
+ *
+ * The walk is newest-first so that once we find the first absent tag we can
+ * mark everything from that point backwards as absent candidates and — by
+ * stopping at the first gap — avoid scanning the entire tag history.
+ */
+export function detectVersionRange(finding: Finding, options: VersionRangeOptions): VersionRangeResult {
+  const repoPath = resolve(options.repoPath);
+  const tagLimit = options.tagLimit ?? 30;
+  const refs = extractFileRefs(finding);
+  const notes: string[] = [];
+
+  if (refs.length === 0) {
+    return {
+      affectedTags: [],
+      presentOnHead: false,
+      status: "indeterminate",
+      notes: ["Could not extract file:line references from the finding. Add explicit `path/to/file.ts:NNN` citations to the description and re-run."],
+    };
+  }
+
+  const tags = listTags(repoPath, tagLimit, options.tagGlob);
+  const presentOnHead = findingPresentAtRef(repoPath, "HEAD", refs);
+
+  if (tags.length === 0) {
+    notes.push(`No tags found in ${repoPath}${options.tagGlob ? ` matching '${options.tagGlob}'` : ""}.`);
+    return {
+      affectedTags: [],
+      presentOnHead,
+      status: "no-tags",
+      notes,
+    };
+  }
+
+  // Walk every tag (newest-first) and classify. Don't short-circuit — the
+  // shape can be introduced in tag N, still present in N+1, and removed at
+  // N+2; stopping at the first absent tag misses the affected range.
+  const classified: Array<{ tag: string; present: boolean }> = tags.map((tag) => ({
+    tag,
+    present: findingPresentAtRef(repoPath, tag, refs),
+  }));
+
+  const affectedTags = classified.filter((c) => c.present).map((c) => c.tag);
+  const introducedIn = affectedTags[affectedTags.length - 1];
+
+  // `fixedIn` = the most-recent absent tag that sits newer than the newest
+  // affected tag. In the newest-first array, that's the absent tag immediately
+  // *before* (higher up in the array) the first present tag.
+  let fixedIn: string | undefined;
+  const firstPresentIdx = classified.findIndex((c) => c.present);
+  if (firstPresentIdx > 0) {
+    // There's at least one absent tag between HEAD and the newest affected tag.
+    // Walk backwards to the one that sits immediately newer than the present
+    // region — that's the "fixed-in" tag.
+    fixedIn = classified[firstPresentIdx - 1]?.tag;
+  }
+
+  let status: VersionRangeResult["status"];
+  if (presentOnHead) status = "present-on-head";
+  else if (affectedTags.length > 0) status = "removed-upstream";
+  else status = "indeterminate";
+
+  if (affectedTags.length === tagLimit) {
+    notes.push(`Hit the ${tagLimit}-tag walk limit — the introducing tag may be older than reported. Pass --tag-limit to extend.`);
+  }
+
+  return {
+    affectedTags,
+    introducedIn,
+    fixedIn,
+    presentOnHead,
+    status,
+    notes,
+  };
+}
+
+/**
+ * Turn the version-range result into a markdown string suited to the advisory
+ * template's "Affected versions" section.
+ */
+export function formatVersionRangeLine(result: VersionRangeResult): string {
+  switch (result.status) {
+    case "present-on-head":
+      if (result.introducedIn) {
+        return `\`>= ${result.introducedIn}\`, including the repo's current \`HEAD\`. Confirmed on: ${result.affectedTags.map((t) => "`" + t + "`").join(", ")}.`;
+      }
+      return "Present on the repo's current `HEAD` (no tagged introduction point detected).";
+    case "removed-upstream":
+      if (result.introducedIn && result.fixedIn) {
+        return `\`>= ${result.introducedIn}\`, \`< ${result.fixedIn}\`. Confirmed affected: ${result.affectedTags.map((t) => "`" + t + "`").join(", ")}. Fixed from \`${result.fixedIn}\` onward.`;
+      }
+      if (result.introducedIn) {
+        return `\`>= ${result.introducedIn}\`. Confirmed affected: ${result.affectedTags.map((t) => "`" + t + "`").join(", ")}. Fixed upstream at HEAD.`;
+      }
+      return "Removed upstream since the last release.";
+    case "no-tags":
+      return "_No release tags available in the target repo to infer a range._";
+    case "indeterminate":
+    default:
+      return "_Could not auto-detect a version range — add file:line citations to the finding and re-run._";
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,5 +133,5 @@ export { verifyKernelCrash, compileAndRunReproducer, matchCrashSignature, valida
 export type { KernelOracleResult, ReproducerResult, CrashSignatureMatch, ConsistencyResult } from "./triage/kernel-oracle.js";
 
 // Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
-export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession, verifyAgainstRef, extractFileRefs, formatPatchStatusSection } from "./disclose/index.js";
-export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions, PatchStatus, FileRef, ReverifyResult, ReverifyOptions } from "./disclose/index.js";
+export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession, verifyAgainstRef, extractFileRefs, formatPatchStatusSection, detectVersionRange, formatVersionRangeLine } from "./disclose/index.js";
+export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions, PatchStatus, FileRef, ReverifyResult, ReverifyOptions, VersionRangeResult, VersionRangeOptions } from "./disclose/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,5 +133,5 @@ export { verifyKernelCrash, compileAndRunReproducer, matchCrashSignature, valida
 export type { KernelOracleResult, ReproducerResult, CrashSignatureMatch, ConsistencyResult } from "./triage/kernel-oracle.js";
 
 // Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
-export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown } from "./disclose/index.js";
-export type { CweEntry, CvssSuggestion, AdvisoryContext, RenderedAdvisory } from "./disclose/index.js";
+export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession } from "./disclose/index.js";
+export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions } from "./disclose/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,3 +131,7 @@ export { parseCrashReport, crashToFinding, ingestArtifactsFromDirectory, ingestA
 // Kernel crash verification oracle
 export { verifyKernelCrash, compileAndRunReproducer, matchCrashSignature, validateCrashReportConsistency } from "./triage/kernel-oracle.js";
 export type { KernelOracleResult, ReproducerResult, CrashSignatureMatch, ConsistencyResult } from "./triage/kernel-oracle.js";
+
+// Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
+export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown } from "./disclose/index.js";
+export type { CweEntry, CvssSuggestion, AdvisoryContext, RenderedAdvisory } from "./disclose/index.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,5 +133,5 @@ export { verifyKernelCrash, compileAndRunReproducer, matchCrashSignature, valida
 export type { KernelOracleResult, ReproducerResult, CrashSignatureMatch, ConsistencyResult } from "./triage/kernel-oracle.js";
 
 // Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
-export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession } from "./disclose/index.js";
-export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions } from "./disclose/index.js";
+export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession, verifyAgainstRef, extractFileRefs, formatPatchStatusSection } from "./disclose/index.js";
+export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions, PatchStatus, FileRef, ReverifyResult, ReverifyOptions } from "./disclose/index.js";


### PR DESCRIPTION
First slice of #168.

## What lands

- `packages/core/src/disclose/cwe.ts` — `AttackCategory` → ranked CWE list (covers all 28 categories in the shared enum).
- `packages/core/src/disclose/cvss.ts` — CVSS 3.1 vector suggester; passes through \`finding.cvssVector\` if present, synthesises a heuristic otherwise.
- `packages/core/src/disclose/template.ts` — GHSA-style markdown assembler; renders Title / Severity / CWE / Affected versions / Summary / PoC / Suggested fix / Patch status / Credits, respecting \`finding.remediation\` (\`summary\` + \`steps\` + \`codeExample\`) when present.
- `pwnkit-cli disclose [findingId]` — loads findings from DB, renders one \`.md\` per finding under \`~/pwnkit/disclosures/scan-<id>/\`, emits an \`INDEX.md\` with filing order.

## Out of scope (checkboxes still open in #168)

- PoC execution + terminal-screenshot rendering
- Canary re-verification + dropped-findings ledger
- Affected-version range detection via \`git log -S\`
- Sibling-code correct-pattern extraction

Those each need separate infra and are queued for follow-up PRs.

## Test plan

- [x] \`pnpm --filter @pwnkit/core test -- --run disclose\` — 11 tests pass
- [x] \`pwnkit-cli disclose --help\` shows the new subcommand
- [ ] Smoke against a local scan DB — covered once next PR adds an integration test; for now the unit tests stand