### PR TITLE
fix(agent): per-turn stderr heartbeat for self-scan diagnosis

### DIFF
--- a/packages/core/src/agent-runner.ts
+++ b/packages/core/src/agent-runner.ts
@@ -33,6 +33,14 @@ export interface AnalysisAgentOptions {
   cliSystemPrompt: string;
   /** Optional: direct API prompt with embedded source code for single-shot fallback */
   directApiPrompt?: string;
+  /**
+   * Why the agent is being invoked. `research` (default) uses the full
+   * depth-derived turn budget. `verify` reproves a single specific finding
+   * and is capped much tighter — late turns in a long verify call cost as
+   * much as in a long research call (each one re-sends the entire growing
+   * conversation), and a single finding shouldn't need 15 turns to reproduce.
+   */
+  purpose?: "research" | "verify";
 }
 
 /**
@@ -50,7 +58,20 @@ export interface AnalysisAgentResult {
 
 // ── Depth → maxTurns mapping ──
 
-function getMaxTurns(role: "audit" | "review", depth: string | undefined, branch: "native" | "legacy"): number {
+function getMaxTurns(
+  role: "audit" | "review",
+  depth: string | undefined,
+  branch: "native" | "legacy",
+  purpose: "research" | "verify" = "research",
+): number {
+  // Verify reproves one specific finding and should never need more than
+  // a handful of turns; cap it tight regardless of depth so verify-wave
+  // wall-clock stays bounded. (See PR #198 heartbeat data: per-turn LLM
+  // call duration grows with conversation history — 5s at turn 1, 60s at
+  // turn 14 — so trimming late verify turns is the highest-leverage cut.)
+  if (purpose === "verify") {
+    return Math.min(8, branch === "native" ? 8 : 10);
+  }
   if (role === "audit") {
     if (branch === "native") {
       return depth === "deep" ? 30 : depth === "default" ? 20 : 10;
@@ -77,7 +98,7 @@ function getMaxTurns(role: "audit" | "review", depth: string | undefined, branch
  * 3. Legacy fallback (runAgentLoop)
  */
 export async function runAnalysisAgent(opts: AnalysisAgentOptions): Promise<AnalysisAgentResult> {
-  const { role, scopePath, target, scanId, sessionId, config, db, emit, cliPrompt, agentSystemPrompt, cliSystemPrompt, directApiPrompt } = opts;
+  const { role, scopePath, target, scanId, sessionId, config, db, emit, cliPrompt, agentSystemPrompt, cliSystemPrompt, directApiPrompt, purpose = "research" } = opts;
 
   const templatePrefix = `cli-${role}`;
   const requestedRuntime = config.runtime as RuntimeType | "auto" | undefined;
@@ -239,7 +260,7 @@ export async function runAnalysisAgent(opts: AnalysisAgentOptions): Promise<Anal
     }
 
     if (supportsNative) {
-      const maxTurns = getMaxTurns(role, config.depth, "native");
+      const maxTurns = getMaxTurns(role, config.depth, "native", purpose);
 
       const agentState = await runNativeAgentLoop({
         config: {
@@ -359,7 +380,7 @@ export async function runAnalysisAgent(opts: AnalysisAgentOptions): Promise<Anal
   }
 
   // ── Branch 3: Legacy fallback — text-based agent loop ──
-  const maxTurns = getMaxTurns(role, config.depth, "legacy");
+  const maxTurns = getMaxTurns(role, config.depth, "legacy", purpose);
 
   const runtimeConfig = {
     type: runtimeType as RuntimeType,

--- a/packages/core/src/agent-runner.ts
+++ b/packages/core/src/agent-runner.ts
@@ -70,7 +70,7 @@ function getMaxTurns(
   // call duration grows with conversation history — 5s at turn 1, 60s at
   // turn 14 — so trimming late verify turns is the highest-leverage cut.)
   if (purpose === "verify") {
-    return Math.min(8, branch === "native" ? 8 : 10);
+    return branch === "native" ? 8 : 10;
   }
   if (role === "audit") {
     if (branch === "native") {

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -124,11 +124,25 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
   process.on("SIGINT", signalCleanup);
   process.on("SIGTERM", signalCleanup);
 
+  // CI heartbeat: one stderr line per turn so a CI log of a hung scan
+  // tells us at which turn / on which tool we stopped making progress.
+  // Gated on CI / explicit opt-in so local TUI runs stay quiet.
+  const heartbeatEnabled = !!(process.env.CI || process.env.PWNKIT_HEARTBEAT || process.env.PWNKIT_DEBUG);
+  const loopStartedAt = Date.now();
+  let lastToolName: string | null = null;
+
   // ── Main loop ──
 
   try {
   while (!state.done && state.turnCount < config.maxTurns) {
     state.turnCount++;
+
+    if (heartbeatEnabled) {
+      const elapsed = ((Date.now() - loopStartedAt) / 1000).toFixed(1);
+      process.stderr.write(
+        `[pwnkit:hb] t=${elapsed}s role=${config.role} turn=${state.turnCount}/${config.maxTurns} runtime=${runtime.type} last_tool=${lastToolName ?? "-"}\n`,
+      );
+    }
 
     // Build the full conversation as a single prompt for the runtime
     const prompt = serializeConversation(state.messages);
@@ -169,6 +183,10 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
 
     const assistantContent = result.output;
     const toolCalls = parseToolCalls(assistantContent);
+
+    if (toolCalls.length > 0) {
+      lastToolName = toolCalls[toolCalls.length - 1].name;
+    }
 
     const assistantMsg: AgentMessage = {
       role: "assistant",

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -240,6 +240,13 @@ export async function runNativeAgentLoop(
   // Collect tool names used for the attempt summary (deduped)
   const toolsUsedSet = new Set<string>();
 
+  // CI heartbeat: one stderr line per turn so a CI log of a hung scan
+  // tells us at which turn / on which tool we stopped making progress.
+  // Gated on CI / explicit opt-in so local TUI runs stay quiet.
+  const heartbeatEnabled = !!(process.env.CI || process.env.PWNKIT_HEARTBEAT || process.env.PWNKIT_DEBUG);
+  const loopStartedAt = Date.now();
+  let lastToolName: string | null = null;
+
   // Context window compaction — allow re-compaction as context regrows
   let compactionCount = 0;
   let tokensAtLastCompaction = 0;
@@ -290,6 +297,16 @@ export async function runNativeAgentLoop(
       max_turns: config.maxTurns,
       role: config.role,
     });
+
+    if (heartbeatEnabled) {
+      const elapsed = ((Date.now() - loopStartedAt) / 1000).toFixed(1);
+      const inTok = state.totalUsage.inputTokens;
+      const outTok = state.totalUsage.outputTokens;
+      const cost = state.estimatedCostUsd.toFixed(4);
+      process.stderr.write(
+        `[pwnkit:hb] t=${elapsed}s role=${config.role} turn=${state.turnCount}/${config.maxTurns} tokens=${inTok}/${outTok} cost=$${cost} last_tool=${lastToolName ?? "-"}\n`,
+      );
+    }
 
     try {
 
@@ -539,6 +556,10 @@ export async function runNativeAgentLoop(
       (b): b is Extract<NativeContentBlock, { type: "tool_use" }> =>
         b.type === "tool_use",
     );
+
+    if (toolUseBlocks.length > 0) {
+      lastToolName = toolUseBlocks[toolUseBlocks.length - 1].name;
+    }
 
     // If no tool calls, the model responded with text only
     if (toolUseBlocks.length === 0) {

--- a/packages/core/src/unified-pipeline.ts
+++ b/packages/core/src/unified-pipeline.ts
@@ -935,6 +935,7 @@ export async function runPipeline(opts: PipelineOptions): Promise<PipelineReport
             try {
               const agentResult = await runAnalysisAgent({
                 role: "review",
+                purpose: "verify",
                 scopePath: prepared.scopePath,
                 target: prepared.resolvedTarget,
                 scanId: `${persistedScanId}-verify`,


### PR DESCRIPTION
## Summary
Diagnose and fix the recurring `Self-Scan` timeouts on `main` by attacking the actual root cause (verify-wave wall-clock), not bumping the timeout.

Two commits, observability-first:

### Commit 1 — `fix(agent): emit per-turn stderr heartbeat`
Two recent self-scan failures on `main` (Apr 30, May 1) hit the wrapper `timeout 480s` with **only the runtime init lines** in stderr — no signal about whether the agent was hung on a single LLM call, in a retry loop, or just slow. Bumping the timeout would mask the distinction.

This adds a one-line stderr heartbeat at each agent-loop turn boundary (both `native-loop.ts` and legacy `loop.ts`), gated on `CI` / `PWNKIT_HEARTBEAT` / `PWNKIT_DEBUG`:

```
[pwnkit:hb] t=12.4s role=review turn=3/15 tokens=15234/892 cost=$0.0421 last_tool=read_file
```

### Commit 2 — `fix(agent): cap verify-agent turns at 8`
Heartbeat data from the first dispatch run (run `25252805762`) revealed:

| Turn | Elapsed | Δ | Tokens (in) | Cost |
|------|---------|---|-------------|------|
| 1 | 0.0s | - | 0 | $0.00 |
| 9 | 48.7s | 6s/turn | 101K | $0.34 |
| 12 | 138.9s | **+47s** | 224K | $0.74 |
| 14 | 209.3s | **+60s** | 342K | $1.10 |
| 15 | 228.6s | +19s | 390K | $1.26 |

Per-turn LLM call duration grows from 5s → 60s as conversation history grows from 0 → 342K tokens (each turn re-sends the entire context). Research finishes in ~228-300s using `maxTurns=15`.

The May 1 push failure had `3 init lines` in stderr = **1 research + 2 verify agents**. Each verify agent gets the same 15-turn budget — but verifying one specific finding (file path + PoC + claimed severity) shouldn't need 15 turns. Wall-clock = research(~250s) + max(verify_durations)(~200s, parallel) = ~450-500s, right at the 480s cap.

Capping verify at 8 turns:
- Cuts verify-wave wall-clock by ~50% on findings>0 scans
- Doesn't touch research budget (still gets full depth-derived turns)
- Doesn't touch any timeout numbers (matches dd5d986 directive)

Adds `purpose: "research" | "verify"` to `AnalysisAgentOptions`, defaults to `"research"` so all existing call sites are unchanged. Only the verify call in `unified-pipeline.ts` is tagged.

## Test plan
- [x] `pnpm build` clean across all packages
- [x] `vitest run` — 746/747 pass (1 pre-existing failure on `main` per PR #196 notes, unrelated)
- [x] Smoke: `CI=1 vitest` confirms heartbeat lines fire, `last_tool` advances per turn
- [x] `workflow_dispatch` of Self-Scan on this branch (run `25252805762`) — full review, 0 findings, 298s total, all 15 heartbeat lines visible in CI log
- [ ] Second `workflow_dispatch` after verify-cap commit — confirms heartbeat still works and no regression on research timing
- [ ] Push to `main` is the only way to exercise `--changed-only` + verify together; verify-cap should land first then we observe the next push

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-turn CI heartbeat: when enabled via environment variables, agent runs write one diagnostic line per turn to stderr with elapsed time, role, turn counters, token usage, estimated cost, and the last-invoked tool.
  * Analysis "verify" mode: new purpose option applies stricter turn limits for verification runs (default behavior remains research).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->