### PR TITLE
feat(agent): emit pocSteps from finding prose evidence (closes #179)

### DIFF
--- a/packages/core/src/agent/poc-steps-from-prose.test.ts
+++ b/packages/core/src/agent/poc-steps-from-prose.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import { extractPocStepsFromProse } from "./poc-steps-from-prose.js";
+
+describe("extractPocStepsFromProse", () => {
+  // ── HTTP-only path (paperclip-style auth-gap) ───────────────────────────
+
+  it("extracts a 3-step graph from an HTTP request + 200 response + analysis", () => {
+    const steps = extractPocStepsFromProse({
+      request: "GET /admin/users HTTP/1.1\nHost: target.example",
+      response: "HTTP/1.1 200 OK\nContent-Type: application/json\n\n[{\"id\":1}]",
+      analysis: "Authenticated admin endpoint exposed without an auth check.",
+    });
+
+    expect(steps).toBeDefined();
+    expect(steps).toHaveLength(3);
+    const [setup, exploit, verify] = steps!;
+
+    expect(setup.kind).toBe("setup");
+    expect(setup.action).toEqual({
+      type: "note",
+      text: "Authenticated admin endpoint exposed without an auth check.",
+    });
+
+    expect(exploit.kind).toBe("exploit");
+    expect(exploit.action).toEqual({
+      type: "http",
+      method: "GET",
+      url: "/admin/users",
+    });
+
+    expect(verify.kind).toBe("verify");
+    expect(verify.action).toEqual({
+      type: "http",
+      method: "GET",
+      url: "/admin/users",
+    });
+    expect(verify.expect).toEqual({ type: "http-status", status: 200 });
+  });
+
+  it("handles HTTP request lines without HTTP/1.1 suffix", () => {
+    const steps = extractPocStepsFromProse({
+      request: "POST /api/login",
+      response: "HTTP/1.1 401 Unauthorized",
+    });
+    expect(steps).toBeDefined();
+    expect(steps!.length).toBe(2);
+    expect(steps![0].action).toEqual({
+      type: "http",
+      method: "POST",
+      url: "/api/login",
+    });
+    expect(steps![1].expect).toEqual({ type: "http-status", status: 401 });
+  });
+
+  it("classifies prerequisite-flavoured analysis prose as 'prerequisite'", () => {
+    const steps = extractPocStepsFromProse({
+      request: "GET /admin",
+      response: "HTTP/1.1 200 OK",
+      analysis: "Requires a valid session cookie from any low-priv user.",
+    });
+    expect(steps).toBeDefined();
+    expect(steps!.find((s) => s.id === "setup")?.kind).toBe("prerequisite");
+  });
+
+  // ── Shell-only path (command injection) ─────────────────────────────────
+
+  it("extracts a 2-step graph from a shell snippet + observed output", () => {
+    const steps = extractPocStepsFromProse({
+      request: "curl http://target/?q=$(id)",
+      response: "uid=33(www-data) gid=33(www-data) groups=33(www-data)",
+    });
+
+    expect(steps).toBeDefined();
+    expect(steps).toHaveLength(2);
+    const [exploit, verify] = steps!;
+
+    expect(exploit.kind).toBe("exploit");
+    expect(exploit.action).toEqual({
+      type: "shell",
+      cmd: "curl http://target/?q=$(id)",
+    });
+
+    expect(verify.kind).toBe("verify");
+    expect(verify.expect).toEqual({
+      type: "body-contains",
+      text: "uid=33(www-data) gid=33(www-data) groups=33(www-data)",
+    });
+  });
+
+  it("strips $ shell prompts from request prose", () => {
+    const steps = extractPocStepsFromProse({
+      request: "$ curl https://target/exploit",
+      response: "flag{abc}",
+    });
+    expect(steps).toBeDefined();
+    expect(steps![0].action).toEqual({
+      type: "shell",
+      cmd: "curl https://target/exploit",
+    });
+  });
+
+  // ── Conservative skip cases ─────────────────────────────────────────────
+
+  it("returns undefined for pure-prose findings with no parseable signals", () => {
+    const result = extractPocStepsFromProse({
+      request: "We checked the page and found a bug.",
+      response: "The server returned something interesting.",
+      analysis: "We think there's an information leak.",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when only analysis prose is present", () => {
+    const result = extractPocStepsFromProse({
+      analysis: "Some narrative without an exploit or response.",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined for an empty input", () => {
+    expect(extractPocStepsFromProse({})).toBeUndefined();
+    expect(extractPocStepsFromProse({ request: "", response: "" })).toBeUndefined();
+  });
+
+  it("skips malformed HTTP request lines (no method match)", () => {
+    const result = extractPocStepsFromProse({
+      request: "GETTING /admin",
+      response: "HTTP/1.1 200 OK",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips HTTP request lines with whitespace in URL", () => {
+    const result = extractPocStepsFromProse({
+      request: "GET /admin users",
+      response: "HTTP/1.1 200 OK",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips a partial response with no status line", () => {
+    // HTTP exploit + response with no parseable status → no verify possible,
+    // and a lone exploit is below the 2-step threshold.
+    const result = extractPocStepsFromProse({
+      request: "GET /admin",
+      response: "{\"users\": []}",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips a sentence that mentions curl but isn't a command", () => {
+    const result = extractPocStepsFromProse({
+      request: "curl returned 200",
+      response: "HTTP/1.1 200 OK",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips out-of-range status codes", () => {
+    const result = extractPocStepsFromProse({
+      request: "GET /admin",
+      response: "HTTP/1.1 999 Bogus",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("skips a shell exploit with no usable observation in response", () => {
+    const result = extractPocStepsFromProse({
+      request: "curl http://target/x",
+      response: "The response showed nothing useful.",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("does not synthesise a setup note when no exploit step is found", () => {
+    const result = extractPocStepsFromProse({
+      analysis: "This setup line should never become a lone note.",
+      response: "HTTP/1.1 200 OK",
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("prefers HTTP request line over shell snippet when both appear", () => {
+    const steps = extractPocStepsFromProse({
+      request: "GET /admin\ncurl http://target/admin",
+      response: "HTTP/1.1 200 OK",
+    });
+    expect(steps).toBeDefined();
+    expect(steps![0].action).toEqual({
+      type: "http",
+      method: "GET",
+      url: "/admin",
+    });
+  });
+
+  it("truncates very long shell command summaries", () => {
+    const longCmd = `curl https://target.example/${"A".repeat(200)}`;
+    const steps = extractPocStepsFromProse({
+      request: longCmd,
+      response: "uid=0",
+    });
+    expect(steps).toBeDefined();
+    expect(steps![0].summary.length).toBeLessThanOrEqual(120);
+  });
+
+  it("issues stable step ids (setup/exploit/verify) for screenshot rendering", () => {
+    const steps = extractPocStepsFromProse({
+      request: "GET /admin",
+      response: "HTTP/1.1 200 OK",
+      analysis: "Admin page exposed.",
+    });
+    expect(steps).toBeDefined();
+    expect(steps!.map((s) => s.id)).toEqual(["setup", "exploit", "verify"]);
+  });
+});

--- a/packages/core/src/agent/poc-steps-from-prose.ts
+++ b/packages/core/src/agent/poc-steps-from-prose.ts
@@ -1,0 +1,283 @@
+// pwnkit#179 — agent-side `pocSteps` emission from prose evidence.
+//
+// Today the agent's `save_finding` tool writes three free-text strings
+// (`request`, `response`, `analysis`). Cloud and renderer code (pwnkit#170,
+// pwnkit#171, pwnkit-cloud#168) prefer the structured `Finding.pocSteps`
+// graph but the agent rarely supplies it. This module is a best-effort
+// fallback: parse the prose, extract a small step graph, and let the caller
+// attach it to the finding. If the heuristic isn't confident it returns
+// undefined — downstream consumers gate on field presence, so a missing
+// graph is strictly safer than a wrong one.
+//
+// Conservative by design: we extract three signal types (HTTP request lines,
+// shell snippets, response status codes) and stitch them into a 2–5 step
+// graph. Anything we can't parse cleanly is skipped, never guessed.
+
+import type { PocStep, PocStepKind } from "@pwnkit/shared";
+
+/**
+ * Inputs are the three prose evidence fields the agent already produces. All
+ * are optional — passing an empty object returns undefined.
+ */
+export interface ProseEvidence {
+  request?: string;
+  response?: string;
+  analysis?: string;
+}
+
+/**
+ * Extract a 2–5 step PoC graph from prose evidence. Returns `undefined` (not
+ * `[]`) when the heuristic can't produce ≥ 2 steps confidently — downstream
+ * consumers gate on field presence, so no graph is preferable to a wrong one.
+ */
+export function extractPocStepsFromProse(prose: ProseEvidence): PocStep[] | undefined {
+  const request = (prose.request ?? "").trim();
+  const response = (prose.response ?? "").trim();
+  const analysis = (prose.analysis ?? "").trim();
+
+  if (!request && !response && !analysis) return undefined;
+
+  const steps: PocStep[] = [];
+
+  // ── 1. Optional setup / prerequisite note from analysis prose ───────────
+  // Use the first line of analysis as a setup note when it reads like a
+  // narrated precondition. We deliberately keep this very conservative: only
+  // emit the note when we already have at least one executable step lined up
+  // (so the result is a multi-step graph, not a lone note).
+  const analysisLead = pickLeadingNote(analysis);
+
+  // ── 2. Executable exploit step from request prose ───────────────────────
+  const httpStep = parseHttpRequest(request);
+  const shellStep = parseShellSnippet(request);
+  // Prefer HTTP when both surface from the same blob — request.lines that
+  // start with `GET`/`POST` are far more decisive than a generic `curl …`.
+  const exploitStep = httpStep ?? shellStep;
+
+  if (!exploitStep) return undefined;
+
+  // ── 3. Verify step from response prose ──────────────────────────────────
+  // For HTTP exploits the verify step replays the same URL/method but with
+  // an http-status predicate parsed from the response. For shell exploits we
+  // can't synthesise a verify command from prose, so we attach an exit-zero
+  // predicate to the existing exploit step instead.
+  const httpStatus = parseHttpStatus(response);
+  const verifyStep = buildVerifyStep(exploitStep, httpStatus, response);
+
+  // Build the graph. Only attach the analysis note when we have a real
+  // exploit + verify pair — a lone note isn't useful.
+  if (analysisLead && verifyStep) {
+    steps.push({
+      id: "setup",
+      kind: kindForAnalysis(analysisLead),
+      summary: analysisLead,
+      action: { type: "note", text: analysisLead },
+    });
+  }
+  steps.push(exploitStep);
+  if (verifyStep) steps.push(verifyStep);
+
+  // Conservative gate: a single step graph is never useful — the whole point
+  // of this field is to capture exploit→verify causality.
+  if (steps.length < 2) return undefined;
+
+  return steps;
+}
+
+// ── HTTP request parsing ──────────────────────────────────────────────────
+
+const HTTP_METHODS = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+]);
+
+/**
+ * Parse a single HTTP request line (e.g. `GET /admin HTTP/1.1` or
+ * `POST /api/login`) into an `http` action. Returns null when no method/path
+ * pair is found. We deliberately do NOT try to parse headers/body — those
+ * aren't reliable from agent prose, and the consumer treats them as optional.
+ */
+function parseHttpRequest(text: string): PocStep | null {
+  if (!text) return null;
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(
+      /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\S+)(?:\s+HTTP\/\d(?:\.\d)?)?$/i,
+    );
+    if (!match) continue;
+    const method = match[1].toUpperCase();
+    const url = match[2];
+    if (!HTTP_METHODS.has(method)) continue;
+    if (!isPlausibleUrl(url)) continue;
+    return {
+      id: "exploit",
+      kind: "exploit",
+      summary: `${method} ${url}`,
+      action: { type: "http", method, url },
+    };
+  }
+  return null;
+}
+
+/** A URL is "plausible" if it starts with `/` or `http(s)://` and has no whitespace. */
+function isPlausibleUrl(url: string): boolean {
+  if (!url || /\s/.test(url)) return false;
+  return url.startsWith("/") || /^https?:\/\//i.test(url);
+}
+
+// ── Shell snippet parsing ─────────────────────────────────────────────────
+
+const SHELL_PREFIXES = ["curl", "wget", "docker", "python3", "python", "sh", "bash", "nc", "ncat"];
+
+/**
+ * Parse a shell snippet from prose. We only accept lines whose first token is
+ * a known executable prefix — this avoids mistaking command-line *output* for
+ * a command. Returns null if no such line exists.
+ */
+function parseShellSnippet(text: string): PocStep | null {
+  if (!text) return null;
+  const lines = text.split(/\r?\n/);
+  for (const raw of lines) {
+    let line = raw.trim();
+    if (!line) continue;
+    // Strip a leading shell prompt marker so `$ curl …` is recognised.
+    if (line.startsWith("$ ")) line = line.slice(2).trim();
+    if (line.startsWith("# ")) line = line.slice(2).trim();
+    const firstToken = line.split(/\s+/)[0]?.toLowerCase();
+    if (!firstToken) continue;
+    if (!SHELL_PREFIXES.includes(firstToken)) continue;
+    // Reject lines that look like a sentence rather than a command (e.g.
+    // "curl returned 200" — no flags, no URL).
+    if (firstToken === "curl" && !/\s\/|\shttps?:\/\//i.test(line)) continue;
+    return {
+      id: "exploit",
+      kind: "exploit",
+      summary: truncate(line, 120),
+      action: { type: "shell", cmd: line },
+    };
+  }
+  return null;
+}
+
+// ── HTTP response status parsing ──────────────────────────────────────────
+
+/**
+ * Parse the HTTP status code from a response blob. Accepts the canonical
+ * status line (`HTTP/1.1 200 OK`), case-insensitive. Returns null when the
+ * response is missing, malformed, or doesn't lead with a status line.
+ */
+function parseHttpStatus(text: string): number | null {
+  if (!text) return null;
+  const lines = text.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^HTTP\/\d(?:\.\d)?\s+(\d{3})\b/i);
+    if (!match) continue;
+    const status = Number.parseInt(match[1], 10);
+    if (Number.isNaN(status)) return null;
+    if (status < 100 || status > 599) return null;
+    return status;
+  }
+  return null;
+}
+
+// ── Verify step synthesis ─────────────────────────────────────────────────
+
+function buildVerifyStep(
+  exploit: PocStep,
+  httpStatus: number | null,
+  response: string,
+): PocStep | null {
+  // For HTTP exploits with a parseable status, build a structurally identical
+  // request and attach the status predicate. Downstream re-verify executors
+  // replay this and check the status matches.
+  if (exploit.action.type === "http" && httpStatus != null) {
+    return {
+      id: "verify",
+      kind: "verify",
+      summary: `Response ${httpStatus} confirms ${exploit.action.method} ${exploit.action.url} succeeds`,
+      action: {
+        type: "http",
+        method: exploit.action.method,
+        url: exploit.action.url,
+      },
+      expect: { type: "http-status", status: httpStatus },
+    };
+  }
+  // For shell exploits we can't synthesise a separate verify command from
+  // prose. If the response prose contains a meaningful observation, capture
+  // it as a body-contains predicate against the exploit's stdout.
+  if (exploit.action.type === "shell") {
+    const observation = pickShellObservation(response);
+    if (!observation) return null;
+    return {
+      id: "verify",
+      kind: "verify",
+      summary: `Output contains "${truncate(observation, 60)}"`,
+      action: { type: "note", text: observation },
+      expect: { type: "body-contains", text: observation },
+    };
+  }
+  return null;
+}
+
+/**
+ * Pick a short, distinctive observation string from shell output prose. We
+ * pick the first non-empty line that's short enough to be a single tokenable
+ * fact (e.g. a flag, a uid, a banner). Returns null if nothing fits.
+ */
+function pickShellObservation(text: string): string | null {
+  if (!text) return null;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.length > 200) continue;
+    // Skip lines that look like prose narration ("The response showed…").
+    if (/^(the |it |this |we |our )/i.test(line)) continue;
+    return line;
+  }
+  return null;
+}
+
+// ── Analysis-prose helpers ────────────────────────────────────────────────
+
+/**
+ * Pick a one-line setup note from the analysis prose. We use the first
+ * non-empty line, capped at 200 chars. Returns null if the analysis is empty
+ * or starts with a stop-phrase that suggests it's not setup ("This shows…",
+ * "The bug is…").
+ */
+function pickLeadingNote(text: string): string | null {
+  if (!text) return null;
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    return truncate(line, 200);
+  }
+  return null;
+}
+
+/**
+ * Categorise the analysis lead as a `setup`, `prerequisite`, or generic
+ * `setup` step. Hueristic-only — when in doubt we use `setup`.
+ */
+function kindForAnalysis(text: string): PocStepKind {
+  const lower = text.toLowerCase();
+  if (/\b(requires?|needs?|must have|prerequisite|precondition)\b/.test(lower)) {
+    return "prerequisite";
+  }
+  return "setup";
+}
+
+// ── small utilities ───────────────────────────────────────────────────────
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}

--- a/packages/core/src/agent/tools.test.ts
+++ b/packages/core/src/agent/tools.test.ts
@@ -103,6 +103,83 @@ describe("ToolExecutor", () => {
     expect(ctx.findings[0].id).toBeTruthy();
   });
 
+  // ── save_finding pocSteps emission (pwnkit#179) ──
+
+  it("save_finding populates pocSteps from prose when agent didn't supply them", async () => {
+    await executor.execute({
+      name: "save_finding",
+      arguments: {
+        title: "Auth gap on /admin/users",
+        severity: "high",
+        category: "auth",
+        evidence_request: "GET /admin/users HTTP/1.1\nHost: target.example",
+        evidence_response: "HTTP/1.1 200 OK\nContent-Type: application/json",
+        evidence_analysis: "Endpoint exposes admin data without authentication.",
+      },
+    });
+
+    const finding = ctx.findings[0];
+    expect(finding.pocSteps).toBeDefined();
+    expect(finding.pocSteps!.length).toBeGreaterThanOrEqual(2);
+    const exploit = finding.pocSteps!.find((s) => s.kind === "exploit");
+    expect(exploit?.action).toEqual({
+      type: "http",
+      method: "GET",
+      url: "/admin/users",
+    });
+    const verify = finding.pocSteps!.find((s) => s.kind === "verify");
+    expect(verify?.expect).toEqual({ type: "http-status", status: 200 });
+  });
+
+  it("save_finding leaves pocSteps undefined when prose has no parseable signals", async () => {
+    await executor.execute({
+      name: "save_finding",
+      arguments: {
+        title: "Vague bug",
+        severity: "low",
+        category: "info",
+        evidence_request: "We poked around the page.",
+        evidence_response: "Some interesting output appeared.",
+        evidence_analysis: "Unclear if exploitable.",
+      },
+    });
+
+    expect(ctx.findings[0].pocSteps).toBeUndefined();
+  });
+
+  it("save_finding prefers an agent-supplied pocSteps array over the heuristic", async () => {
+    const agentSteps = [
+      {
+        id: "manual-step",
+        kind: "exploit",
+        summary: "Hand-crafted graph",
+        action: { type: "shell", cmd: "echo crafted-by-agent" },
+      },
+    ];
+    await executor.execute({
+      name: "save_finding",
+      arguments: {
+        title: "Custom finding",
+        severity: "high",
+        category: "auth",
+        // Prose that would otherwise trigger the heuristic.
+        evidence_request: "GET /admin",
+        evidence_response: "HTTP/1.1 200 OK",
+        evidence_analysis: "Admin endpoint exposed.",
+        poc_steps: JSON.stringify(agentSteps),
+      },
+    });
+
+    const finding = ctx.findings[0];
+    expect(finding.pocSteps).toBeDefined();
+    expect(finding.pocSteps!.length).toBe(1);
+    expect(finding.pocSteps![0].id).toBe("manual-step");
+    expect(finding.pocSteps![0].action).toEqual({
+      type: "shell",
+      cmd: "echo crafted-by-agent",
+    });
+  });
+
   // ── query_findings ──
 
   it("payload_lookup returns reusable JSFuck payloads", async () => {

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -16,6 +16,7 @@ import {
   type FetchLike,
 } from "./wp-fingerprint.js";
 import { validateFlagShape } from "./flag-validator.js";
+import { extractPocStepsFromProse } from "./poc-steps-from-prose.js";
 import {
   forgeObjectId,
   forgeObjectIdSequence,
@@ -1454,7 +1455,21 @@ export class ToolExecutor {
     // tolerate already-parsed arrays too. Anything malformed is silently
     // dropped so a bad payload never blocks the finding from being saved.
     const pocSteps = parsePocStepsArg(args.poc_steps);
-    if (pocSteps && pocSteps.length > 0) finding.pocSteps = pocSteps;
+    if (pocSteps && pocSteps.length > 0) {
+      finding.pocSteps = pocSteps;
+    } else {
+      // pwnkit#179 — fall back to a prose-derived heuristic graph when the
+      // agent didn't supply one explicitly. The heuristic is conservative:
+      // it returns undefined whenever it can't extract ≥ 2 steps cleanly,
+      // and we leave `pocSteps` undefined in that case (downstream consumers
+      // gate on field presence).
+      const inferred = extractPocStepsFromProse({
+        request: finding.evidence.request,
+        response: finding.evidence.response,
+        analysis: finding.evidence.analysis,
+      });
+      if (inferred && inferred.length >= 2) finding.pocSteps = inferred;
+    }
 
     this.ctx.findings.push(finding);
     if (this.db && this.ctx.persistFindings !== false) {


### PR DESCRIPTION
## Summary

Closes #179. The producer half of the pocSteps story: cloud (#168) and the renderer/re-verify pipeline (#170, #171) already prefer `Finding.pocSteps` over the prose evidence blob, but the agent rarely supplies it. This PR adds a conservative prose-derived heuristic so existing findings start carrying a structured step graph automatically.

- New helper `extractPocStepsFromProse` in `packages/core/src/agent/poc-steps-from-prose.ts` parses three signal types from prose:
  - HTTP request line (`GET /admin/users HTTP/1.1`, `POST /api/login`) -> `http` exploit step.
  - Shell snippet (`curl ...`, `docker run ...`, `python3 ...`, optional leading `$ ` prompt) -> `shell` exploit step.
  - `HTTP/1.1 NNN` status line in the response -> `http-status` verify predicate.
  - Shell-output line in the response -> `body-contains` verify predicate against an exploit-stdout note.
  - Leading line of `analysis` -> `setup` / `prerequisite` note step, but only when there's already an exploit + verify pair so the result is multi-step.
- `save_finding` (in `tools.ts`) now calls the heuristic when the agent didn't supply `poc_steps`. Agent-supplied graphs still win.

The heuristic returns `undefined` (not `[]`) whenever it can't extract >=2 steps cleanly. Downstream consumers gate on field presence, so a missing graph is strictly safer than a wrong one. Out-of-range status codes, malformed request lines, sentences that mention `curl` without flags, and lone setup notes all skip cleanly.

## Tests

`packages/core/src/agent/poc-steps-from-prose.test.ts` (19 tests):
- Auth-gap fixture (HTTP request + 200 response + analysis prose) -> 3-step graph (setup note -> http exploit -> http verify with status predicate).
- Command-injection fixture (shell `curl ...` + observed output) -> 2-step graph (shell exploit -> body-contains verify).
- Pure-prose fixture, empty input, malformed method, whitespace in URL, partial response, sentence-shaped `curl ...`, out-of-range status, lone setup-only analysis -> all return `undefined`.
- Edge cases: HTTP request without `HTTP/1.1` suffix, prerequisite-flavoured analysis classified as `prerequisite`, `$ ` prompt stripping, HTTP preferred over shell when both surface, summary truncation, stable step ids.

`packages/core/src/agent/tools.test.ts` adds three integration tests:
- `save_finding` populates `pocSteps` from prose when the agent didn't supply them.
- `save_finding` leaves `pocSteps` undefined when prose has no parseable signals.
- `save_finding` prefers an agent-supplied `poc_steps` array over the heuristic.

## Test plan

- [x] `pnpm --filter @pwnkit/core test` -> 630 passing, 1 pre-existing unrelated failure (`runtime/llm-api.test.ts > parses function_call items from Responses API output`, unchanged from `main`).
- [x] `pnpm run lint` (typecheck) clean.
- [x] `pnpm -r build` clean.
- [x] No public-API change beyond a new internal helper. `Finding.pocSteps` was already optional/additive (#170), so existing consumers keep working.

## Decisions / scope cuts

- Heuristic is intentionally conservative. Notable false-negative cases that we **do not** try to handle:
  - Multi-step shell pipelines (we emit a single shell step, per #179 out-of-scope note).
  - Headers/body parsing on HTTP request lines (unreliable in prose, downstream treats them as optional).
  - Constructing a separate verify shell command from response prose (we attach a `body-contains` predicate to the exploit's stdout instead).
- Step ids are stable strings (`setup` / `exploit` / `verify`) so the screenshot renderer (#170 acceptance) can name its output deterministically.
- No backfill onto historic findings (out-of-scope per #179).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Proof of Concept step extraction: The system now intelligently parses request, response, and analysis prose to automatically generate structured verification steps and exploit demonstrations when explicit steps aren't provided.

* **Tests**
  * Added comprehensive test coverage for the proof of concept extraction logic, including HTTP request/response parsing, shell command handling, and finding save behavior with various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->