### PR TITLE
ci: publish Docker image under repo org

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,23 +29,24 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        # The image is published under the personal `peaktwilight` namespace
-        # (`ghcr.io/peaktwilight/pwnkit`). The default `GITHUB_TOKEN` is scoped
-        # to the `PwnKit-Labs` org and cannot push to a personal-account
-        # namespace, so we authenticate with a personal access token
-        # (`write:packages`) supplied via the `GHCR_PEAKTWILIGHT_TOKEN`
-        # repository secret. See PR description for setup instructions.
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: peaktwilight
-          password: ${{ secrets.GHCR_PEAKTWILIGHT_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image name
+        id: image
+        run: |
+          set -euo pipefail
+          OWNER="$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')"
+          echo "name=ghcr.io/${OWNER}/pwnkit" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/peaktwilight/pwnkit
+          images: ${{ steps.image.outputs.name }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
@@ -55,7 +56,7 @@ jobs:
           labels: |
             org.opencontainers.image.title=pwnkit
             org.opencontainers.image.description=AI-powered agentic security scanner
-            org.opencontainers.image.source=https://github.com/peaktwilight/pwnkit
+            org.opencontainers.image.source=https://github.com/PwnKit-Labs/pwnkit
             org.opencontainers.image.licenses=Apache-2.0
 
       - name: Build and push

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Binaries ship for linux-x64, linux-arm64, darwin-arm64, and windows-x64. The int
 
 ```bash
 docker run --rm -e OPENROUTER_API_KEY=$KEY \
-  ghcr.io/peaktwilight/pwnkit:latest scan --target https://example.com
+  ghcr.io/pwnkit-labs/pwnkit:latest scan --target https://example.com
 ```
 
 If you use Azure OpenAI instead, also pass `AZURE_OPENAI_BASE_URL` and `AZURE_OPENAI_MODEL`. For the Responses API, the Azure base URL should include `/openai/v1`.

--- a/docs/src/content/docs/configuration.md
+++ b/docs/src/content/docs/configuration.md
@@ -162,7 +162,7 @@ control the container image, networking, and bootstrap behavior:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `PWNKIT_DOCKER_IMAGE` | `ghcr.io/PwnKit-Labs/pwnkit:latest` | Override the executor image |
+| `PWNKIT_DOCKER_IMAGE` | `ghcr.io/pwnkit-labs/pwnkit:latest` | Override the executor image |
 | `PWNKIT_DOCKER_NETWORK` | `bridge` | Docker network mode for the executor container |
 | `PWNKIT_DOCKER_BOOTSTRAP_TOOLS` | auto | Force or disable apt-based tool bootstrap inside the container |
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -168,7 +168,7 @@ npx pwnkit-cli scan --target https://example.com --mode web --race
 
 ### Kali Docker executor
 
-Enable `PWNKIT_FEATURE_DOCKER_EXECUTOR=1` to run every bash command inside a containerized pentest environment. By default, pwnkit now pulls the prebuilt GHCR image `ghcr.io/PwnKit-Labs/pwnkit:latest`, which already includes Node, Playwright/Chromium, and the standard pentest toolset. No host pollution, reproducible tool versions, and much faster startup than bootstrapping raw Kali on every run.
+Enable `PWNKIT_FEATURE_DOCKER_EXECUTOR=1` to run every bash command inside a containerized pentest environment. By default, pwnkit now pulls the prebuilt GHCR image `ghcr.io/pwnkit-labs/pwnkit:latest`, which already includes Node, Playwright/Chromium, and the standard pentest toolset. No host pollution, reproducible tool versions, and much faster startup than bootstrapping raw Kali on every run.
 
 ```bash
 export PWNKIT_FEATURE_DOCKER_EXECUTOR=1
@@ -179,7 +179,7 @@ Advanced overrides:
 
 ```bash
 # Force a specific image
-export PWNKIT_DOCKER_IMAGE=ghcr.io/PwnKit-Labs/pwnkit:latest
+export PWNKIT_DOCKER_IMAGE=ghcr.io/pwnkit-labs/pwnkit:latest
 
 # Force apt-based tool bootstrap even on a custom image
 export PWNKIT_DOCKER_BOOTSTRAP_TOOLS=1


### PR DESCRIPTION
## Summary
- publish the Docker image to the repository-owner GHCR namespace instead of the stale personal namespace
- authenticate GHCR pushes with the default GITHUB_TOKEN
- update Docker image references in README and docs to ghcr.io/pwnkit-labs/pwnkit:latest

Closes #174.

## Verification
- git diff --cached --check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docker-publish.yml'); puts 'yaml ok'"

Note: I did not run workflow_dispatch locally; that still needs to be verified by GitHub Actions after merge or from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker publishing workflow to use native GitHub Actions authentication instead of personal credentials.
  * Standardized Docker image registry path across configuration.

* **Documentation**
  * Updated Docker image references and corrected naming consistency in Quick Start, configuration, and getting-started guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->