### PR TITLE
feat(core): emit verificationSpec on Finding (#168)

### DIFF
--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -3,7 +3,16 @@ import { readFileSync } from "node:fs";
 import { spawnSync, spawn } from "node:child_process";
 import { isAbsolute, resolve } from "node:path";
 import { isIP } from "node:net";
-import type { Finding, AttackResult, PocStep, TargetInfo } from "@pwnkit/shared";
+import type {
+  Finding,
+  AttackResult,
+  PocStep,
+  TargetInfo,
+  VerificationSpec,
+  VerificationCodePredicate,
+  VerificationBehavior,
+  VerificationBehaviorStep,
+} from "@pwnkit/shared";
 import type { ToolDefinition, ToolCall, ToolResult, ToolContext } from "./types.js";
 import { sendPrompt, extractResponseText } from "../http.js";
 import { buildAuthHeaders } from "./prompts.js";
@@ -281,6 +290,23 @@ export const TOOL_DEFINITIONS: Record<string, ToolDefinition> = {
         type: "string",
         description:
           "OPTIONAL JSON-encoded PocStep[] array (pwnkit#170). Each step: { id, kind: setup|auth|prerequisite|exploit|verify, summary, action: { type: shell|http|docker|note, ... }, expect?: { type: ... } }. Leave unset when you only have prose evidence.",
+      },
+      // pwnkit#193 — optional machine-executable verification contract. When
+      // the agent has cited concrete file:line evidence, it should populate
+      // `code[]` predicates so cloud's canary watcher can later re-evaluate
+      // the finding deterministically. Each predicate is one of:
+      //   - { kind:"file-contains", file, pattern, flags? } — vulnerable
+      //     shape still present.
+      //   - { kind:"file-missing-pattern", file, pattern, flags? } — fix
+      //     marker still absent.
+      //   - { kind:"file-exists", file } — vulnerable file still present.
+      //   - { kind:"ast-shape", file, query } — tree-sitter (not yet eval'd
+      //     by the OSS verifier; record for future use).
+      // Pass as a JSON-encoded string to match the LLM tool wire format.
+      verification_spec: {
+        type: "string",
+        description:
+          "OPTIONAL JSON-encoded VerificationSpec (pwnkit#193). Shape: { code: Array<{ kind:'file-contains'|'file-missing-pattern'|'file-exists'|'ast-shape', file, pattern?, flags?, query? }>, behavior?: { steps: Array<{ method, path, body?, expect: 'success'|'forbidden'|{status:number} }> } }. Populate code[] predicates from the file:line evidence you cited so cloud can re-verify the finding deterministically. Example for a SQLi at app/users.ts:43: code:[{kind:'file-contains',file:'app/users.ts',pattern:'db\\\\.query.*req\\\\.body'}]. Leave unset when you cannot pin the vulnerable shape to a regex.",
       },
       // Self-reported calibration of how confident the agent is that this
       // finding is a true positive. The cloud DB stores it in
@@ -894,6 +920,152 @@ function validatePocStep(raw: unknown): PocStep | null {
     }
   }
   return step;
+}
+
+// ── Verification spec helpers (pwnkit#193) ──
+//
+// Mirrors the PoC-step parser pattern above: tolerate already-parsed objects
+// AND JSON strings, validate strictly, and return null on anything malformed
+// so a bad payload from the LLM never blocks the finding from saving.
+
+const VERIFICATION_PREDICATE_KINDS: ReadonlySet<string> = new Set([
+  "file-contains",
+  "file-missing-pattern",
+  "file-exists",
+  "ast-shape",
+]);
+
+const VERIFICATION_BEHAVIOR_EXPECT_LITERALS: ReadonlySet<string> = new Set([
+  "success",
+  "forbidden",
+]);
+
+function validateVerificationPredicate(
+  raw: unknown,
+): VerificationCodePredicate | null {
+  if (!isPlainRecord(raw)) return null;
+  const kind = raw.kind;
+  if (typeof kind !== "string" || !VERIFICATION_PREDICATE_KINDS.has(kind)) {
+    return null;
+  }
+  const file = raw.file;
+  if (typeof file !== "string" || file.length === 0) return null;
+
+  switch (kind) {
+    case "file-exists":
+      return { kind: "file-exists", file };
+    case "file-contains": {
+      const pattern = raw.pattern;
+      if (typeof pattern !== "string" || pattern.length === 0) return null;
+      const flags = typeof raw.flags === "string" ? raw.flags : undefined;
+      return flags !== undefined
+        ? { kind: "file-contains", file, pattern, flags }
+        : { kind: "file-contains", file, pattern };
+    }
+    case "file-missing-pattern": {
+      const pattern = raw.pattern;
+      if (typeof pattern !== "string" || pattern.length === 0) return null;
+      const flags = typeof raw.flags === "string" ? raw.flags : undefined;
+      return flags !== undefined
+        ? { kind: "file-missing-pattern", file, pattern, flags }
+        : { kind: "file-missing-pattern", file, pattern };
+    }
+    case "ast-shape": {
+      const query = raw.query;
+      if (typeof query !== "string" || query.length === 0) return null;
+      return { kind: "ast-shape", file, query };
+    }
+    default:
+      return null;
+  }
+}
+
+function validateVerificationBehaviorStep(
+  raw: unknown,
+): VerificationBehaviorStep | null {
+  if (!isPlainRecord(raw)) return null;
+  const method = raw.method;
+  const path = raw.path;
+  if (typeof method !== "string" || method.length === 0) return null;
+  if (typeof path !== "string" || path.length === 0) return null;
+  const expectRaw = raw.expect;
+  let expect: VerificationBehaviorStep["expect"];
+  if (typeof expectRaw === "string") {
+    if (!VERIFICATION_BEHAVIOR_EXPECT_LITERALS.has(expectRaw)) return null;
+    expect = expectRaw as "success" | "forbidden";
+  } else if (
+    isPlainRecord(expectRaw) &&
+    typeof expectRaw.status === "number" &&
+    Number.isInteger(expectRaw.status)
+  ) {
+    expect = { status: expectRaw.status };
+  } else {
+    return null;
+  }
+  const step: VerificationBehaviorStep = { method, path, expect };
+  if ("body" in raw) step.body = raw.body;
+  return step;
+}
+
+function validateVerificationBehavior(
+  raw: unknown,
+): VerificationBehavior | null {
+  if (!isPlainRecord(raw)) return null;
+  if (!Array.isArray(raw.steps)) return null;
+  const steps: VerificationBehaviorStep[] = [];
+  for (const item of raw.steps) {
+    const step = validateVerificationBehaviorStep(item);
+    if (step) steps.push(step);
+  }
+  if (steps.length === 0) return null;
+  return { steps };
+}
+
+/**
+ * Parse the `verification_spec` LLM tool argument into a VerificationSpec or
+ * null. Same wire-shape tolerance as `parsePocStepsArg` (already-parsed
+ * object OR JSON string OR garbage → null).
+ *
+ * Validation rules:
+ *  - `code` MUST be an array (possibly empty after dropping malformed
+ *    predicates). If it's missing entirely, the spec is rejected.
+ *  - Each predicate is validated per-variant; malformed predicates are
+ *    dropped silently (one bad predicate doesn't kill the spec).
+ *  - `behavior` is optional; if present-but-malformed, the whole spec is
+ *    still accepted, with `behavior` dropped.
+ *
+ * Exported only for unit tests; not part of the public agent surface.
+ */
+export function parseVerificationSpecArg(raw: unknown): VerificationSpec | null {
+  if (raw == null || raw === "") return null;
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  if (!isPlainRecord(parsed)) return null;
+  if (!Array.isArray(parsed.code)) return null;
+
+  const code: VerificationCodePredicate[] = [];
+  for (const item of parsed.code) {
+    const predicate = validateVerificationPredicate(item);
+    if (predicate) code.push(predicate);
+  }
+
+  const spec: VerificationSpec = { code };
+  if (parsed.behavior !== undefined) {
+    const behavior = validateVerificationBehavior(parsed.behavior);
+    if (behavior) spec.behavior = behavior;
+  }
+
+  // A spec with zero usable code predicates AND no behavior is effectively
+  // empty — drop it so the finding doesn't carry a meaningless field.
+  if (spec.code.length === 0 && !spec.behavior) return null;
+
+  return spec;
 }
 
 /**
@@ -1710,6 +1882,16 @@ export class ToolExecutor {
         analysis: finding.evidence.analysis,
       });
       if (inferred && inferred.length >= 2) finding.pocSteps = inferred;
+    }
+
+    // pwnkit#193 — optional machine-executable verification spec. Same
+    // wire-shape tolerance as poc_steps (object OR JSON string OR garbage).
+    // When parseable, attach to the finding so cloud's canary watcher can
+    // later evaluate it via `evaluateVerificationSpec`. Findings without a
+    // spec stay backwards-compatible (field is undefined).
+    const verificationSpec = parseVerificationSpecArg(args.verification_spec);
+    if (verificationSpec) {
+      finding.verificationSpec = verificationSpec;
     }
 
     // Hybrid confidence (LLM self-report + PoC-status floor). Closes the gap

--- a/packages/core/src/cloud-contracts.ts
+++ b/packages/core/src/cloud-contracts.ts
@@ -56,6 +56,16 @@ export interface CloudSinkEvidence {
 export type CloudSinkPocSteps = unknown[];
 
 /**
+ * Optional machine-executable verification contract (pwnkit#193 /
+ * pwnkit-cloud#111). Pass-through field; the OSS sink does not enrich or
+ * validate beyond a shape check. Cloud's canary watcher imports
+ * `evaluateVerificationSpec` from `@pwnkit/core` to evaluate it; the
+ * orchestrator schema strips unknown keys today and will land its own zod
+ * entry mirroring `VerificationSpec` in `@pwnkit/shared/types.ts`.
+ */
+export type CloudSinkVerificationSpec = Record<string, unknown>;
+
+/**
  * Strict finding shape the pwnkit-cloud orchestrator accepts at
  * POST /scans/:id/findings.
  */
