### PR TITLE
feat(finding): add optional pocSteps step-graph to Finding (closes #170)

### DIFF
--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { isAbsolute, resolve } from "node:path";
 import { isIP } from "node:net";
-import type { Finding, AttackResult, TargetInfo } from "@pwnkit/shared";
+import type { Finding, AttackResult, PocStep, TargetInfo } from "@pwnkit/shared";
 import type { ToolDefinition, ToolCall, ToolResult, ToolContext } from "./types.js";
 import { sendPrompt, extractResponseText } from "../http.js";
 import { buildAuthHeaders } from "./prompts.js";
@@ -132,6 +132,17 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
       evidence_request: { type: "string", description: "The request/prompt that triggered the vuln" },
       evidence_response: { type: "string", description: "The response showing the vulnerability" },
       evidence_analysis: { type: "string", description: "Your analysis of why this is a vulnerability" },
+      // pwnkit#170 — optional structured proof-of-concept step graph. When the
+      // agent has structured execution data (e.g. it actually ran the curl /
+      // docker steps and observed predictable outputs), it can pass them as a
+      // JSON string here. Each step has { id, kind, summary, action, expect? }.
+      // See PocStep / PocStepKind in @pwnkit/shared/types.ts. Optional —
+      // findings with prose-only evidence MUST leave this unset.
+      poc_steps: {
+        type: "string",
+        description:
+          "OPTIONAL JSON-encoded PocStep[] array (pwnkit#170). Each step: { id, kind: setup|auth|prerequisite|exploit|verify, summary, action: { type: shell|http|docker|note, ... }, expect?: { type: ... } }. Leave unset when you only have prose evidence.",
+      },
     },
     required: ["title", "severity", "category", "evidence_request", "evidence_response"],
   },
@@ -592,6 +603,91 @@ function validateTargetUrl(baseUrl: string, requestedUrl: string): string {
   }
 
   return candidate.toString();
+}
+
+// ── PoC step graph helpers (pwnkit#170) ──
+
+const POC_STEP_KINDS: ReadonlySet<string> = new Set([
+  "setup",
+  "auth",
+  "prerequisite",
+  "exploit",
+  "verify",
+]);
+const POC_ACTION_TYPES: ReadonlySet<string> = new Set(["shell", "http", "docker", "note"]);
+const POC_EXPECT_TYPES: ReadonlySet<string> = new Set([
+  "exit-zero",
+  "http-status",
+  "body-contains",
+  "body-matches",
+  "file-exists",
+]);
+
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function validatePocStep(raw: unknown): PocStep | null {
+  if (!isPlainRecord(raw)) return null;
+  const id = typeof raw.id === "string" && raw.id.length > 0 ? raw.id : null;
+  const summary = typeof raw.summary === "string" ? raw.summary : null;
+  const kind = typeof raw.kind === "string" && POC_STEP_KINDS.has(raw.kind) ? raw.kind : null;
+  if (!id || !summary || !kind) return null;
+  if (!isPlainRecord(raw.action)) return null;
+  const actionType = raw.action.type;
+  if (typeof actionType !== "string" || !POC_ACTION_TYPES.has(actionType)) return null;
+  // We trust the rest of the action fields to the PocStepAction discriminated
+  // union; downstream executors validate per-variant before running anything.
+  const step: PocStep = {
+    id,
+    kind: kind as PocStep["kind"],
+    summary,
+    action: raw.action as PocStep["action"],
+  };
+  if (raw.expect != null) {
+    if (
+      isPlainRecord(raw.expect) &&
+      typeof raw.expect.type === "string" &&
+      POC_EXPECT_TYPES.has(raw.expect.type)
+    ) {
+      step.expect = raw.expect as PocStep["expect"];
+    } else {
+      // Malformed expect — drop just the predicate, keep the step. The step is
+      // still useful for screenshot rendering and advisory prose even without
+      // an executable predicate.
+    }
+  }
+  return step;
+}
+
+/**
+ * Parse the `poc_steps` LLM tool argument into a PocStep[] or null.
+ *
+ * Tolerates three wire shapes seen from real models:
+ *   1. Already-parsed array (some runtimes auto-parse JSON-shaped strings).
+ *   2. JSON-encoded string of an array.
+ *   3. Anything else / malformed — returns null so the finding still saves
+ *      with prose evidence only.
+ *
+ * Exported only for unit tests; not part of the public agent surface.
+ */
+export function parsePocStepsArg(raw: unknown): PocStep[] | null {
+  if (raw == null || raw === "") return null;
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!Array.isArray(parsed)) return null;
+  const out: PocStep[] = [];
+  for (const item of parsed) {
+    const step = validatePocStep(item);
+    if (step) out.push(step);
+  }
+  return out.length > 0 ? out : null;
 }
 
 // ── Tool Executor ──
@@ -1351,6 +1447,13 @@ export class ToolExecutor {
       },
       timestamp: Date.now(),
     };