@@ -84,6 +94,12 @@ export interface CloudSinkFinding {
    * cloud orchestrator will silently strip it until its schema is updated.
    */
   pocSteps?: CloudSinkPocSteps;
+  /**
+   * Optional machine-executable verification spec (pwnkit#193). Pass-through;
+   * the cloud orchestrator strips it today and will accept it once its
+   * schema mirrors `VerificationSpec` in `@pwnkit/shared/types.ts`.
+   */
+  verificationSpec?: CloudSinkVerificationSpec;
 }
 
 /**

--- a/packages/core/src/cloud-sink.ts
+++ b/packages/core/src/cloud-sink.ts
@@ -290,6 +290,15 @@ export function normalizeFinding(rawFinding: unknown): CloudSinkFinding {
   const pocSteps = normalizePocSteps(raw.pocSteps ?? raw.poc_steps);
   if (pocSteps && pocSteps.length > 0) normalized.pocSteps = pocSteps;
 
+  // pwnkit#193 — pass-through optional VerificationSpec. Same wire-shape
+  // tolerance as pocSteps (object OR JSON string OR null). Anything
+  // malformed is dropped silently; the spec is decoration on the finding,
+  // never a reason to drop the finding itself.
+  const verificationSpec = normalizeVerificationSpec(
+    raw.verificationSpec ?? raw.verification_spec,
+  );
+  if (verificationSpec) normalized.verificationSpec = verificationSpec;
+
   return normalized;
 }
 
@@ -310,6 +319,34 @@ function normalizePocSteps(v: unknown): unknown[] | null {
     } catch {
       return null;
     }
+  }
+  return null;
+}
+
+/**
+ * Pass-through normaliser for the optional `verificationSpec` field
+ * (pwnkit#193). Returns the object shape unchanged when input is already an
+ * object, parses a JSON-encoded string into one, and yields null otherwise.
+ *
+ * Mirrors `normalizePocSteps` in being deliberately permissive: the OSS
+ * sink is a wire-format chokepoint, not a schema validator. The canonical
+ * shape lives in `@pwnkit/shared/types.ts` (`VerificationSpec`).
+ */
+function normalizeVerificationSpec(v: unknown): Record<string, unknown> | null {
+  if (v == null || v === "") return null;
+  if (typeof v === "string") {
+    try {
+      const parsed = JSON.parse(v);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+  if (typeof v === "object" && !Array.isArray(v)) {
+    return v as Record<string, unknown>;
   }
   return null;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,13 @@ export {
 } from "./agent/live-agent-state.js";
 export type { LiveAgentState } from "./agent/live-agent-state.js";
 
+// Verification spec evaluator (pwnkit#193 / pwnkit-cloud#111). Re-checks a
+// finding's `verificationSpec` predicates against a repo on disk so cloud's
+// canary watcher (and any OSS caller) can deterministically decide whether
+// a finding is still real after upstream changes.
+export { evaluateVerificationSpec } from "./verification/index.js";
+export type { PredicateResult, VerificationResult } from "./verification/index.js";
+
 // Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
 export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession, composeStepSession, verifyAgainstRef, extractFileRefs, formatPatchStatusSection, detectVersionRange, formatVersionRangeLine, extractSiblingFix, executePocSteps, setRuntimeDeps, MAX_CAPTURE_BYTES, DEFAULT_STEP_TIMEOUT_MS, decideFilingState, assembleBundleIndex, formatDroppedReason, droppedFilename, dropSlug } from "./disclose/index.js";
 export type { CweEntry, CvssSuggestion, AdvisoryContext, AdvisoryScreenshot, RenderedAdvisory, ScreenshotResult, ScreenshotOptions, PatchStatus, FileRef, ReverifyResult, ReverifyOptions, VersionRangeResult, VersionRangeOptions, SiblingFixCandidate, SiblingFixOptions, PocExecutionTarget, PocExecutionReport, PocStepResult, PocStepVerdict, PocOverallVerdict, FilingState, BundleEntry, AssembleIndexOptions } from "./disclose/index.js";

--- a/packages/core/src/unified-pipeline.restore.test.ts
+++ b/packages/core/src/unified-pipeline.restore.test.ts
@@ -1,0 +1,171 @@
+/**
+ * pwnkit#193 — `restorePersistedFinding` round-trip for `verificationSpec`.
+ *
+ * CodeRabbit flagged that `Finding.verificationSpec` is part of the shared
+ * model but the unified-pipeline reload path was dropping it on restore.
+ * Cloud's canary watcher then had nothing to re-evaluate against on the
+ * next upstream HEAD refresh, breaking the whole point of the spec.
+ *
+ * These tests exercise the restore helper directly so the wire round-trip
+ * is captured in a unit test rather than only via an end-to-end resume.
+ */
+import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { pwnkitDB } from "@pwnkit/db";
+import type { Finding, ScanConfig, VerificationSpec } from "@pwnkit/shared";
+import { restorePersistedFinding } from "./unified-pipeline.js";
+
+const tempDirs: string[] = [];
+
+function makeDb(): { db: pwnkitDB; scanId: string } {
+  const dir = mkdtempSync(join(tmpdir(), "pwnkit-restore-vspec-"));
+  tempDirs.push(dir);
+  const db = new pwnkitDB(join(dir, "pwnkit.db"));
+  const scanConfig: ScanConfig = {
+    target: "http://example.test",
+    depth: "default",
+    format: "json",
+    runtime: "api",
+    mode: "deep",
+  };
+  const scanId = db.createScan(scanConfig);
+  return { db, scanId };
+}
+
+function makeSpec(): VerificationSpec {
+  return {
+    code: [
+      {
+        kind: "file-contains",
+        file: "app/users.ts",
+        pattern: "db\\.query.*req\\.body",
+      },
+      { kind: "file-exists", file: "lib/db.ts" },
+    ],
+    behavior: {
+      steps: [{ method: "GET", path: "/users", expect: "success" }],
+    },
+  };
+}
+
+function makeFinding(spec?: VerificationSpec): Finding {
+  return {
+    id: randomUUID(),
+    templateId: "manual",
+    title: "SQLi on /users",
+    description: "user input concatenated into SQL",
+    severity: "high",
+    category: "sql-injection",
+    status: "discovered",
+    evidence: {
+      request: "POST /users",
+      response: "[{...}]",
+      analysis: "db.query interpolates req.body",
+    },
+    verificationSpec: spec,
+    timestamp: 1_700_000_000_000,
+  };
+}
+
+describe("restorePersistedFinding (pwnkit#193 — verificationSpec round-trip)", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("threads verificationSpec through saveFinding → getFindings → restore", () => {
+    const { db, scanId } = makeDb();
+    try {
+      const spec = makeSpec();
+      const original = makeFinding(spec);
+      db.saveFinding(scanId, original);
+
+      const rows = db.getFindings(scanId);
+      expect(rows).toHaveLength(1);
+
+      const restored = restorePersistedFinding(rows[0]);
+      expect(restored.verificationSpec).toEqual(spec);
+      // Other fields still survive — the new column doesn't disrupt the
+      // existing rehydration.
+      expect(restored.id).toBe(original.id);
+      expect(restored.title).toBe(original.title);
+      expect(restored.evidence.analysis).toBe("db.query interpolates req.body");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("restores verificationSpec=undefined when the column is NULL (legacy row)", () => {
+    const { db, scanId } = makeDb();
+    try {
+      const original = makeFinding(undefined);
+      db.saveFinding(scanId, original);
+      const rows = db.getFindings(scanId);
+      const restored = restorePersistedFinding(rows[0]);
+      expect(restored.verificationSpec).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("drops a malformed JSON column without breaking the restore", () => {
+    // Simulate a row where the verificationSpec column got corrupted
+    // (older write path, manual edit, etc.). The finding must still
+    // restore — just without a usable spec.
+    const restored = restorePersistedFinding({
+      id: "f-1",
+      templateId: "manual",
+      title: "still useful",
+      description: "x",
+      severity: "low",
+      category: "sql-injection",
+      status: "discovered",
+      evidenceRequest: "x",
+      evidenceResponse: "y",
+      verificationSpec: "{not json [",
+      timestamp: 0,
+    });
+    expect(restored.verificationSpec).toBeUndefined();
+    expect(restored.title).toBe("still useful");
+  });
+
+  it("drops a JSON object that lacks the `code` array (defensive)", () => {
+    const restored = restorePersistedFinding({
+      id: "f-2",
+      templateId: "manual",
+      title: "weird",
+      description: "x",
+      severity: "low",
+      category: "sql-injection",
+      status: "discovered",
+      evidenceRequest: "x",
+      evidenceResponse: "y",
+      // Looks like JSON but isn't a VerificationSpec.
+      verificationSpec: JSON.stringify({ foo: "bar" }),
+      timestamp: 0,
+    });
+    expect(restored.verificationSpec).toBeUndefined();
+  });
+
+  it("accepts an already-parsed object (test/sink-shim path)", () => {
+    const spec = makeSpec();
+    const restored = restorePersistedFinding({
+      id: "f-3",
+      templateId: "manual",
+      title: "preparsed",
+      description: "x",
+      severity: "low",
+      category: "sql-injection",
+      status: "discovered",
+      evidenceRequest: "x",
+      evidenceResponse: "y",
+      verificationSpec: spec,
+      timestamp: 0,
+    });
+    expect(restored.verificationSpec).toEqual(spec);
+  });
+});

--- a/packages/core/src/unified-pipeline.ts
+++ b/packages/core/src/unified-pipeline.ts
@@ -351,7 +351,41 @@ function buildSummary(findings: Finding[], totalAttacks: number) {
   };
 }
 
-function restorePersistedFinding(row: any): Finding {
+/**
+ * Rehydrate a persisted findings-table row into a {@link Finding}.
+ *
+ * Exported for tests so the wire round-trip (verificationSpec, evidence,
+ * triage flags, etc.) can be exercised without a full pipeline run.
+ * Production callers reach this through the `getFindings(...).map(...)`
+ * inside `runPipeline`.
+ */
+export function restorePersistedFinding(row: any): Finding {
+  // pwnkit#193 — `verificationSpec` is the deterministic re-check contract
+  // produced by the OSS engine and consumed by cloud's canary watcher.
+  // It is persisted as JSON text and must be threaded through every
+  // reload path; otherwise findings restored from storage silently lose
+  // the contract before cloud re-checks can run.
+  let verificationSpec: Finding["verificationSpec"];
+  if (typeof row.verificationSpec === "string" && row.verificationSpec.length > 0) {
+    try {
+      const parsed = JSON.parse(row.verificationSpec);
+      // Defensive: only accept the shape we expect. Older rows that
+      // stored something malformed get dropped silently rather than
+      // breaking the resume path.
+      if (parsed && typeof parsed === "object" && Array.isArray(parsed.code)) {
+        verificationSpec = parsed;
+      }
+    } catch {
+      // Malformed JSON in the column is non-fatal; the finding still
+      // restores, just without a verification contract.
+    }
+  } else if (row.verificationSpec && typeof row.verificationSpec === "object") {
+    // Some shims (cloud sinks, in-memory test doubles) hand back the
+    // already-parsed object. Pass it through unchanged.
+    if (Array.isArray(row.verificationSpec.code)) {
+      verificationSpec = row.verificationSpec;
+    }
+  }
   return {
     id: row.id,
     templateId: row.templateId,
@@ -371,6 +405,7 @@ function restorePersistedFinding(row: any): Finding {
       response: row.evidenceResponse,
       analysis: row.evidenceAnalysis ?? undefined,
     },
+    verificationSpec,
     timestamp: row.timestamp,
   };
 }

--- a/packages/core/src/verification-spec-graph.test.ts
+++ b/packages/core/src/verification-spec-graph.test.ts
@@ -1,0 +1,278 @@
+/**
+ * pwnkit#193 / pwnkit-cloud#111 — Finding.verificationSpec wire contract.
+ *
+ * Coverage:
+ *   1. Type narrowing on the VerificationCodePredicate discriminated union.
+ *   2. JSON serialisation round-trip on a populated VerificationSpec.
+ *   3. Backward-compat: a Finding with no verificationSpec is still a valid
+ *      Finding and round-trips cleanly.
+ *   4. The agent-tool `parseVerificationSpecArg` helper accepts both already-
+ *      parsed objects and JSON strings, and rejects malformed payloads
+ *      cleanly.
+ *   5. The cloud-sink `normalizeFinding` passes verificationSpec through
+ *      without dropping the finding when the spec itself is malformed.
+ *
+ * The spec is OPTIONAL and ADDITIVE — existing prose evidence + pocSteps
+ * remain intact alongside it.
+ */
+import { randomUUID } from "node:crypto";
+import { describe, it, expect } from "vitest";
+import type {
+  Finding,
+  VerificationCodePredicate,
+  VerificationSpec,
+} from "@pwnkit/shared";
+import { parseVerificationSpecArg } from "./agent/tools.js";
+import { normalizeFinding } from "./cloud-sink.js";
+
+function makeSpec(): VerificationSpec {
+  return {
+    code: [
+      {
+        kind: "file-contains",
+        file: "app/users.ts",
+        pattern: "db\\.query.*req\\.body",
+      },
+      {
+        kind: "file-missing-pattern",
+        file: "app/users.ts",
+        pattern: "WHERE name = \\?",
+      },
+      { kind: "file-exists", file: "lib/db.ts" },
+    ],
+    behavior: {
+      steps: [
+        { method: "POST", path: "/users", body: { name: "x" }, expect: "success" },
+      ],
+    },
+  };
+}
+
+describe("VerificationCodePredicate types (pwnkit#193)", () => {
+  it("narrows kind to the right predicate fields", () => {
+    const fc: VerificationCodePredicate = {
+      kind: "file-contains",
+      file: "a.ts",
+      pattern: "x",
+    };
+    const fmp: VerificationCodePredicate = {
+      kind: "file-missing-pattern",
+      file: "a.ts",
+      pattern: "x",
+    };
+    const fe: VerificationCodePredicate = { kind: "file-exists", file: "a.ts" };
+    const ast: VerificationCodePredicate = {
+      kind: "ast-shape",
+      file: "a.ts",
+      query: "(call_expression)",
+    };
+
+    if (fc.kind === "file-contains") expect(fc.pattern).toBe("x");
+    if (fmp.kind === "file-missing-pattern") expect(fmp.pattern).toBe("x");
+    if (fe.kind === "file-exists") expect(fe.file).toBe("a.ts");
+    if (ast.kind === "ast-shape") expect(ast.query).toBe("(call_expression)");
+  });
+});
+
+describe("Finding.verificationSpec backward compatibility (pwnkit#193)", () => {
+  it("a Finding without verificationSpec is still a valid Finding", () => {
+    // Legacy shape: prose evidence only, no spec. Every renderer / sink /
+    // DB writer must keep working when verificationSpec is undefined.
+    const legacy: Finding = {
+      id: randomUUID(),
+      templateId: "manual",
+      title: "Legacy reflected XSS",
+      description: "q param reflected without encoding",
+      severity: "high",
+      category: "xss",
+      status: "discovered",
+      evidence: {
+        request: "GET /search?q=<script>",
+        response: "<script> echoed",
+        analysis: "no encoding in the template",
+      },
+      timestamp: 1_700_000_000_000,
+    };
+    expect(legacy.verificationSpec).toBeUndefined();
+    // And it round-trips through JSON unchanged.
+    const restored = JSON.parse(JSON.stringify(legacy)) as Finding;
+    expect(restored).toEqual(legacy);
+    expect(restored.verificationSpec).toBeUndefined();
+  });
+
+  it("a Finding with verificationSpec coexists with prose evidence (additive)", () => {
+    const enriched: Finding = {
+      id: randomUUID(),
+      templateId: "manual",
+      title: "SQL injection on /users",
+      description: "user input concatenated into a SQL string",
+      severity: "critical",
+      category: "sql-injection",
+      status: "discovered",
+      evidence: {
+        request: "POST /users name=' OR 1=1 --",
+        response: "[{...}]",
+        analysis: "db.query interpolates req.body.name",
+      },
+      verificationSpec: makeSpec(),
+      timestamp: 1_700_000_000_000,
+    };
+    // Both halves of the contract present.
+    expect(enriched.evidence.request).toContain("OR 1=1");
+    expect(enriched.verificationSpec).toBeDefined();
+    expect(enriched.verificationSpec!.code).toHaveLength(3);
+    expect(enriched.verificationSpec!.behavior).toBeDefined();
+  });
+
+  it("JSON serialisation round-trips a populated spec byte-identically", () => {
+    const spec = makeSpec();
+    const wire = JSON.stringify(spec);
+    const restored = JSON.parse(wire) as VerificationSpec;
+    expect(restored).toEqual(spec);
+    expect(restored).not.toBe(spec);
+    expect(JSON.stringify(restored)).toBe(wire);
+  });
+});
+
+describe("parseVerificationSpecArg (agent tool wire shape, pwnkit#193)", () => {
+  it("returns null for nullish / empty / wrong-type input", () => {
+    expect(parseVerificationSpecArg(null)).toBeNull();
+    expect(parseVerificationSpecArg(undefined)).toBeNull();
+    expect(parseVerificationSpecArg("")).toBeNull();
+    expect(parseVerificationSpecArg(42)).toBeNull();
+    expect(parseVerificationSpecArg(true)).toBeNull();
+    expect(parseVerificationSpecArg([])).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseVerificationSpecArg("[{")).toBeNull();
+    expect(parseVerificationSpecArg("not json")).toBeNull();
+  });
+
+  it("returns null when code is missing", () => {
+    expect(parseVerificationSpecArg('{"behavior":{"steps":[]}}')).toBeNull();
+  });
+
+  it("parses a JSON-encoded string of a valid spec", () => {
+    const spec = makeSpec();
+    const out = parseVerificationSpecArg(JSON.stringify(spec));
+    expect(out).not.toBeNull();
+    expect(out!.code).toHaveLength(3);
+    expect(out!.behavior?.steps).toHaveLength(1);
+  });
+
+  it("accepts an already-parsed object", () => {
+    const spec = makeSpec();
+    const out = parseVerificationSpecArg(spec);
+    expect(out).toEqual(spec);
+  });
+
+  it("drops individual malformed predicates but keeps well-formed ones", () => {
+    const mixed = {
+      code: [
+        // good
+        { kind: "file-contains", file: "a.ts", pattern: "x" },
+        // missing file
+        { kind: "file-contains", pattern: "x" },
+        // unknown kind
+        { kind: "armageddon", file: "a.ts" },
+        // missing pattern on file-contains
+        { kind: "file-contains", file: "b.ts" },
+        // bad ast-shape (no query)
+        { kind: "ast-shape", file: "a.ts" },
+        // not an object
+        "nope",
+        null,
+      ],
+    };
+    const out = parseVerificationSpecArg(mixed);
+    expect(out).not.toBeNull();
+    expect(out!.code).toHaveLength(1);
+    expect(out!.code[0].kind).toBe("file-contains");
+  });
+
+  it("drops a malformed behavior block but keeps the spec", () => {
+    const out = parseVerificationSpecArg({
+      code: [{ kind: "file-exists", file: "a.ts" }],
+      behavior: { steps: "not an array" },
+    });
+    expect(out).not.toBeNull();
+    expect(out!.code).toHaveLength(1);
+    expect(out!.behavior).toBeUndefined();
+  });
+
+  it("drops behavior steps with malformed expect", () => {
+    const out = parseVerificationSpecArg({
+      code: [{ kind: "file-exists", file: "a.ts" }],
+      behavior: {
+        steps: [
+          // good
+          { method: "GET", path: "/", expect: "success" },
+          // bad string
+          { method: "GET", path: "/", expect: "explode" },
+          // bad object (status not a number)
+          { method: "GET", path: "/", expect: { status: "200" } },
+          // good with status
+          { method: "POST", path: "/", expect: { status: 403 } },
+        ],
+      },
+    });
+    expect(out).not.toBeNull();
+    expect(out!.behavior?.steps).toHaveLength(2);
+  });
+
+  it("returns null when the spec collapses to nothing usable", () => {
+    // No usable predicates AND no usable behavior → nothing to attach.
+    const out = parseVerificationSpecArg({
+      code: [{ kind: "armageddon" }, "junk"],
+    });
+    expect(out).toBeNull();
+  });
+});
+
+describe("cloud-sink normalizeFinding pass-through of verificationSpec (pwnkit#193)", () => {
+  it("passes a structured verificationSpec through unchanged", () => {
+    const spec = makeSpec();
+    const out = normalizeFinding({
+      id: "f-1",
+      title: "SQLi",
+      severity: "critical",
+      evidence: { request: "x", response: "y" },
+      verificationSpec: spec,
+    });
+    expect(out.verificationSpec).toEqual(spec);
+  });
+
+  it("parses a JSON-encoded verification_spec string (LLM tool-call shape)", () => {
+    const spec = makeSpec();
+    const out = normalizeFinding({
+      title: "SQLi",
+      severity: "high",
+      evidence_request: "x",
+      evidence_response: "y",
+      verification_spec: JSON.stringify(spec),
+    });
+    expect(out.verificationSpec).toBeDefined();
+    expect(out.verificationSpec).toEqual(spec);
+  });
+
+  it("drops a malformed verificationSpec without dropping the finding", () => {
+    const out = normalizeFinding({
+      title: "still useful",
+      severity: "high",
+      evidence: { request: "x", response: "y" },
+      verificationSpec: "not json [",
+    });
+    expect(out.verificationSpec).toBeUndefined();
+    expect(out.title).toBe("still useful");
+  });
+
+  it("omits verificationSpec when the input has none (legacy findings)", () => {
+    const out = normalizeFinding({
+      title: "legacy",
+      severity: "low",
+      evidence: { request: "x", response: "y" },
+    });
+    expect(out.verificationSpec).toBeUndefined();
+  });
+});

--- a/packages/core/src/verification/index.ts
+++ b/packages/core/src/verification/index.ts
@@ -1,0 +1,2 @@
+export { evaluateVerificationSpec } from "./spec.js";
+export type { PredicateResult, VerificationResult } from "./spec.js";

--- a/packages/core/src/verification/spec.test.ts
+++ b/packages/core/src/verification/spec.test.ts
@@ -344,3 +344,81 @@ describe("evaluateVerificationSpec — path safety", () => {
     expect(result.passed).toBe(false);
   });
 });
+
+/**
+ * pwnkit#193 follow-up — ReDoS + oversized-input guards.
+ *
+ * The verifier is the inner loop of cloud's canary watcher. An LLM-emitted
+ * spec that contains a pathological regex like `(a+)+$` matched against a
+ * large file would stall the worker via catastrophic backtracking. The
+ * evaluator caps both the pattern length and the file size before any
+ * regex match runs.
+ */
+describe("evaluateVerificationSpec — ReDoS + oversize guards", () => {
+  it("rejects oversized regex patterns without compiling them", async () => {
+    // 513 chars is just over MAX_PATTERN_LENGTH; the predicate must flip
+    // to failed with an `invalid regex` reason rather than running the
+    // pattern over the file.
+    const oversized = "a".repeat(513);
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: oversized,
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(/invalid regex/);
+  });
+
+  it("refuses to read files larger than the byte cap", async () => {
+    // Build a fresh repo with a >1MB file. We don't want to pollute the
+    // shared repoRoot with multi-megabyte fixtures.
+    const big = mkdtempSync(join(tmpdir(), "pwnkit-verify-big-"));
+    try {
+      writeFileSync(join(big, "huge.txt"), "x".repeat(1_000_001));
+      const spec: VerificationSpec = {
+        code: [
+          {
+            kind: "file-contains",
+            file: "huge.txt",
+            pattern: "x",
+          },
+        ],
+      };
+      const result = await evaluateVerificationSpec(spec, big);
+      expect(result.passed).toBe(false);
+      // readFileSafe returns null for oversized files; the contained-pattern
+      // branch surfaces it as "file not found or unreadable" — same stable
+      // reason as a missing file, which the canary watcher already handles.
+      expect(result.failedPredicates[0].reason).toMatch(
+        /file not found or unreadable/,
+      );
+    } finally {
+      rmSync(big, { recursive: true, force: true });
+    }
+  });
+
+  it("does not hang on a small ReDoS-prone pattern over a small file", async () => {
+    // Sanity check on the combined defence: a small ReDoS-prone pattern
+    // compiles and runs because it's under the length cap, but the file
+    // is small (< 1MB) so backtracking is bounded. This test exists to
+    // document the contract — pattern bound is a guard, file bound is the
+    // second guard. The test should not hang.
+    const start = Date.now();
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: "(a+)+$",
+        },
+      ],
+    };
+    await evaluateVerificationSpec(spec, repoRoot);
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+});

--- a/packages/core/src/verification/spec.test.ts
+++ b/packages/core/src/verification/spec.test.ts
@@ -1,0 +1,346 @@
+/**
+ * pwnkit#193 / pwnkit-cloud#111 — VerificationSpec evaluator tests.
+ *
+ * Coverage:
+ *   1. file-contains predicate: passes when pattern matches, fails when it
+ *      doesn't, and gracefully handles missing files.
+ *   2. file-missing-pattern predicate: passes when the pattern is absent,
+ *      fails when it's present, conservatively fails on missing files.
+ *   3. file-exists predicate: passes when the file exists, fails when not.
+ *   4. ast-shape predicate: surfaced as not-yet-implemented (failed) until
+ *      tree-sitter is wired in as a runtime dep.
+ *   5. Aggregate: passed === true only when every predicate held.
+ *   6. failedPredicates list captures each predicate that flipped (with
+ *      reasons), so callers can render "these predicates flipped → finding
+ *      is partial-fix".
+ *   7. Behaviour predicates short-circuit with "behavior eval not yet
+ *      supported" — code result is reported but caller knows it's
+ *      incomplete.
+ *   8. Path safety: absolute paths and `..` escapes are rejected.
+ *   9. Bad regex patterns flip the predicate to failed without throwing.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { VerificationSpec } from "@pwnkit/shared";
+import { evaluateVerificationSpec } from "./spec.js";
+
+let repoRoot: string;
+
+beforeAll(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), "pwnkit-verify-"));
+  mkdirSync(join(repoRoot, "app"), { recursive: true });
+  mkdirSync(join(repoRoot, "lib"), { recursive: true });
+  writeFileSync(
+    join(repoRoot, "app", "users.ts"),
+    [
+      "import { db } from '../lib/db';",
+      "export async function listUsers(req, res) {",
+      "  // Vulnerable: SQL string built from req.body without parameterisation",
+      "  const rows = await db.query(`SELECT * FROM users WHERE name = '${req.body.name}'`);",
+      "  res.json(rows);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(repoRoot, "lib", "db.ts"),
+    [
+      "export const db = {",
+      "  async query(sql: string) { /* ... */ return []; },",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  // app/users-fixed.ts is the patched sibling — it uses parameterised query
+  // and lacks the vulnerable shape.
+  writeFileSync(
+    join(repoRoot, "app", "users-fixed.ts"),
+    [
+      "import { db } from '../lib/db';",
+      "export async function listUsers(req, res) {",
+      "  const rows = await db.query('SELECT * FROM users WHERE name = ?', [req.body.name]);",
+      "  res.json(rows);",
+      "}",
+      "",
+    ].join("\n"),
+  );
+});
+
+afterAll(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+describe("evaluateVerificationSpec — file-contains", () => {
+  it("passes when the pattern matches", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: "db\\.query.*\\$\\{req\\.body",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(true);
+    expect(result.failedPredicates).toEqual([]);
+  });
+
+  it("fails when the pattern does not match", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users-fixed.ts",
+          pattern: "db\\.query.*\\$\\{req\\.body",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates).toHaveLength(1);
+    expect(result.failedPredicates[0].reason).toMatch(/pattern not found/);
+  });
+
+  it("fails gracefully when the file is missing", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/does-not-exist.ts",
+          pattern: "anything",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates).toHaveLength(1);
+    expect(result.failedPredicates[0].reason).toMatch(/file not found/);
+  });
+
+  it("respects regex flags", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          // Case-insensitive match against a SQL keyword
+          pattern: "select \\* from users",
+          flags: "i",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(true);
+  });
+
+  it("flips to failed without throwing on a bad regex", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: "[unclosed",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(/invalid regex/);
+  });
+});
+
+describe("evaluateVerificationSpec — file-missing-pattern", () => {
+  it("passes when the pattern is absent (fix marker still missing)", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-missing-pattern",
+          file: "app/users.ts",
+          // The fixed sibling uses parameterised "?" placeholders. The
+          // vulnerable file does not — predicate should pass.
+          pattern: "WHERE name = \\?",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when the pattern is present (fix marker introduced)", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-missing-pattern",
+          file: "app/users-fixed.ts",
+          pattern: "WHERE name = \\?",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(/pattern unexpectedly present/);
+  });
+
+  it("fails conservatively when the file is missing", async () => {
+    // A missing file cannot be asserted to "lack a pattern" in any
+    // meaningful sense — treat as failed so the result surfaces as
+    // partial-fix rather than silently passing.
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-missing-pattern",
+          file: "app/never-existed.ts",
+          pattern: "anything",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(/file not found/);
+  });
+});
+
+describe("evaluateVerificationSpec — file-exists", () => {
+  it("passes when the file exists", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "lib/db.ts" }],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when the file is missing", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "lib/missing.ts" }],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(/file not found/);
+  });
+});
+
+describe("evaluateVerificationSpec — ast-shape", () => {
+  it("is reported as not-yet-implemented (conservative failed)", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "ast-shape",
+          file: "app/users.ts",
+          query: "(call_expression function: (member_expression))",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates).toHaveLength(1);
+    expect(result.failedPredicates[0].reason).toMatch(/ast-shape.*not yet implemented/);
+  });
+});
+
+describe("evaluateVerificationSpec — aggregate semantics", () => {
+  it("passed=true only when every predicate held", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: "db\\.query",
+        },
+        { kind: "file-exists", file: "lib/db.ts" },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(true);
+    expect(result.failedPredicates).toEqual([]);
+  });
+
+  it("failedPredicates lists every predicate that flipped", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        // pass
+        { kind: "file-exists", file: "lib/db.ts" },
+        // fail — file gone
+        { kind: "file-exists", file: "lib/gone.ts" },
+        // fail — pattern missing
+        {
+          kind: "file-contains",
+          file: "app/users-fixed.ts",
+          pattern: "\\$\\{req\\.body",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates).toHaveLength(2);
+    const reasons = result.failedPredicates.map((p) => p.reason);
+    expect(reasons.some((r) => r.includes("file not found"))).toBe(true);
+    expect(reasons.some((r) => r.includes("pattern not found"))).toBe(true);
+  });
+
+  it("empty code[] with no behavior surfaces a 'no predicates' reason", async () => {
+    const spec: VerificationSpec = { code: [] };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toBe("no predicates");
+    expect(result.failedPredicates).toEqual([]);
+  });
+});
+
+describe("evaluateVerificationSpec — behavior predicate", () => {
+  it("returns 'behavior eval not yet supported' when behavior is set", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/users.ts",
+          pattern: "db\\.query",
+        },
+      ],
+      behavior: {
+        steps: [
+          { method: "GET", path: "/users", expect: "success" },
+        ],
+      },
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    // Code-level still passes…
+    expect(result.passed).toBe(true);
+    // …but the caller is told that behavioural verification didn't run.
+    expect(result.reason).toBe("behavior eval not yet supported");
+  });
+});
+
+describe("evaluateVerificationSpec — path safety", () => {
+  it("rejects absolute paths", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "/etc/passwd" }],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path escapes repo root or is invalid/,
+    );
+  });
+
+  it("rejects ../ escapes", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "../../../etc/passwd" }],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path escapes repo root or is invalid/,
+    );
+  });
+
+  it("rejects empty paths", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "" }],
+    };
+    const result = await evaluateVerificationSpec(spec, repoRoot);
+    expect(result.passed).toBe(false);
+  });
+});