+
+    // pwnkit#170 — optional structured PoC step graph. The agent passes
+    // `poc_steps` as a JSON-encoded string (LLM tool call wire format). We
+    // tolerate already-parsed arrays too. Anything malformed is silently
+    // dropped so a bad payload never blocks the finding from being saved.
+    const pocSteps = parsePocStepsArg(args.poc_steps);
+    if (pocSteps && pocSteps.length > 0) finding.pocSteps = pocSteps;
 
     this.ctx.findings.push(finding);
     if (this.db && this.ctx.persistFindings !== false) {

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -629,8 +629,9 @@ function isPlainRecord(v: unknown): v is Record<string, unknown> {
 
 function validatePocStep(raw: unknown): PocStep | null {
   if (!isPlainRecord(raw)) return null;
-  const id = typeof raw.id === "string" && raw.id.length > 0 ? raw.id : null;
-  const summary = typeof raw.summary === "string" ? raw.summary : null;
+  const id = typeof raw.id === "string" && raw.id.trim().length > 0 ? raw.id.trim() : null;
+  const summary =
+    typeof raw.summary === "string" && raw.summary.trim().length > 0 ? raw.summary.trim() : null;
   const kind = typeof raw.kind === "string" && POC_STEP_KINDS.has(raw.kind) ? raw.kind : null;
   if (!id || !summary || !kind) return null;
   if (!isPlainRecord(raw.action)) return null;

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -17,7 +17,7 @@ import { detectAvailableRuntimes } from "./runtime/registry.js";
 import { runAgentLoop } from "./agent/loop.js";
 import { runNativeAgentLoop } from "./agent/native-loop.js";
 import { toolCallPreview } from "./agent/tool-preview.js";
-import { getToolsForRole, TOOL_DEFINITIONS } from "./agent/tools.js";
+import { getToolsForRole, TOOL_DEFINITIONS, parsePocStepsArg } from "./agent/tools.js";
 import {
   discoveryPrompt,
   attackPrompt,
@@ -2247,8 +2247,12 @@ function dbFindingToFinding(dbf: {
   if (dbf.pocSteps) {
     try {
       const parsed = JSON.parse(dbf.pocSteps) as unknown;
-      if (Array.isArray(parsed) && parsed.length > 0) {
-        pocSteps = parsed as PocStep[];
+      // Validate each element via the same predicate the agent tool path uses,
+      // so a half-corrupt array degrades to "drop bad steps" rather than
+      // letting malformed rows escape into Finding.pocSteps.
+      const valid = parsePocStepsArg(parsed);
+      if (valid && valid.length > 0) {
+        pocSteps = valid;
       }
     } catch {
       // Corrupt or legacy row — drop the field rather than crashing

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -4,6 +4,7 @@ import type {
   Finding,
   LayerVerdict,
   LayerVerdictKind,
+  PocStep,
   Severity,
   TriageLayerName,
 } from "@pwnkit/shared";
@@ -2229,6 +2230,7 @@ function dbFindingToFinding(dbf: {
   evidenceResponse: string;
   evidenceAnalysis: string | null;
   layerVerdicts?: string | null;
+  pocSteps?: string | null;
   timestamp: number;
 }): Finding {
   let layerVerdicts: LayerVerdict[] | undefined;
@@ -2239,6 +2241,18 @@ function dbFindingToFinding(dbf: {
     } catch {
       // Corrupt or legacy row — drop the field rather than crashing the
       // hydration. The triage stage will repopulate on the next scan.
+    }
+  }
+  let pocSteps: PocStep[] | undefined;
+  if (dbf.pocSteps) {
+    try {
+      const parsed = JSON.parse(dbf.pocSteps) as unknown;
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        pocSteps = parsed as PocStep[];
+      }
+    } catch {
+      // Corrupt or legacy row — drop the field rather than crashing
+      // hydration. The agent loop is free to repopulate on a future scan.
     }
   }
   return {
@@ -2258,6 +2272,7 @@ function dbFindingToFinding(dbf: {
       analysis: dbf.evidenceAnalysis ?? undefined,
     },
     ...(layerVerdicts ? { layerVerdicts } : {}),
+    ...(pocSteps ? { pocSteps } : {}),
     timestamp: dbf.timestamp,
   };
 }

--- a/packages/core/src/cloud-contracts.ts
+++ b/packages/core/src/cloud-contracts.ts
@@ -43,6 +43,19 @@ export interface CloudSinkEvidence {
 }
 
 /**
+ * Optional structured proof-of-concept step graph (pwnkit#170). Emitted only
+ * when the OSS agent has structured execution data; otherwise undefined and
+ * the cloud falls back to the prose `evidence.*` strings as before.
+ *
+ * The cloud orchestrator currently does NOT yet validate this field — by
+ * default zod strips unknown keys, so sending it is safe even before cloud
+ * adds its own schema. When cloud lands the matching zod entry, it should
+ * mirror the `PocStep` shape in `@pwnkit/shared/types.ts` (kept loose here
+ * as `unknown[]` so OSS additions can roll out before cloud's schema does).
+ */
+export type CloudSinkPocSteps = unknown[];
+
+/**
  * Strict finding shape the pwnkit-cloud orchestrator accepts at
  * POST /scans/:id/findings.
  */
@@ -65,6 +78,12 @@ export interface CloudSinkFinding {
   confidence?: number;
   /** Unix epoch milliseconds. */
   timestamp: number;
+  /**
+   * Optional ordered PoC step graph (pwnkit#170). Pass-through field — the
+   * OSS sink does not enrich or validate it beyond a shape check, and the
+   * cloud orchestrator will silently strip it until its schema is updated.
+   */
+  pocSteps?: CloudSinkPocSteps;
 }
 
 /**

--- a/packages/core/src/cloud-sink.ts
+++ b/packages/core/src/cloud-sink.ts
@@ -283,7 +283,35 @@ export function normalizeFinding(rawFinding: unknown): CloudSinkFinding {
   };
   if (confidence !== undefined) normalized.confidence = confidence;
 
+  // pwnkit#170 — pass-through optional PoC step graph. We accept already-
+  // structured arrays (the in-process OSS Finding case) and JSON-encoded
+  // strings (the LLM tool-call case). Anything malformed is dropped — a bad
+  // step graph must never block a finding from reaching cloud.
+  const pocSteps = normalizePocSteps(raw.pocSteps ?? raw.poc_steps);
+  if (pocSteps && pocSteps.length > 0) normalized.pocSteps = pocSteps;
+
   return normalized;
+}
+
+/**
+ * Pass-through normaliser for the optional pocSteps field. Returns the array
+ * shape unchanged when the input is already array-shaped, parses a JSON-
+ * encoded string into one, and yields null for any other shape. This is
+ * deliberately permissive: the OSS sink is a wire-format chokepoint, not a
+ * schema validator — see PocStep in @pwnkit/shared for the canonical shape.
+ */
+function normalizePocSteps(v: unknown): unknown[] | null {
+  if (v == null || v === "") return null;
+  if (Array.isArray(v)) return v;
+  if (typeof v === "string") {
+    try {
+      const parsed = JSON.parse(v);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      return null;
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/core/src/poc-step-graph.test.ts
+++ b/packages/core/src/poc-step-graph.test.ts
@@ -1,0 +1,318 @@
+/**
+ * pwnkit#170 — formalise Finding.evidence into a PoC step graph.
+ *
+ * Coverage:
+ *   1. Type narrowing on PocStepAction / PocStepExpect discriminated unions.
+ *   2. JSON serialisation round-trip on a populated PocStep[].
+ *   3. Backward-compat: a Finding with no pocSteps is still a valid Finding.
+ *   4. The agent-loop `parsePocStepsArg` helper accepts JSON strings and
+ *      already-parsed arrays, and rejects malformed payloads cleanly.
+ *   5. The cloud-sink `normalizeFinding` passes pocSteps through and drops
+ *      malformed step graphs without dropping the finding itself.
+ *
+ * The PoC step graph is OPTIONAL and ADDITIVE — the existing prose evidence
+ * fields (`request`/`response`/`analysis`) stay intact alongside it.
+ */
+import { randomUUID } from "node:crypto";
+import { describe, it, expect } from "vitest";
+import type { Finding, PocStep, PocStepAction, PocStepExpect } from "@pwnkit/shared";
+import { parsePocStepsArg } from "./agent/tools.js";
+import { normalizeFinding } from "./cloud-sink.js";
+
+function makePocSteps(): PocStep[] {
+  return [
+    {
+      id: "setup-docker",
+      kind: "setup",
+      summary: "Boot the vulnerable target in Docker",
+      action: { type: "shell", cmd: "docker run -d -p 8080:80 vuln/app:latest" },
+      expect: { type: "exit-zero" },
+    },
+    {
+      id: "auth-signup",
+      kind: "auth",
+      summary: "Create a low-privilege attacker account",
+      action: {
+        type: "http",
+        method: "POST",
+        url: "http://localhost:8080/signup",
+        headers: { "Content-Type": "application/json" },
+        body: '{"username":"attacker","password":"hunter2"}',
+      },
+      expect: { type: "http-status", status: [200, 201] },
+    },
+    {
+      id: "exploit-rce",
+      kind: "exploit",
+      summary: "Trigger command injection via the avatar URL",
+      action: {
+        type: "http",
+        method: "POST",
+        url: "http://localhost:8080/profile/avatar",
+        body: 'url=$(id)',
+      },
+      expect: { type: "body-contains", text: "uid=0(root)" },
+    },
+    {
+      id: "verify-shell",
+      kind: "verify",
+      summary: "Confirm we landed a shell on the target container",
+      action: { type: "docker", image: "kalilinux/kali-rolling", args: ["nc", "127.0.0.1", "4444"] },
+      expect: { type: "body-matches", pattern: "root@.*#" },
+    },
+    {
+      id: "note-cleanup",
+      kind: "verify",
+      summary: "Operator note: tear down the target before re-running",
+      action: { type: "note", text: "docker rm -f $(docker ps -q --filter ancestor=vuln/app)" },
+    },
+  ];
+}
+
+describe("PocStep types (pwnkit#170)", () => {
+  it("narrows action.type to the right variant fields", () => {
+    const shell: PocStepAction = { type: "shell", cmd: "ls", cwd: "/tmp" };
+    const http: PocStepAction = { type: "http", method: "GET", url: "http://x" };
+    const docker: PocStepAction = { type: "docker", image: "alpine", args: ["sh"] };
+    const note: PocStepAction = { type: "note", text: "do this manually" };
+
+    // The narrowing here is the test — if the union ever broke, tsc would
+    // flag .cmd / .url / .image / .text being missing on the wrong variant.
+    if (shell.type === "shell") expect(shell.cmd).toBe("ls");
+    if (http.type === "http") expect(http.url).toBe("http://x");
+    if (docker.type === "docker") expect(docker.image).toBe("alpine");
+    if (note.type === "note") expect(note.text).toBe("do this manually");
+  });
+
+  it("narrows expect.type to the right predicate fields", () => {
+    const exitZero: PocStepExpect = { type: "exit-zero" };
+    const httpStatus: PocStepExpect = { type: "http-status", status: 200 };
+    const httpStatusList: PocStepExpect = { type: "http-status", status: [200, 201, 204] };
+    const bodyContains: PocStepExpect = { type: "body-contains", text: "ok" };
+    const bodyMatches: PocStepExpect = { type: "body-matches", pattern: "^ok$" };
+    const fileExists: PocStepExpect = { type: "file-exists", path: "/tmp/flag" };
+
+    if (exitZero.type === "exit-zero") expect(exitZero).toBeTruthy();
+    if (httpStatus.type === "http-status") expect(httpStatus.status).toBe(200);
+    if (httpStatusList.type === "http-status" && Array.isArray(httpStatusList.status)) {
+      expect(httpStatusList.status).toEqual([200, 201, 204]);
+    }
+    if (bodyContains.type === "body-contains") expect(bodyContains.text).toBe("ok");
+    if (bodyMatches.type === "body-matches") expect(bodyMatches.pattern).toBe("^ok$");
+    if (fileExists.type === "file-exists") expect(fileExists.path).toBe("/tmp/flag");
+  });
+});
+
+describe("Finding.pocSteps backward compatibility (pwnkit#170)", () => {
+  it("a Finding without pocSteps is still a valid Finding", () => {
+    // This is intentionally the legacy shape: prose evidence only, no step
+    // graph. Every renderer / sink / DB writer must keep working in this
+    // case — the field is OPTIONAL.
+    const legacy: Finding = {
+      id: randomUUID(),
+      templateId: "manual",
+      title: "Legacy reflected XSS",
+      description: "q param reflected without encoding",
+      severity: "high",
+      category: "xss",
+      status: "discovered",
+      evidence: {
+        request: "GET /search?q=<script>",
+        response: "<script> echoed",
+        analysis: "no encoding in the template",
+      },
+      timestamp: 1_700_000_000_000,
+    };
+    expect(legacy.pocSteps).toBeUndefined();
+    expect(legacy.evidence.request).toContain("<script>");
+  });
+
+  it("a Finding with pocSteps coexists with prose evidence (additive)", () => {
+    const enriched: Finding = {
+      id: randomUUID(),
+      templateId: "manual",
+      title: "RCE via avatar URL",
+      description: "shell metacharacters reach a curl invocation",
+      severity: "critical",
+      category: "command-injection",
+      status: "discovered",
+      evidence: {
+        request: "POST /profile/avatar url=$(id)",
+        response: "uid=0(root)",
+        analysis: "$() reaches the shell",
+      },
+      pocSteps: makePocSteps(),
+      timestamp: 1_700_000_000_000,
+    };
+    // Both halves of the contract present.
+    expect(enriched.evidence.request).toContain("$(id)");
+    expect(enriched.pocSteps).toBeDefined();
+    expect(enriched.pocSteps).toHaveLength(5);
+    expect(enriched.pocSteps![0].kind).toBe("setup");
+    expect(enriched.pocSteps![enriched.pocSteps!.length - 1].kind).toBe("verify");
+  });
+
+  it("JSON serialisation round-trips a populated step graph byte-identically", () => {
+    const steps = makePocSteps();
+    const wire = JSON.stringify(steps);
+    const restored = JSON.parse(wire) as PocStep[];
+    // Deep-equal restores; identity does not, by design.
+    expect(restored).toEqual(steps);
+    expect(restored).not.toBe(steps);
+    // Re-stringifying yields the same bytes — i.e. no reordering / loss.
+    expect(JSON.stringify(restored)).toBe(wire);
+  });
+
+  it("a Finding with pocSteps round-trips through JSON unchanged", () => {
+    const f: Finding = {
+      id: "f-1",
+      templateId: "manual",
+      title: "x",
+      description: "y",
+      severity: "low",
+      category: "ssrf",
+      status: "discovered",
+      evidence: { request: "GET /", response: "ok" },
+      pocSteps: makePocSteps(),
+      timestamp: 1,
+    };
+    const restored = JSON.parse(JSON.stringify(f)) as Finding;
+    expect(restored).toEqual(f);
+  });
+});
+
+describe("parsePocStepsArg (agent tool wire shape, pwnkit#170)", () => {
+  it("returns null for nullish / empty / non-string non-array input", () => {
+    expect(parsePocStepsArg(null)).toBeNull();
+    expect(parsePocStepsArg(undefined)).toBeNull();
+    expect(parsePocStepsArg("")).toBeNull();
+    expect(parsePocStepsArg(42)).toBeNull();
+    expect(parsePocStepsArg(true)).toBeNull();
+    expect(parsePocStepsArg({ kind: "setup" })).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parsePocStepsArg("[{")).toBeNull();
+    expect(parsePocStepsArg("not json")).toBeNull();
+  });
+
+  it("returns null for valid JSON that isn't an array", () => {
+    expect(parsePocStepsArg('{"kind":"setup"}')).toBeNull();
+    expect(parsePocStepsArg('"setup"')).toBeNull();
+    expect(parsePocStepsArg("123")).toBeNull();
+  });
+
+  it("parses a JSON-encoded string of valid steps", () => {
+    const steps = makePocSteps();
+    const out = parsePocStepsArg(JSON.stringify(steps));
+    expect(out).not.toBeNull();
+    expect(out).toHaveLength(steps.length);
+    expect(out![0].id).toBe("setup-docker");
+  });
+
+  it("accepts an already-parsed array of valid steps", () => {
+    const steps = makePocSteps();
+    const out = parsePocStepsArg(steps);
+    expect(out).toEqual(steps);
+  });
+
+  it("drops individual malformed steps but keeps the well-formed ones", () => {
+    const mixed = [
+      // good
+      {
+        id: "ok",
+        kind: "exploit",
+        summary: "send the payload",
+        action: { type: "shell", cmd: "id" },
+      },
+      // missing id
+      { kind: "exploit", summary: "no id", action: { type: "shell", cmd: "id" } },
+      // unknown kind
+      {
+        id: "x",
+        kind: "armageddon",
+        summary: "bad kind",
+        action: { type: "shell", cmd: "id" },
+      },
+      // unknown action type
+      {
+        id: "y",
+        kind: "exploit",
+        summary: "bad action",
+        action: { type: "smtp", host: "x" },
+      },
+      // not an object
+      "nope",
+      null,
+    ];
+    const out = parsePocStepsArg(mixed);
+    expect(out).toHaveLength(1);
+    expect(out![0].id).toBe("ok");
+  });
+
+  it("drops a malformed expect predicate but keeps the step itself", () => {
+    const out = parsePocStepsArg([
+      {
+        id: "exp",
+        kind: "exploit",
+        summary: "send and check",
+        action: { type: "shell", cmd: "id" },
+        expect: { type: "definitely-not-a-predicate" },
+      },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out![0].expect).toBeUndefined();
+  });
+
+  it("returns null when every candidate step is malformed", () => {
+    const out = parsePocStepsArg([{ kind: "broken" }, "string", 7]);
+    expect(out).toBeNull();
+  });
+});
+
+describe("cloud-sink normalizeFinding pass-through of pocSteps (pwnkit#170)", () => {
+  it("passes a structured pocSteps array through unchanged", () => {
+    const steps = makePocSteps();
+    const out = normalizeFinding({
+      id: "f-1",
+      title: "RCE",
+      severity: "critical",
+      evidence: { request: "x", response: "y" },
+      pocSteps: steps,
+    });
+    expect(out.pocSteps).toEqual(steps);
+  });
+
+  it("parses a JSON-encoded poc_steps string (LLM tool-call shape)", () => {
+    const steps = makePocSteps();
+    const out = normalizeFinding({
+      title: "RCE",
+      severity: "high",
+      evidence_request: "x",
+      evidence_response: "y",
+      poc_steps: JSON.stringify(steps),
+    });
+    expect(Array.isArray(out.pocSteps)).toBe(true);
+    expect(out.pocSteps).toHaveLength(steps.length);
+  });
+
+  it("drops malformed pocSteps without dropping the finding", () => {
+    const out = normalizeFinding({
+      title: "still useful",
+      severity: "high",
+      evidence: { request: "x", response: "y" },
+      pocSteps: "not json [",
+    });
+    expect(out.pocSteps).toBeUndefined();
+    expect(out.title).toBe("still useful");
+  });
+
+  it("omits pocSteps when the input has none (legacy findings)", () => {
+    const out = normalizeFinding({
+      title: "legacy",
+      severity: "low",
+      evidence: { request: "x", response: "y" },
+    });
+    expect(out.pocSteps).toBeUndefined();
+  });
+});

--- a/packages/core/src/poc-step-graph.test.ts
+++ b/packages/core/src/poc-step-graph.test.ts
@@ -294,6 +294,7 @@ describe("cloud-sink normalizeFinding pass-through of pocSteps (pwnkit#170)", ()
     });
     expect(Array.isArray(out.pocSteps)).toBe(true);
     expect(out.pocSteps).toHaveLength(steps.length);
+    expect(out.pocSteps).toEqual(steps);
   });
 
   it("drops malformed pocSteps without dropping the finding", () => {

--- a/packages/core/src/triage-persistence.test.ts
+++ b/packages/core/src/triage-persistence.test.ts
@@ -110,6 +110,9 @@ describe("triage persistence", () => {
 
       const persisted = db.getFinding(finding.id) as { pocSteps: string | null } | undefined;
       expect(persisted?.pocSteps).toBeTruthy();
+      // Byte-identical persistence: the column stores exactly JSON.stringify(steps),
+      // so disclosure replay can fingerprint by hash without reserializing.
+      expect(persisted!.pocSteps).toBe(JSON.stringify(steps));
       // Stored as JSON text — round-trip parses to the original array.
       const restored = JSON.parse(persisted!.pocSteps as string);
       expect(restored).toEqual(steps);

--- a/packages/core/src/triage-persistence.test.ts
+++ b/packages/core/src/triage-persistence.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { pwnkitDB } from "@pwnkit/db";
-import type { Finding, ScanConfig } from "@pwnkit/shared";
+import type { Finding, PocStep, ScanConfig } from "@pwnkit/shared";
 
 const tempDirs: string[] = [];
 
@@ -69,6 +69,65 @@ describe("triage persistence", () => {
       expect(persisted?.triageNote).toBe("rejected: holding-it-wrong");
       expect(persisted?.evidenceAnalysis).toBe("updated after triage");
       expect(persisted?.triagedAt).toBeTruthy();
+    } finally {
+      db.close();
+    }
+  });
+
+  // pwnkit#170 — PoC step graph DB round-trip.
+  //
+  // Findings can carry an optional `pocSteps` field. The DB persists it as a
+  // JSON-stringified blob in a new `pocSteps` text column. Round-trip must be
+  // byte-identical for save → read, and findings without the field must keep
+  // working unchanged (the column is NULL).
+  it("persists pocSteps as JSON and reads it back byte-identically", () => {
+    const { db, scanId } = makeDb();
+    try {
+      const steps: PocStep[] = [
+        {
+          id: "setup",
+          kind: "setup",
+          summary: "Boot target in docker",
+          action: { type: "shell", cmd: "docker run vuln" },
+          expect: { type: "exit-zero" },
+        },
+        {
+          id: "exp",
+          kind: "exploit",
+          summary: "Trigger SQLi",
+          action: {
+            type: "http",
+            method: "POST",
+            url: "http://localhost/login",
+            body: "user=' OR 1=1--",
+          },
+          expect: { type: "http-status", status: [200, 302] },
+        },
+      ];
+      const finding = makeFinding();
+      finding.pocSteps = steps;
+      db.saveFinding(scanId, finding);
+
+      const persisted = db.getFinding(finding.id) as { pocSteps: string | null } | undefined;
+      expect(persisted?.pocSteps).toBeTruthy();
+      // Stored as JSON text — round-trip parses to the original array.
+      const restored = JSON.parse(persisted!.pocSteps as string);
+      expect(restored).toEqual(steps);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("leaves pocSteps NULL on findings that don't carry a step graph", () => {
+    const { db, scanId } = makeDb();
+    try {
+      const finding = makeFinding();
+      // Intentionally NOT setting pocSteps. The legacy prose-only path must
+      // keep working; the DB column should be NULL.
+      db.saveFinding(scanId, finding);
+
+      const persisted = db.getFinding(finding.id) as { pocSteps: string | null } | undefined;
+      expect(persisted?.pocSteps ?? null).toBeNull();
     } finally {
       db.close();
     }

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -365,6 +365,10 @@ export class pwnkitDB {
     if (!colNames.has("layerVerdicts")) {
       this.sqlite.exec("ALTER TABLE findings ADD COLUMN layerVerdicts TEXT");
     }
+    // pwnkit#170 — proof-of-concept step graph. JSON-stringified PocStep[].
+    if (!colNames.has("pocSteps")) {
+      this.sqlite.exec("ALTER TABLE findings ADD COLUMN pocSteps TEXT");
+    }
     this.sqlite.exec("UPDATE findings SET fingerprint = id WHERE fingerprint IS NULL OR fingerprint = ''");
     this.sqlite.exec("UPDATE findings SET triageStatus = 'new' WHERE triageStatus IS NULL OR triageStatus = ''");
     this.sqlite.exec(`
@@ -1155,6 +1159,13 @@ export class pwnkitDB {
       finding.layerVerdicts && finding.layerVerdicts.length > 0
         ? JSON.stringify(finding.layerVerdicts)
         : null;
+    // pwnkit#170 — persist the optional PoC step graph. NULL when the agent
+    // only produced prose evidence; JSON-stringified PocStep[] otherwise. The
+    // field is additive: existing readers that ignore it keep working.
+    const pocStepsJson =
+      finding.pocSteps && finding.pocSteps.length > 0
+        ? JSON.stringify(finding.pocSteps)
+        : null;
     this.db
       .insert(schema.findings)
       .values({
@@ -1180,6 +1191,7 @@ export class pwnkitDB {
         evidenceResponse: finding.evidence.response,
         evidenceAnalysis: finding.evidence.analysis ?? null,
         layerVerdicts: layerVerdictsJson,
+        pocSteps: pocStepsJson,
         timestamp: finding.timestamp,
       })
       .onConflictDoUpdate({
@@ -1205,6 +1217,7 @@ export class pwnkitDB {
           evidenceResponse: finding.evidence.response,
           evidenceAnalysis: finding.evidence.analysis ?? null,
           layerVerdicts: layerVerdictsJson,
+          pocSteps: pocStepsJson,
           timestamp: finding.timestamp,
         },
       })
@@ -2006,6 +2019,7 @@ CREATE TABLE IF NOT EXISTS findings (
   evidenceRequest TEXT NOT NULL,
   evidenceResponse TEXT NOT NULL,
   evidenceAnalysis TEXT,
+  pocSteps TEXT,
   timestamp INTEGER NOT NULL
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -108,6 +108,14 @@ export const findings = sqliteTable(
      * query individual verdict rows. See pwnkit#112.
      */
     layerVerdicts: text("layerVerdicts"),
+    /**
+     * JSON-stringified PocStep[] (see @pwnkit/shared types). NULL when the
+     * agent only produced prose evidence (the legacy default). Stored as
+     * text rather than a join table because the array is read-and-write
+     * together at finding-save time and we never query individual steps.
+     * See pwnkit#170.
+     */
+    pocSteps: text("pocSteps"),
     timestamp: integer("timestamp").notNull(),
   },
   (table) => [

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -251,6 +251,14 @@ export interface Finding {
   cvssVector?: string; // CVSS vector string
   cvssScore?: number; // CVSS numeric score (0–10)
   remediation?: FindingRemediation;
+  /**
+   * Ordered proof-of-concept step graph (pwnkit#170). Optional and additive —
+   * findings produced before this field existed leave it undefined, and every
+   * renderer/exporter/sink must continue to work in that case. When populated,
+   * downstream consumers (screenshot renderer, behavioural re-verify, advisory
+   * markdown) prefer this structured form over the prose `evidence.*` strings.
+   */
+  pocSteps?: PocStep[];
   timestamp: number;
 }
 
@@ -355,6 +363,87 @@ export interface Evidence {
   request: string;
   response: string;
   analysis?: string;
+}
+
+// ── PoC Step Graph (pwnkit#170) ──────────────────────────────────────────────
+//
+// Today, `Finding.evidence` is three free-text strings. Everything downstream
+// that wants to *act* on the PoC — multi-frame screenshot rendering, behavioural
+// re-verification (pwnkit#171), advisory rendering, machine-checkable
+// verification specs — has to re-parse that prose.
+//
+// `pocSteps` formalises the proof-of-concept as an ordered list of named
+// steps. Each step has a `kind` (setup / auth / prerequisite / exploit /
+// verify), a one-line `summary` that captions the step in screenshots and
+// advisories, an `action` (shell / http / docker / note), and an optional
+// `expect` predicate that downstream executors check to decide pass/fail.
+//
+// The field is OPTIONAL and ADDITIVE. Existing findings produced before this
+// type existed have `pocSteps === undefined` and continue to round-trip
+// unchanged through every renderer, exporter, the DB, and the cloud sink.
+
+/** Stage of a PoC step in the discover → exploit → verify lifecycle. */
+export type PocStepKind = "setup" | "auth" | "prerequisite" | "exploit" | "verify";
+
+/**
+ * Action of a PoC step. Discriminated union keyed on `type`. Exactly one
+ * variant is set; downstream executors switch on `type` to dispatch.
+ *
+ * - `shell` — a command to run in a shell. `cwd` is optional and defaults to
+ *   the executor's working directory.
+ * - `http` — a single HTTP request. `headers`/`body` optional.
+ * - `docker` — a docker run with image + args, used when the PoC needs a
+ *   side-container (e.g. attacker-controlled HTTP listener).
+ * - `note` — operator-narrated, non-executable step. Renders into screenshots
+ *   and advisories but is skipped by the behavioural re-verify executor.
+ */
+export type PocStepAction =
+  | { type: "shell"; cmd: string; cwd?: string }
+  | {
+      type: "http";
+      method: string;
+      url: string;
+      headers?: Record<string, string>;
+      body?: string;
+    }
+  | { type: "docker"; image: string; args: string[] }
+  | { type: "note"; text: string };
+
+/**
+ * Predicate the behavioural re-verify executor checks after running an action.
+ * If `expect` is undefined the step is treated as informational and any
+ * non-throwing execution counts as pass.
+ *
+ * - `exit-zero` — process exited 0 (only meaningful for shell/docker).
+ * - `http-status` — HTTP status equals the given code or is a member of the
+ *   given set.
+ * - `body-contains` — response body contains the given substring (HTTP) or
+ *   stdout contains it (shell/docker).
+ * - `body-matches` — response body matches the given regex pattern.
+ * - `file-exists` — the named path exists after the step ran.
+ */
+export type PocStepExpect =
+  | { type: "exit-zero" }
+  | { type: "http-status"; status: number | number[] }
+  | { type: "body-contains"; text: string }
+  | { type: "body-matches"; pattern: string }
+  | { type: "file-exists"; path: string };
+
+export interface PocStep {
+  /** Stable identifier — used by the screenshot renderer to name its output. */
+  id: string;
+  /** Lifecycle stage of this step. */
+  kind: PocStepKind;
+  /** One-line description shown as caption in screenshots and the advisory. */
+  summary: string;
+  /** How to execute this step. Exactly one variant set. */
+  action: PocStepAction;
+  /**
+   * Optional predicate the re-verify executor checks. When present, the step
+   * counts as pass only if the predicate is satisfied; otherwise the step is
+   * informational.
+   */
+  expect?: PocStepExpect;
 }
 
 // ── Kernel Crash Reports ──


### PR DESCRIPTION
## Summary

Today, `Finding.evidence` is three free-text strings (`request`, `response`, `analysis`). Everything downstream that wants to *act* on the PoC — multi-frame screenshot rendering, the behavioural re-verify executor (#171), advisory rendering, machine-checkable verification specs — has to re-parse that prose.

This PR formalises the proof-of-concept as an ordered list of named steps. Each step has:

- a `kind` (`setup` / `auth` / `prerequisite` / `exploit` / `verify`)
- a one-line `summary` (used as a screenshot caption / advisory line)
- an `action` (`shell` / `http` / `docker` / `note`)
- an optional `expect` predicate (`exit-zero` / `http-status` / `body-contains` / `body-matches` / `file-exists`)

```ts
interface PocStep {
  id: string;
  kind: PocStepKind;
  summary: string;
  action: PocStepAction;     // discriminated union on `type`
  expect?: PocStepExpect;    // discriminated union on `type`
}

interface Finding {
  // ...existing fields stay intact...
  pocSteps?: PocStep[];      // NEW (optional, additive)
}
```

## Why the field is optional / additive

Existing findings produced before this type existed leave `pocSteps` undefined. Every renderer, exporter, the SQLite DB, and the cloud sink continue to work in that case — there is no forced migration path. The legacy `evidence.request` / `.response` / `.analysis` strings stay intact and coexist with the new step graph; consumers that already render them keep doing so unchanged.

The agent loop is also additive: `save_finding` grows an *optional* `poc_steps` parameter. Agents that have structured execution data can populate it; agents that only have prose evidence simply omit it.

## Wire-up

- **`packages/shared`** — `PocStepKind` / `PocStepAction` / `PocStepExpect` / `PocStep` types plus the optional field on `Finding`.
- **`packages/db`** — new `pocSteps` TEXT column on the `findings` table with an `ALTER TABLE` migration in `database.ts`. `saveFinding` JSON-stringifies; `dbFindingToFinding` JSON-parses defensively (corrupt rows drop the field, never crash hydration).
- **`packages/core` agent tools** — `save_finding` accepts an optional `poc_steps` parameter (LLM tool-call shape: JSON-encoded string OR already-parsed array). A small validator (`parsePocStepsArg`) drops malformed steps without dropping the finding.
- **`packages/core` cloud-sink** — `normalizeFinding` passes `pocSteps` through. Default zod `.object()` strips unknown keys, so this is safe to deploy before the cloud orchestrator's schema is updated; once cloud lands the matching zod entry, it just starts seeing the field.
- **22 new unit tests** covering: discriminated-union narrowing on `action.type` / `expect.type`, JSON serialisation round-trip, DB persistence round-trip (populated + NULL), `parsePocStepsArg` happy/edge/malformed paths, and the cloud-sink pass-through path.

## Test plan

- [x] `pnpm --filter @pwnkit/core test` — 552 passed, 1 unrelated pre-existing failure (Azure Responses API parser test, fails on `origin/main` too).
- [x] `pnpm --filter @pwnkit/shared --filter @pwnkit/db --filter @pwnkit/core --filter @pwnkit/templates --filter pwnkit-cli --filter @pwnkit/dashboard --filter @pwnkit/benchmark exec tsc --noEmit` — clean.
- [x] All 18 new tests in `poc-step-graph.test.ts` pass; both new DB round-trip tests in `triage-persistence.test.ts` pass.
- [x] Backward-compat verified: a legacy `Finding` with no `pocSteps` round-trips through DB save / read / cloud-sink normalisation unchanged.

## Out of scope (follow-up PRs)

- Multi-frame screenshot rendering off `pocSteps` (separate sibling issue — the existing single-image renderer keeps working off the prose blob).
- Behavioural re-verify executor (#171 — runs each step against a provisioned target and checks the `expect` predicate).
- Markdown-advisory rendering of the step graph (cloud-cloud #143 / #144 already render the artifact bundle but don't yet consume `pocSteps`).
- Heuristic auto-population of `pocSteps` from agent prose / source-code review reasoning (would be a separate, focused PR).
- Cloud orchestrator's zod schema update to accept `pocSteps` on the wire (currently the cloud silently strips the field; the contract comment in `cloud-contracts.ts` flags the upcoming matching change).

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional structured proof-of-concept (PoC) steps on findings for step-by-step evidence.
  * PoC steps support multiple action types (shell, HTTP, Docker, notes) and optional expect predicates for verification; malformed predicates are ignored per-step.
  * PoC step data is persisted and remains backward compatible—legacy findings unchanged; malformed or empty step graphs are safely omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->