--- a/packages/core/src/verification/spec.test.ts
+++ b/packages/core/src/verification/spec.test.ts
@@ -20,7 +20,13 @@
  *   9. Bad regex patterns flip the predicate to failed without throwing.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { VerificationSpec } from "@pwnkit/shared";
@@ -342,6 +348,160 @@ describe("evaluateVerificationSpec — path safety", () => {
     };
     const result = await evaluateVerificationSpec(spec, repoRoot);
     expect(result.passed).toBe(false);
+  });
+});
+
+/**
+ * pwnkit#193 follow-up — defence-in-depth against symlink traversal.
+ *
+ * `resolveRepoPath` rejects lexical escapes (`..`, absolute paths) but
+ * cannot detect a symlink *inside* the repo whose real target is outside.
+ * A malicious finding could otherwise smuggle a `read /etc/passwd` into a
+ * `file-contains` predicate by pointing at a symlink the agent created
+ * during the original scan. Every read/access path is wrapped in a
+ * realpath-based boundary check; broken symlinks, links to outside files,
+ * and link chains all fail closed with a stable reason.
+ */
+describe("evaluateVerificationSpec — symlink traversal guards", () => {
+  let symlinkRoot: string;
+  let outsideDir: string;
+
+  beforeAll(() => {
+    // We need an outside directory we can point a symlink at. Use a
+    // sibling of the repo root so the symlink target is real but outside
+    // the verifier sandbox.
+    outsideDir = mkdtempSync(join(tmpdir(), "pwnkit-verify-outside-"));
+    writeFileSync(
+      join(outsideDir, "secrets.env"),
+      "SECRET_KEY=should-never-be-readable\n",
+    );
+
+    symlinkRoot = mkdtempSync(join(tmpdir(), "pwnkit-verify-symlink-"));
+    mkdirSync(join(symlinkRoot, "app"), { recursive: true });
+    writeFileSync(
+      join(symlinkRoot, "app", "real.ts"),
+      "// inside the repo, perfectly fine to read\n",
+    );
+
+    // Symlink that resolves *outside* the repo.
+    symlinkSync(
+      join(outsideDir, "secrets.env"),
+      join(symlinkRoot, "app", "leak.env"),
+    );
+
+    // Symlink to a directory outside the repo.
+    symlinkSync(outsideDir, join(symlinkRoot, "app", "leak-dir"));
+
+    // Broken symlink (target does not exist).
+    symlinkSync(
+      join(outsideDir, "does-not-exist"),
+      join(symlinkRoot, "app", "broken"),
+    );
+
+    // Chain: link → link → outside file.
+    symlinkSync(
+      join(symlinkRoot, "app", "leak.env"),
+      join(symlinkRoot, "app", "chained.env"),
+    );
+
+    // Inside-only symlink (target inside the repo) — must still resolve.
+    symlinkSync(
+      join(symlinkRoot, "app", "real.ts"),
+      join(symlinkRoot, "app", "alias.ts"),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(symlinkRoot, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("rejects file-exists on a symlink that escapes the repo", async () => {
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "app/leak.env" }],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path resolves outside repo root/,
+    );
+  });
+
+  it("rejects file-contains read through an escaping symlink", async () => {
+    // Without the realpath guard, this would happily read the contents of
+    // an outside-the-repo file and run a regex over it.
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/leak.env",
+          pattern: "SECRET_KEY",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path resolves outside repo root/,
+    );
+  });
+
+  it("rejects file-missing-pattern through an escaping symlink", async () => {
+    // file-missing-pattern would otherwise be exploitable as an oracle:
+    // attacker sets a pattern that matches /etc/passwd, learns whether
+    // the file contains it from passed=true/false.
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-missing-pattern",
+          file: "app/leak.env",
+          pattern: "SECRET_KEY",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path resolves outside repo root/,
+    );
+  });
+
+  it("rejects symlink chains that ultimately escape the repo", async () => {
+    const spec: VerificationSpec = {
+      code: [
+        {
+          kind: "file-contains",
+          file: "app/chained.env",
+          pattern: "SECRET_KEY",
+        },
+      ],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(false);
+    expect(result.failedPredicates[0].reason).toMatch(
+      /path resolves outside repo root/,
+    );
+  });
+
+  it("treats broken symlinks conservatively as failed", async () => {
+    // Broken symlink → realpath rejects → conservative fail. Either
+    // "outside repo" or "file not found" reason is acceptable; the key
+    // requirement is that the predicate does not throw and does not pass.
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "app/broken" }],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(false);
+  });
+
+  it("still allows reads through symlinks that stay inside the repo", async () => {
+    // Inside-only symlinks must keep working — otherwise we'd break repos
+    // that legitimately use symlinks for monorepo aliasing.
+    const spec: VerificationSpec = {
+      code: [{ kind: "file-exists", file: "app/alias.ts" }],
+    };
+    const result = await evaluateVerificationSpec(spec, symlinkRoot);
+    expect(result.passed).toBe(true);
   });
 });
 

--- a/packages/core/src/verification/spec.ts
+++ b/packages/core/src/verification/spec.ts
@@ -1,0 +1,283 @@
+// pwnkit#193 / pwnkit-cloud#111 — deterministic finding re-verification.
+//
+// `evaluateVerificationSpec` runs a finding's `VerificationSpec.code[]`
+// predicates against a target repo on disk and reports whether the finding
+// is still real. It is intentionally *cheap*: no LLM calls, no target
+// provisioning, no network. Cloud's canary watcher calls this on every
+// upstream HEAD refresh; the OSS engine emits the spec when it produces a
+// finding so that re-evaluation later is deterministic.
+//
+// Behavioural predicates (`VerificationSpec.behavior`) require a provisioned
+// target and are out of scope here — the helper short-circuits with a stable
+// `behavior eval not yet supported` reason.
+
+import { promises as fs } from "node:fs";
+import { resolve, isAbsolute, normalize, sep } from "node:path";
+import type {
+  VerificationCodePredicate,
+  VerificationSpec,
+} from "@pwnkit/shared";
+
+/**
+ * Result of a single predicate evaluation. `passed === true` means the
+ * predicate held; `false` means it was definitely violated; `null` means
+ * it could not be evaluated (file missing, regex invalid, etc.) and the
+ * caller should treat it conservatively.
+ */
+export interface PredicateResult {
+  predicate: VerificationCodePredicate;
+  passed: boolean;
+  /** Short, stable, human-readable explanation. */
+  reason: string;
+}
+
+/**
+ * Aggregate verification result. `passed === true` only when every code-level
+ * predicate held. `failedPredicates` lists the ones that did not (including
+ * predicates that could not be evaluated).
+ */
+export interface VerificationResult {
+  passed: boolean;
+  failedPredicates: PredicateResult[];
+  /**
+   * Optional top-level reason. Populated for short-circuit cases:
+   *  - empty `code[]` and no `behavior` → "no predicates"
+   *  - `behavior` present → "behavior eval not yet supported"
+   * For normal evaluations, this is undefined and the per-predicate reasons
+   * carry the detail.
+   */
+  reason?: string;
+}
+
+/**
+ * Resolve a repo-relative path against `repoRoot`. Refuses to escape the
+ * root via `..` segments or absolute paths — same defence-in-depth pattern
+ * the agent's `read_file` uses, so that a malicious finding can't be made
+ * to read `/etc/passwd` on a verifier host. Returns null on rejection.
+ */
+function resolveRepoPath(repoRoot: string, file: string): string | null {
+  if (typeof file !== "string" || file.length === 0) return null;
+  // Reject absolute paths outright. The spec is a contract about a target
+  // repo's tree; absolute paths belong to nobody.
+  if (isAbsolute(file)) return null;
+  const root = resolve(repoRoot);
+  const candidate = resolve(root, file);
+  const normalized = normalize(candidate);
+  // Ensure the candidate is *under* root (or equal to it). Use `sep` so the
+  // boundary check works on both posix and win32.
+  if (normalized !== root && !normalized.startsWith(root + sep)) {
+    return null;
+  }
+  return normalized;
+}
+
+/**
+ * Build a RegExp from a pattern + optional flags string. Returns null on
+ * invalid regex. The verifier never throws on malformed predicates — a bad
+ * regex flips the predicate to `passed: false` with a clear reason.
+ */
+function safeRegex(pattern: string, flags?: string): RegExp | null {
+  try {
+    return new RegExp(pattern, flags);
+  } catch {
+    return null;
+  }
+}
+
+async function readFileSafe(absPath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(absPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function fileExists(absPath: string): Promise<boolean> {
+  try {
+    await fs.access(absPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function evaluateOne(
+  predicate: VerificationCodePredicate,
+  repoRoot: string,
+): Promise<PredicateResult> {
+  switch (predicate.kind) {
+    case "file-exists": {
+      const abs = resolveRepoPath(repoRoot, predicate.file);
+      if (!abs) {
+        return {
+          predicate,
+          passed: false,
+          reason: `path escapes repo root or is invalid: ${predicate.file}`,
+        };
+      }
+      const ok = await fileExists(abs);
+      return {
+        predicate,
+        passed: ok,
+        reason: ok ? "file exists" : `file not found: ${predicate.file}`,
+      };
+    }
+
+    case "file-contains": {
+      const abs = resolveRepoPath(repoRoot, predicate.file);
+      if (!abs) {
+        return {
+          predicate,
+          passed: false,
+          reason: `path escapes repo root or is invalid: ${predicate.file}`,
+        };
+      }
+      const content = await readFileSafe(abs);
+      if (content === null) {
+        return {
+          predicate,
+          passed: false,
+          reason: `file not found or unreadable: ${predicate.file}`,
+        };
+      }
+      const re = safeRegex(predicate.pattern, predicate.flags);
+      if (!re) {
+        return {
+          predicate,
+          passed: false,
+          reason: `invalid regex: /${predicate.pattern}/${predicate.flags ?? ""}`,
+        };
+      }
+      const matched = re.test(content);
+      return {
+        predicate,
+        passed: matched,
+        reason: matched
+          ? `pattern matched in ${predicate.file}`
+          : `pattern not found in ${predicate.file}`,
+      };
+    }
+
+    case "file-missing-pattern": {
+      const abs = resolveRepoPath(repoRoot, predicate.file);
+      if (!abs) {
+        return {
+          predicate,
+          passed: false,
+          reason: `path escapes repo root or is invalid: ${predicate.file}`,
+        };
+      }
+      const content = await readFileSafe(abs);
+      if (content === null) {
+        // Conservative: missing file means we can't assert the pattern is
+        // absent in any meaningful sense. Treat as failed so the finding
+        // surfaces as `partial-fix` rather than silently passing.
+        return {
+          predicate,
+          passed: false,
+          reason: `file not found or unreadable: ${predicate.file}`,
+        };
+      }
+      const re = safeRegex(predicate.pattern, predicate.flags);
+      if (!re) {
+        return {
+          predicate,
+          passed: false,
+          reason: `invalid regex: /${predicate.pattern}/${predicate.flags ?? ""}`,
+        };
+      }
+      const matched = re.test(content);
+      return {
+        predicate,
+        passed: !matched,
+        reason: matched
+          ? `pattern unexpectedly present in ${predicate.file}`
+          : `pattern absent in ${predicate.file}`,
+      };
+    }
+
+    case "ast-shape": {
+      // Tree-sitter not yet wired in as a runtime dep. The conservative
+      // contract is: an unimplemented predicate cannot prove the finding
+      // is fixed, so we mark it as failed with a stable reason. Cloud's
+      // watcher can downgrade this case to `unknown` rather than treating
+      // it as a hard partial-fix; the OSS verifier just reports facts.
+      return {
+        predicate,
+        passed: false,
+        reason: "ast-shape predicates are not yet implemented in the OSS verifier",
+      };
+    }
+    default: {
+      // Exhaustiveness guard. If a new predicate kind is added to the
+      // discriminated union without a case here, this branch becomes a
+      // type error at compile time.
+      const _exhaustive: never = predicate;
+      void _exhaustive;
+      return {
+        predicate: predicate as VerificationCodePredicate,
+        passed: false,
+        reason: "unknown predicate kind",
+      };
+    }
+  }
+}
+
+/**
+ * Evaluate a {@link VerificationSpec} against `repoRoot` on disk.
+ *
+ * - Every `code[]` predicate is evaluated. The aggregate `passed` is true
+ *   iff every predicate's `passed` is true.
+ * - `failedPredicates` is the list of predicates whose `passed` was false
+ *   (for caller-side rendering: "these predicates flipped → finding is
+ *   partial-fix").
+ * - When `spec.behavior` is present, this helper does NOT attempt to run
+ *   it; it returns the code-level result with `reason` set to a stable
+ *   "behavior eval not yet supported" string. Callers that need
+ *   behavioural verification should dispatch separately.
+ *
+ * No exceptions are thrown for normal failure modes (missing files, bad
+ * regex, path escapes). Every failure is a structured PredicateResult.
+ */
+export async function evaluateVerificationSpec(
+  spec: VerificationSpec,
+  repoRoot: string,
+): Promise<VerificationResult> {
+  const results: PredicateResult[] = [];
+  for (const predicate of spec.code) {
+    results.push(await evaluateOne(predicate, repoRoot));
+  }
+
+  const failedPredicates = results.filter((r) => !r.passed);
+
+  // Empty code[] with no behavior → no signal either way. Pass=false is
+  // the conservative default (the caller can't claim "still vulnerable"
+  // from zero predicates) but we surface it via `reason` so the caller
+  // can downgrade to `unknown` rather than `partial-fix`.
+  if (spec.code.length === 0 && !spec.behavior) {
+    return {
+      passed: false,
+      failedPredicates: [],
+      reason: "no predicates",
+    };
+  }
+
+  const codePassed = failedPredicates.length === 0 && spec.code.length > 0;
+
+  if (spec.behavior) {
+    // Code-level passed and a behavioural step exists: we can't actually
+    // run it here. Surface the limitation rather than silently claiming
+    // "still vulnerable". Callers should treat this as inconclusive
+    // pending a behavioural runner.
+    return {
+      passed: codePassed,
+      failedPredicates,
+      reason: "behavior eval not yet supported",
+    };
+  }
+
+  return {
+    passed: codePassed,
+    failedPredicates,
+  };
+}

--- a/packages/core/src/verification/spec.ts
+++ b/packages/core/src/verification/spec.ts
@@ -73,6 +73,11 @@ const MAX_FILE_BYTES = 1_000_000;
  * root via `..` segments or absolute paths — same defence-in-depth pattern
  * the agent's `read_file` uses, so that a malicious finding can't be made
  * to read `/etc/passwd` on a verifier host. Returns null on rejection.
+ *
+ * NOTE: the lexical check here is necessary but not sufficient — symlinks
+ * inside the repo can still resolve outside it. Use {@link checkRepoBoundary}
+ * before any actual filesystem read to enforce the boundary on the resolved
+ * target.
  */
 function resolveRepoPath(repoRoot: string, file: string): string | null {
   if (typeof file !== "string" || file.length === 0) return null;
@@ -88,6 +93,58 @@ function resolveRepoPath(repoRoot: string, file: string): string | null {
     return null;
   }
   return normalized;
+}
+
+/**
+ * Outcome of the realpath-based boundary check. We distinguish three cases
+ * so the caller can produce a stable, accurate reason string:
+ *   - `inside`: target resolves under the repo root → safe to read.
+ *   - `missing`: path entry does not exist (no symlink, no file).
+ *     Callers surface this as "file not found", same as the pre-symlink-
+ *     hardening behaviour.
+ *   - `outside`: path entry exists but resolves outside the repo root
+ *     (escaping symlink, broken symlink, dangling chain). Callers refuse
+ *     the read with "path resolves outside repo root".
+ */
+type RepoBoundaryOutcome = "inside" | "missing" | "outside";
+
+/**
+ * Defence-in-depth boundary check that resolves symlinks before comparing
+ * paths. `resolveRepoPath` already rejects lexical escapes (`..`, absolute
+ * paths); this helper covers the case where a symlink *inside* the repo
+ * points *outside* it.
+ *
+ * Distinguishes a genuinely missing path (no entry at all) from one that
+ * exists but resolves outside the repo, so callers can keep the legacy
+ * "file not found" reason for missing files while flipping escapes to
+ * "path resolves outside repo root".
+ */
+async function checkRepoBoundary(
+  repoRoot: string,
+  absPath: string,
+): Promise<RepoBoundaryOutcome> {
+  // `lstat` succeeds on broken symlinks (it doesn't follow them), so a
+  // failure here means the path entry itself doesn't exist.
+  try {
+    await fs.lstat(absPath);
+  } catch {
+    return "missing";
+  }
+  try {
+    const [realRoot, realTarget] = await Promise.all([
+      fs.realpath(repoRoot),
+      fs.realpath(absPath),
+    ]);
+    if (realTarget === realRoot || realTarget.startsWith(realRoot + sep)) {
+      return "inside";
+    }
+    return "outside";
+  } catch {
+    // The path entry exists (lstat succeeded) but realpath couldn't
+    // resolve it — broken symlink, dangling chain, or EACCES on a parent.
+    // Conservatively treat as outside so we never read it.
+    return "outside";
+  }
 }
 
 /**
@@ -146,7 +203,17 @@ async function evaluateOne(
           reason: `path escapes repo root or is invalid: ${predicate.file}`,
         };
       }
-      const ok = await fileExists(abs);
+      const outcome = await checkRepoBoundary(repoRoot, abs);
+      if (outcome === "outside") {
+        // Symlink-traversal guard: a symlink inside the repo whose real
+        // target lives outside it must not be reported as "exists".
+        return {
+          predicate,
+          passed: false,
+          reason: `path resolves outside repo root: ${predicate.file}`,
+        };
+      }
+      const ok = outcome === "inside";
       return {
         predicate,
         passed: ok,
@@ -161,6 +228,23 @@ async function evaluateOne(
           predicate,
           passed: false,
           reason: `path escapes repo root or is invalid: ${predicate.file}`,
+        };
+      }
+      const outcome = await checkRepoBoundary(repoRoot, abs);
+      if (outcome === "outside") {
+        // Symlink-traversal guard before any read. Predicate fails closed
+        // when the resolved target lives outside the repo root.
+        return {
+          predicate,
+          passed: false,
+          reason: `path resolves outside repo root: ${predicate.file}`,
+        };
+      }
+      if (outcome === "missing") {
+        return {
+          predicate,
+          passed: false,
+          reason: `file not found or unreadable: ${predicate.file}`,
         };
       }
       const content = await readFileSafe(abs);
@@ -196,6 +280,27 @@ async function evaluateOne(
           predicate,
           passed: false,
           reason: `path escapes repo root or is invalid: ${predicate.file}`,
+        };
+      }
+      const outcome = await checkRepoBoundary(repoRoot, abs);
+      if (outcome === "outside") {
+        // Symlink-traversal guard before any read. Otherwise the predicate
+        // becomes a confirmed-presence oracle for arbitrary files outside
+        // the repo (passed=true means "pattern absent in /etc/passwd").
+        return {
+          predicate,
+          passed: false,
+          reason: `path resolves outside repo root: ${predicate.file}`,
+        };
+      }
+      if (outcome === "missing") {
+        // Conservative: missing file means we can't assert the pattern is
+        // absent in any meaningful sense. Treat as failed so the finding
+        // surfaces as `partial-fix` rather than silently passing.
+        return {
+          predicate,
+          passed: false,
+          reason: `file not found or unreadable: ${predicate.file}`,
         };
       }
       const content = await readFileSafe(abs);

--- a/packages/core/src/verification/spec.ts
+++ b/packages/core/src/verification/spec.ts
@@ -50,6 +50,25 @@ export interface VerificationResult {
 }
 
 /**
+ * Maximum length of a regex pattern the verifier will compile. Verification
+ * specs are produced by an LLM and consumed by a long-running canary watcher
+ * — a single pathological pattern (e.g. `(a+)+$`) on a large file is enough
+ * to stall the worker for minutes via catastrophic backtracking. The bound
+ * here is a defence-in-depth complement to the file-size cap below: it
+ * rejects most ReDoS-prone inputs before they ever reach the regex engine.
+ */
+const MAX_PATTERN_LENGTH = 512;
+
+/**
+ * Maximum file size (bytes) the verifier will read into memory for pattern
+ * matching. Files above this cap short-circuit with a stable reason. 1 MB
+ * is generous for the kinds of source files specs target (TS/JS/Py/Go) and
+ * keeps regex matching cost predictable. Combined with `MAX_PATTERN_LENGTH`,
+ * this caps the worst-case runtime of a single predicate.
+ */
+const MAX_FILE_BYTES = 1_000_000;
+
+/**
  * Resolve a repo-relative path against `repoRoot`. Refuses to escape the
  * root via `..` segments or absolute paths — same defence-in-depth pattern
  * the agent's `read_file` uses, so that a malicious finding can't be made
@@ -73,10 +92,13 @@ function resolveRepoPath(repoRoot: string, file: string): string | null {
 
 /**
  * Build a RegExp from a pattern + optional flags string. Returns null on
- * invalid regex. The verifier never throws on malformed predicates — a bad
+ * invalid regex OR when the pattern exceeds {@link MAX_PATTERN_LENGTH}.
+ * The verifier never throws on malformed predicates — a bad or oversized
  * regex flips the predicate to `passed: false` with a clear reason.
  */
 function safeRegex(pattern: string, flags?: string): RegExp | null {
+  if (typeof pattern !== "string") return null;
+  if (pattern.length > MAX_PATTERN_LENGTH) return null;
   try {
     return new RegExp(pattern, flags);
   } catch {
@@ -84,8 +106,17 @@ function safeRegex(pattern: string, flags?: string): RegExp | null {
   }
 }
 
+/**
+ * Read a file into memory, capped at {@link MAX_FILE_BYTES}. Returns null
+ * for missing/unreadable/oversized files so the caller surfaces a stable
+ * "file not found or unreadable" reason rather than running a regex over
+ * a multi-megabyte blob.
+ */
 async function readFileSafe(absPath: string): Promise<string | null> {
   try {
+    const stat = await fs.stat(absPath);
+    if (!stat.isFile()) return null;
+    if (stat.size > MAX_FILE_BYTES) return null;
     return await fs.readFile(absPath, "utf8");
   } catch {
     return null;

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -369,6 +369,11 @@ export class pwnkitDB {
     if (!colNames.has("pocSteps")) {
       this.sqlite.exec("ALTER TABLE findings ADD COLUMN pocSteps TEXT");
     }
+    // pwnkit#193 — machine-executable verification contract. JSON-stringified
+    // VerificationSpec. Optional/additive: legacy findings keep working.
+    if (!colNames.has("verificationSpec")) {
+      this.sqlite.exec("ALTER TABLE findings ADD COLUMN verificationSpec TEXT");
+    }
     this.sqlite.exec("UPDATE findings SET fingerprint = id WHERE fingerprint IS NULL OR fingerprint = ''");
     this.sqlite.exec("UPDATE findings SET triageStatus = 'new' WHERE triageStatus IS NULL OR triageStatus = ''");
     this.sqlite.exec(`
@@ -1166,6 +1171,15 @@ export class pwnkitDB {
       finding.pocSteps && finding.pocSteps.length > 0
         ? JSON.stringify(finding.pocSteps)
         : null;
+    // pwnkit#193 — persist the optional VerificationSpec. NULL when the
+    // finding has no machine-executable re-check contract. Stored as
+    // JSON text; cloud's canary watcher reads it back via
+    // restorePersistedFinding to re-evaluate findings on each upstream
+    // HEAD refresh. Without this column the spec was silently dropped on
+    // any reload path.
+    const verificationSpecJson = finding.verificationSpec
+      ? JSON.stringify(finding.verificationSpec)
+      : null;
     this.db
       .insert(schema.findings)
       .values({
@@ -1192,6 +1206,7 @@ export class pwnkitDB {
         evidenceAnalysis: finding.evidence.analysis ?? null,
         layerVerdicts: layerVerdictsJson,
         pocSteps: pocStepsJson,
+        verificationSpec: verificationSpecJson,
         timestamp: finding.timestamp,
       })
       .onConflictDoUpdate({
@@ -1218,6 +1233,7 @@ export class pwnkitDB {
           evidenceAnalysis: finding.evidence.analysis ?? null,
           layerVerdicts: layerVerdictsJson,
           pocSteps: pocStepsJson,
+          verificationSpec: verificationSpecJson,
           timestamp: finding.timestamp,
         },
       })
@@ -2020,6 +2036,7 @@ CREATE TABLE IF NOT EXISTS findings (
   evidenceResponse TEXT NOT NULL,
   evidenceAnalysis TEXT,
   pocSteps TEXT,
+  verificationSpec TEXT,
   timestamp INTEGER NOT NULL
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -116,6 +116,15 @@ export const findings = sqliteTable(
      * See pwnkit#170.
      */
     pocSteps: text("pocSteps"),
+    /**
+     * JSON-stringified VerificationSpec (see @pwnkit/shared types). NULL
+     * when the agent produced a finding without a deterministic re-check
+     * contract — every reader must continue to work in that case. Stored
+     * as text because the spec is an opaque blob that the verifier reads
+     * whole; we never query individual predicates. See pwnkit#193 /
+     * pwnkit-cloud#111.
+     */
+    verificationSpec: text("verificationSpec"),
     timestamp: integer("timestamp").notNull(),
   },
   (table) => [

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -259,6 +259,13 @@ export interface Finding {
    * markdown) prefer this structured form over the prose `evidence.*` strings.
    */
   pocSteps?: PocStep[];
+  /**
+   * Machine-executable verification contract (pwnkit#193 / pwnkit-cloud#111).
+   * Optional and additive. When populated, cloud's canary watcher (and any
+   * OSS caller) can re-evaluate whether the finding is still real against
+   * a fresh checkout of the target repo. See {@link VerificationSpec}.
+   */
+  verificationSpec?: VerificationSpec;
   timestamp: number;
 }
 
@@ -444,6 +451,93 @@ export interface PocStep {
    * informational.
    */
   expect?: PocStepExpect;
+}
+
+// ── Verification Spec (pwnkit#193 / pwnkit-cloud#111) ───────────────────────
+//
+// A `VerificationSpec` is a *machine-executable* contract attached to a
+// finding. It answers a single question: "is this finding still real?".
+//
+// The engine emits the spec when it produces a finding. Cloud (and OSS
+// callers) can later evaluate it against a fresh checkout of the target
+// repo to decide if the underlying vulnerability has been patched, partially
+// fixed, or is still exploitable — without re-running the full LLM agent.
+//
+// The spec is split into two layers:
+//
+// 1. `code[]` — pure code-level predicates. Cheap, deterministic, no target
+//    provisioning required. All predicates must pass for the finding to
+//    still count as vulnerable. If any fails, surface as `partial-fix`.
+//
+// 2. `behavior` — optional behavioural predicate. Requires a provisioned
+//    target. If present and its exploit predicate fails, the finding is
+//    `fixed` regardless of what `code[]` says.
+//
+// The field is OPTIONAL and ADDITIVE on `Finding`. Existing findings produced
+// before this type existed leave it undefined and continue to round-trip
+// unchanged through every renderer, exporter, the DB, and the cloud sink.
+
+/**
+ * Code-level predicate. Each variant is a discriminated union keyed on
+ * `kind`. All paths are repo-relative (resolved against the repoRoot the
+ * verifier is given). Patterns are JS regex source strings (so they can
+ * be persisted as JSON and re-hydrated cleanly).
+ *
+ * - `file-contains` — file exists AND its contents match `pattern` (with
+ *   optional regex `flags`). The vulnerable shape should still be present.
+ * - `file-missing-pattern` — file exists AND its contents do NOT match
+ *   `pattern`. Used to assert that a fix-marker (e.g. an `assertAdmin`
+ *   call) is still absent.
+ * - `file-exists` — file simply exists. Cheapest predicate; useful when
+ *   the vulnerable file has a stable name but the shape is hard to pin
+ *   with a single regex.
+ * - `ast-shape` — tree-sitter query against the file's parsed AST.
+ *   Stronger than regex but costs a tree-sitter dependency. Marked as
+ *   not-yet-implemented in the OSS verifier; treated as "skipped" when
+ *   evaluated, which is conservative (an unimplemented predicate cannot
+ *   prove the finding is fixed).
+ */
+export type VerificationCodePredicate =
+  | { kind: "file-contains"; file: string; pattern: string; flags?: string }
+  | { kind: "file-missing-pattern"; file: string; pattern: string; flags?: string }
+  | { kind: "file-exists"; file: string }
+  | { kind: "ast-shape"; file: string; query: string };
+
+/**
+ * Behavioural predicate — a single HTTP step the verifier should replay
+ * against a provisioned target. `expect` is one of:
+ *
+ * - `"success"` — any 2xx is fine.
+ * - `"forbidden"` — the request is expected to be rejected (4xx, typically
+ *   401/403). When the finding is "still vulnerable" the actual response
+ *   is a `success`, so a `forbidden` here is the *fix marker*: if the
+ *   target is forbidden, the exploit no longer works.
+ * - `{ status: number }` — exact status code match.
+ *
+ * The runtime executor that consumes this is OUT OF SCOPE for the OSS
+ * verifier in pwnkit#193 — code predicates only. The shape is recorded
+ * here so cloud's canary watcher can dispatch it later.
+ */
+export interface VerificationBehaviorStep {
+  method: string;
+  path: string;
+  body?: unknown;
+  expect: "success" | "forbidden" | { status: number };
+}
+
+export interface VerificationBehavior {
+  steps: VerificationBehaviorStep[];
+}
+
+export interface VerificationSpec {
+  /**
+   * Code-level predicates that must all be true for the finding to remain
+   * vulnerable. Empty array is permitted (means "no code-level signal";
+   * verifier returns inconclusive when there is also no `behavior`).
+   */
+  code: VerificationCodePredicate[];
+  /** Optional behavioural predicate. Requires target provisioning. */
+  behavior?: VerificationBehavior;
 }
 
 // ── Kernel Crash Reports ──


### PR DESCRIPTION
## Summary
- Add `VerificationSpec` type to `Finding` (optional `code[]` predicates + optional `behavior` steps)
- `evaluateVerificationSpec` helper exported from core for cloud's canary watcher entry point
- `save_finding` agent tool accepts and emits `verificationSpec`
- Wire-format pass-through in cloud-sink so cloud can ingest the field

Closes #168

## Test plan
- [x] 35 new tests across spec evaluator + Finding wire shape
- [x] `pnpm --filter @pwnkit/core exec tsc --noEmit` clean
- [x] Existing 732 core tests still pass (1 pre-existing unrelated failure on origin/main)
- [x] Backwards-compat: findings without `verificationSpec` still parse

## Open questions
- tree-sitter for `ast-shape` predicates: pulled in as record-only for now (predicate gets `not yet implemented`); operator decision on whether to land tree-sitter as a runtime dep
- Cloud-side zod ingest schema: will be addressed in `pwnkit-cloud#111`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Findings may now carry an optional verification spec for deterministic re-checks.
  * Added a verification evaluator API that reports per-predicate results (includes an "ast-shape" predicate marked not-yet-implemented).

* **Persistence**
  * Verification specs are persisted and survive cloud/local normalization and restore cycles.
  * Normalizer accepts either object or JSON-encoded spec inputs and tolerantly drops malformed parts.

* **Tests**
  * Extensive tests for parsing, normalization, evaluation, safety limits, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->