### PR TITLE
feat: add deterministic CLI path traversal replay fixture

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -63,6 +63,7 @@ export default defineConfig({
             { label: "Agent Loop", slug: "agent-loop" },
             { label: "Finding Triage", slug: "triage" },
             { label: "Blind Verification", slug: "blind-verification" },
+            { label: "Verification Results", slug: "verification-result" },
             { label: "Adversarial Evals", slug: "adversarial-evals" },
           ],
         },

--- a/docs/src/content/docs/blind-verification.md
+++ b/docs/src/content/docs/blind-verification.md
@@ -80,6 +80,12 @@ When no API key is available, pwnkit falls back to a statistical heuristic. Inst
 
 This is a weaker signal than agentic verification, but it still filters out one-off flukes. Deterministic findings from structured checks (web baseline probes, MCP security checks) bypass this heuristic -- they are validated by direct HTTP response matching and don't need AI verification.
 
+Deterministic replay fixtures emit a structured
+[`verification_result`](/verification-result/) with command records, assertion
+results, artifact references, and a replay status. That status is an automated
+proof signal, not the human triage state for the finding. Maintainers can still
+accept, suppress, or reopen findings after reviewing the replay evidence.
+
 ## What gets killed
 
 In practice, blind verification kills 30-60% of raw findings from the attack stage. These are findings that a traditional scanner would report and a human would have to triage manually.

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -394,24 +394,28 @@ an LLM.
 # Replay PoC steps from a finding JSON
 npx pwnkit-cli verify --finding finding.json
 
-# Run the deterministic CLI path traversal fixture
-npx pwnkit-cli verify --fixture cli-path-traversal
+# Run the deterministic CLI path traversal fixture against the CLI under test
+npx pwnkit-cli verify --fixture cli-path-traversal \
+  --fixture-command '["paperclip","company","export","--api","{{apiUrl}}","--output","{{exportDir}}"]'
 
-# Keep the sandbox, harness script, and stdout/stderr logs
-npx pwnkit-cli verify --fixture cli-path-traversal --retain-artifacts
+# Keep the sandbox, harness metadata, and stdout/stderr logs
+npx pwnkit-cli verify --fixture cli-path-traversal \
+  --fixture-command '["paperclip","company","export","--api","{{apiUrl}}","--output","{{exportDir}}"]' \
+  --retain-artifacts
 ```
 
-The `cli-path-traversal` fixture starts a malicious local API, runs a
-Paperclip-style export CLI against a temp export directory, and checks that a
-marker file escapes the selected export root while staying inside the sandbox.
-Use `--fixture-mode patched` as a negative control; it rejects `../` paths and
-should return `status: "not_reproduced"`.
+The `cli-path-traversal` fixture starts a malicious local API and runs the
+caller-supplied CLI command against a temp export directory. The harness does
+not implement export behavior itself; it only supplies `{{apiUrl}}`,
+`{{exportDir}}`, records stdout/stderr, and checks that a marker file escapes
+the selected export root while staying inside the sandbox.
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--finding <path>` | Finding JSON with `pocSteps` to replay | |
 | `--target <path>` | Optional `PocExecutionTarget` JSON for PoC steps | |
 | `--fixture <name>` | Built-in deterministic fixture. Supported: `cli-path-traversal` | |
+| `--fixture-command <json>` | JSON argv array for the CLI under test. Supports `{{apiUrl}}`, `{{exportDir}}`, and `{{fixtureMode}}` placeholders | |
 | `--fixture-mode <mode>` | Fixture behavior: `vulnerable` or `patched` | `vulnerable` |
 | `--retain-artifacts` | Keep the fixture sandbox and log files | `false` |
 | `--artifact-dir <path>` | Use a specific fixture sandbox root | |

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -388,7 +388,8 @@ npx pwnkit-cli findings reopen <finding-id>
 
 Replay structured PoC steps or a built-in deterministic fixture and emit a
 `verification_result` JSON payload. The final assertion phase does not require
-an LLM.
+an LLM. See [Verification Results](/verification-result/) for the stable result
+schema.
 
 ```bash
 # Replay PoC steps from a finding JSON

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -384,6 +384,39 @@ npx pwnkit-cli findings reopen <finding-id>
 | `suppress <id>` | Suppress a finding (known FP or accepted risk) |
 | `reopen <id>` | Reopen a previously suppressed finding |
 
+## verify
+
+Replay structured PoC steps or a built-in deterministic fixture and emit a
+`verification_result` JSON payload. The final assertion phase does not require
+an LLM.
+
+```bash
+# Replay PoC steps from a finding JSON
+npx pwnkit-cli verify --finding finding.json
+
+# Run the deterministic CLI path traversal fixture
+npx pwnkit-cli verify --fixture cli-path-traversal
+
+# Keep the sandbox, harness script, and stdout/stderr logs
+npx pwnkit-cli verify --fixture cli-path-traversal --retain-artifacts
+```
+
+The `cli-path-traversal` fixture starts a malicious local API, runs a
+Paperclip-style export CLI against a temp export directory, and checks that a
+marker file escapes the selected export root while staying inside the sandbox.
+Use `--fixture-mode patched` as a negative control; it rejects `../` paths and
+should return `status: "not_reproduced"`.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--finding <path>` | Finding JSON with `pocSteps` to replay | |
+| `--target <path>` | Optional `PocExecutionTarget` JSON for PoC steps | |
+| `--fixture <name>` | Built-in deterministic fixture. Supported: `cli-path-traversal` | |
+| `--fixture-mode <mode>` | Fixture behavior: `vulnerable` or `patched` | `vulnerable` |
+| `--retain-artifacts` | Keep the fixture sandbox and log files | `false` |
+| `--artifact-dir <path>` | Use a specific fixture sandbox root | |
+| `--output <path>` | Write JSON to a file instead of stdout | |
+
 ## XBOW benchmark runner
 
 The XBOW benchmark runner lives in `packages/benchmark` and is invoked with `pnpm --filter @pwnkit/benchmark xbow`. It runs pwnkit against the 104 XBOW validation challenges and reports pass/fail with evidence.

--- a/docs/src/content/docs/commands.md
+++ b/docs/src/content/docs/commands.md
@@ -414,8 +414,8 @@ the selected export root while staying inside the sandbox.
 |------|-------------|---------|
 | `--finding <path>` | Finding JSON with `pocSteps` to replay | |
 | `--target <path>` | Optional `PocExecutionTarget` JSON for PoC steps | |
-| `--fixture <name>` | Built-in deterministic fixture. Supported: `cli-path-traversal` | |
-| `--fixture-command <json>` | JSON argv array for the CLI under test. Supports `{{apiUrl}}`, `{{exportDir}}`, and `{{fixtureMode}}` placeholders | |
+| `--fixture <name>` | Built-in deterministic fixture. Supported: `cli-path-traversal`; this fixture requires `--fixture-command` | |
+| `--fixture-command <json>` | JSON argv array for the CLI under test. Required when `--fixture=cli-path-traversal`. Supports `{{apiUrl}}`, `{{exportDir}}`, and `{{fixtureMode}}` placeholders | |
 | `--fixture-mode <mode>` | Fixture behavior: `vulnerable` or `patched` | `vulnerable` |
 | `--retain-artifacts` | Keep the fixture sandbox and log files | `false` |
 | `--artifact-dir <path>` | Use a specific fixture sandbox root | |

--- a/docs/src/content/docs/verification-result.md
+++ b/docs/src/content/docs/verification-result.md
@@ -1,0 +1,200 @@
+---
+title: Verification Results
+description: Stable JSON contract emitted by deterministic replay verifiers.
+---
+
+Deterministic verification emits a `verification_result` JSON object. The object
+is evidence produced by the open-source engine after it runs a replay harness and
+checks concrete assertions. It is separate from human triage and finding
+lifecycle state.
+
+The schema is designed to be stored by local CI, reproduced by maintainers, and
+ingested by cloud systems without reimplementing the exploit logic.
+
+## Result schema
+
+The first version uses this shape:
+
+```typescript
+type VerificationStatus =
+  | "reproduced"
+  | "not_reproduced"
+  | "inconclusive"
+  | "error";
+
+interface VerificationCommand {
+  argv: string[];
+  exit_code: number | null;
+  stdout_excerpt: string;
+  stderr_excerpt: string;
+}
+
+interface VerificationAssertion {
+  kind: string;
+  passed: boolean;
+  detail: string;
+}
+
+interface VerificationResult {
+  status: VerificationStatus;
+  mode: "deterministic_replay";
+  finding_id: string;
+  engine_version: string;
+  started_at: string;
+  completed_at: string;
+  commands: VerificationCommand[];
+  assertions: VerificationAssertion[];
+  artifacts: Record<string, string>;
+  summary: string;
+  error_reason: string | null;
+}
+```
+
+Fields may be added over time. Consumers should treat the fields above as the
+minimum stable contract and ignore unknown fields.
+
+## Status semantics
+
+| Status | Meaning |
+|--------|---------|
+| `reproduced` | The replay ran far enough to evaluate the verifier's concrete assertions, and the required exploit assertions passed. |
+| `not_reproduced` | The replay ran far enough to evaluate the verifier's concrete assertions, but the exploit condition was not observed. A secure CLI that rejects malicious input can still exit non-zero and produce this status when filesystem assertions prove no escape happened. |
+| `inconclusive` | The verifier reached the target but did not have enough assertion evidence to prove or disprove the finding. |
+| `error` | The verifier failed before it could produce a reliable assertion result, for example malformed input, setup failure, an unlaunchable command, or a timeout before useful assertions were available. |
+
+Do not use `verification_result.status` as the finding's human triage state.
+It is an automated proof signal. A maintainer can still accept, suppress, or
+reopen a finding after reviewing the evidence.
+
+## Commands
+
+Each command record captures the real command that the verifier executed:
+
+```json
+{
+  "argv": [
+    "paperclip",
+    "company",
+    "export",
+    "--api",
+    "http://127.0.0.1:50345",
+    "--output",
+    "/tmp/pwnkit-verify-a1b2/export"
+  ],
+  "exit_code": 0,
+  "stdout_excerpt": "wrote /tmp/pwnkit-verify-a1b2/escaped-marker\n",
+  "stderr_excerpt": ""
+}
+```
+
+`argv` must point at the implementation under test. A deterministic fixture may
+provide servers, files, directories, and placeholders, but it must not synthesize
+the vulnerable behavior that the finding is supposed to verify.
+
+## Assertions
+
+Assertions are the machine-checkable facts that turn a replay into a verdict.
+The CLI path traversal fixture uses filesystem assertions such as:
+
+| Kind | Purpose |
+|------|---------|
+| `filesystem_exists` | A marker file exists at the escaped path. |
+| `filesystem_not_exists` | The marker was not written inside the selected export root. |
+| `path_outside_export_root` | The escaped marker realpath is outside the export directory. |
+| `path_inside_sandbox` | The escaped marker stayed inside the verifier sandbox. |
+| `no_home_profile_touch` | The replay did not write to the user's home directory or shell profile files. |
+
+The final assertion phase is deterministic code, not an LLM judgement.
+
+## Artifacts
+
+`artifacts` contains references that let a maintainer inspect or reproduce the
+run. For local runs these are paths; for cloud runs they can be storage keys or
+other retrievable references.
+
+Common artifact keys are:
+
+| Key | Meaning |
+|-----|---------|
+| `sandbox_ref` | Root directory for the isolated replay sandbox. |
+| `harness_ref` | Harness metadata, including fixture name and expanded command argv. |
+| `stdout_ref` | Full stdout log for the executed command. |
+| `stderr_ref` | Full stderr log for the executed command. |
+| `export_ref` | Fixture-specific export directory or output root. |
+
+The CLI cleans temporary sandboxes by default. Use `--retain-artifacts` or
+`--artifact-dir` when full logs and harness files need to survive after the run.
+
+## CLI path traversal example
+
+The `cli-path-traversal` fixture starts a malicious local API, creates a
+sandboxed export directory, and runs the real CLI argv supplied through
+`--fixture-command`.
+
+```bash
+npx pwnkit-cli verify --fixture cli-path-traversal \
+  --fixture-command '["paperclip","company","export","--api","{{apiUrl}}","--output","{{exportDir}}"]' \
+  --retain-artifacts
+```
+
+Example result:
+
+```json
+{
+  "status": "reproduced",
+  "mode": "deterministic_replay",
+  "finding_id": "fixture:cli-path-traversal",
+  "engine_version": "0.7.13",
+  "started_at": "2026-05-06T07:23:02.223Z",
+  "completed_at": "2026-05-06T07:23:02.510Z",
+  "commands": [
+    {
+      "argv": [
+        "paperclip",
+        "company",
+        "export",
+        "--api",
+        "http://127.0.0.1:50345",
+        "--output",
+        "/tmp/pwnkit-verify-a1b2/export"
+      ],
+      "exit_code": 0,
+      "stdout_excerpt": "wrote /tmp/pwnkit-verify-a1b2/escaped-marker\n",
+      "stderr_excerpt": ""
+    }
+  ],
+  "assertions": [
+    {
+      "kind": "filesystem_exists",
+      "passed": true,
+      "detail": "escaped marker exists at /tmp/pwnkit-verify-a1b2/escaped-marker"
+    },
+    {
+      "kind": "path_outside_export_root",
+      "passed": true,
+      "detail": "escaped marker realpath /tmp/pwnkit-verify-a1b2/escaped-marker is outside export root /tmp/pwnkit-verify-a1b2/export"
+    },
+    {
+      "kind": "path_inside_sandbox",
+      "passed": true,
+      "detail": "escaped marker stayed inside sandbox /tmp/pwnkit-verify-a1b2"
+    }
+  ],
+  "artifacts": {
+    "sandbox_ref": "/tmp/pwnkit-verify-a1b2",
+    "harness_ref": "/tmp/pwnkit-verify-a1b2/harness/harness.json",
+    "stdout_ref": "/tmp/pwnkit-verify-a1b2/stdout.log",
+    "stderr_ref": "/tmp/pwnkit-verify-a1b2/stderr.log",
+    "export_ref": "/tmp/pwnkit-verify-a1b2/export"
+  },
+  "summary": "CLI path traversal replay wrote a marker outside the selected export directory inside the sandbox.",
+  "error_reason": null
+}
+```
+
+## Cloud ingestion
+
+Cloud systems should schedule runs, persist `verification_result` payloads, show
+the commands, assertions, and artifact references, and gate downstream workflows
+on explicit proof signals. They should treat this OSS schema as the source of
+truth for verifier semantics instead of implementing separate replay logic.

--- a/packages/cli/src/commands/__tests__/verify.test.ts
+++ b/packages/cli/src/commands/__tests__/verify.test.ts
@@ -374,6 +374,19 @@ describe("runVerify", () => {
     expect(existsSync(outcome.result.artifacts.stderr_ref)).toBe(true);
     expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
   });
+
+  it("rejects --fixture-mode when --fixture is not set", async () => {
+    const findingPath = writeFinding(makeFinding());
+    const outcome = await runVerify({
+      findingPath,
+      fixtureMode: "patched",
+    });
+
+    expect(outcome.exitCode).toBe(3);
+    expect(outcome.result.status).toBe("error");
+    expect(outcome.result.error_reason).toBe("--fixture-mode is only supported with --fixture");
+    expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
+  });
 });
 
 // ── Workspace isolation tests (CodeRabbit #194 — cwd safety) ────────────────

--- a/packages/cli/src/commands/__tests__/verify.test.ts
+++ b/packages/cli/src/commands/__tests__/verify.test.ts
@@ -93,6 +93,59 @@ function writeFinding(finding: Finding): string {
   return path;
 }
 
+function writeTestExportCli(): string {
+  const path = join(tmpRoot, "test-export-cli.mjs");
+  writeFileSync(
+    path,
+    `#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) out[argv[i].slice(2)] = argv[i + 1];
+  return out;
+}
+function isInside(root, candidate) {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const body = await fetch(new URL("/company/export", args.api)).then((r) => r.json());
+const root = resolve(args.output);
+await mkdir(root, { recursive: true });
+let blocked = false;
+for (const [name, content] of Object.entries(body.files || {})) {
+  const destination = resolve(root, name);
+  if (args.mode === "patched" && !isInside(root, destination)) {
+    console.error("blocked path traversal: " + name);
+    blocked = true;
+    continue;
+  }
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, String(content), "utf8");
+  console.log("wrote " + destination);
+}
+if (blocked) process.exitCode = 1;
+`,
+    { encoding: "utf8", mode: 0o755 },
+  );
+  return path;
+}
+
+function testExportCliArgv(): string[] {
+  return [
+    process.execPath,
+    writeTestExportCli(),
+    "--api",
+    "{{apiUrl}}",
+    "--output",
+    "{{exportDir}}",
+    "--mode",
+    "{{fixtureMode}}",
+  ];
+}
+
 // ── Fake spawn helper ───────────────────────────────────────────────────────
 
 class FakeChild extends EventEmitter {
@@ -333,6 +386,7 @@ describe("runVerify", () => {
   it("runs the built-in cli-path-traversal fixture and reports reproduced", async () => {
     const outcome = await runVerify({
       fixture: "cli-path-traversal",
+      fixtureCommand: testExportCliArgv(),
       fixtureMode: "vulnerable",
     });
 
@@ -348,6 +402,7 @@ describe("runVerify", () => {
   it("runs the patched cli-path-traversal fixture as the negative control", async () => {
     const outcome = await runVerify({
       fixture: "cli-path-traversal",
+      fixtureCommand: testExportCliArgv(),
       fixtureMode: "patched",
     });
 
@@ -362,6 +417,7 @@ describe("runVerify", () => {
     const artifactDir = join(tmpRoot, "retained-fixture");
     const outcome = await runVerify({
       fixture: "cli-path-traversal",
+      fixtureCommand: testExportCliArgv(),
       retainArtifacts: true,
       artifactDir,
     });
@@ -372,6 +428,17 @@ describe("runVerify", () => {
     expect(existsSync(outcome.result.artifacts.harness_ref)).toBe(true);
     expect(existsSync(outcome.result.artifacts.stdout_ref)).toBe(true);
     expect(existsSync(outcome.result.artifacts.stderr_ref)).toBe(true);
+    expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
+  });
+
+  it("requires --fixture-command when --fixture is set", async () => {
+    const outcome = await runVerify({
+      fixture: "cli-path-traversal",
+    });
+
+    expect(outcome.exitCode).toBe(3);
+    expect(outcome.result.status).toBe("error");
+    expect(outcome.result.error_reason).toBe("--fixture-command is required with --fixture");
     expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
   });
 

--- a/packages/cli/src/commands/__tests__/verify.test.ts
+++ b/packages/cli/src/commands/__tests__/verify.test.ts
@@ -54,6 +54,7 @@ const verificationResultSchema = z.object({
       detail: z.string(),
     }),
   ),
+  artifacts: z.record(z.string()),
   summary: z.string(),
   error_reason: z.union([z.string(), z.null()]),
 });
@@ -327,6 +328,51 @@ describe("runVerify", () => {
     writeFileSync(outPath, JSON.stringify(outcome.result, null, 2), "utf8");
     const parsed: VerificationResult = JSON.parse(readFileSync(outPath, "utf8"));
     expect(verificationResultSchema.parse(parsed)).toEqual(parsed);
+  });
+
+  it("runs the built-in cli-path-traversal fixture and reports reproduced", async () => {
+    const outcome = await runVerify({
+      fixture: "cli-path-traversal",
+      fixtureMode: "vulnerable",
+    });
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.result.status).toBe("reproduced");
+    expect(outcome.result.finding_id).toBe("fixture:cli-path-traversal");
+    expect(outcome.result.commands).toHaveLength(1);
+    expect(outcome.result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(true);
+    expect(outcome.result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(true);
+    expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
+  });
+
+  it("runs the patched cli-path-traversal fixture as the negative control", async () => {
+    const outcome = await runVerify({
+      fixture: "cli-path-traversal",
+      fixtureMode: "patched",
+    });
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.result.status).toBe("not_reproduced");
+    expect(outcome.result.commands[0].stderr_excerpt).toContain("blocked path traversal");
+    expect(outcome.result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(false);
+    expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
+  });
+
+  it("retains fixture artifacts when requested", async () => {
+    const artifactDir = join(tmpRoot, "retained-fixture");
+    const outcome = await runVerify({
+      fixture: "cli-path-traversal",
+      retainArtifacts: true,
+      artifactDir,
+    });
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.result.artifacts.sandbox_ref).toBe(artifactDir);
+    expect(outcome.result.artifacts.harness_ref).toBeTruthy();
+    expect(existsSync(outcome.result.artifacts.harness_ref)).toBe(true);
+    expect(existsSync(outcome.result.artifacts.stdout_ref)).toBe(true);
+    expect(existsSync(outcome.result.artifacts.stderr_ref)).toBe(true);
+    expect(verificationResultSchema.parse(outcome.result)).toEqual(outcome.result);
   });
 });
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -581,7 +581,6 @@ export function registerVerifyCommand(program: Command): void {
     .option(
       "--fixture-mode <mode>",
       "Fixture behavior for --fixture: vulnerable or patched.",
-      "vulnerable",
     )
     .option(
       "--retain-artifacts",

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -25,6 +25,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import {
   executePocSteps,
+  runCliPathTraversalReplayFixture,
   type PocExecutionReport,
   type PocExecutionTarget,
   type PocStepResult,
@@ -62,6 +63,7 @@ export interface VerificationResult {
   completed_at: string;
   commands: VerificationCommand[];
   assertions: VerificationAssertion[];
+  artifacts: Record<string, string>;
   summary: string;
   error_reason: string | null;
 }
@@ -229,6 +231,7 @@ export function buildVerificationResult(args: {
     completed_at: completedAt,
     commands,
     assertions,
+    artifacts: {},
     summary: defaultSummary(status, ran, total),
     error_reason: null,
   };
@@ -263,6 +266,7 @@ export function buildNoStepsResult(args: {
     completed_at: args.completedAt,
     commands: [],
     assertions: [],
+    artifacts: {},
     summary: "No PoC steps to execute",
     error_reason: null,
   };
@@ -286,6 +290,7 @@ export function buildErrorResult(args: {
     completed_at: args.completedAt,
     commands: [],
     assertions: [],
+    artifacts: {},
     summary: "Verifier failed before reaching a verdict.",
     error_reason: reason,
   };
@@ -298,6 +303,10 @@ interface VerifyOpts {
   findingId?: string;
   bundle?: string;
   target?: string;
+  fixture?: string;
+  fixtureMode?: string;
+  retainArtifacts?: boolean;
+  artifactDir?: string;
   format?: string;
   output?: string;
 }
@@ -366,13 +375,46 @@ function allocateIsolatedWorkspace(): { cwd: string; cleanup: () => void } {
  * caller's `process.cwd()`.
  */
 export async function runVerify(opts: {
-  findingPath: string;
+  findingPath?: string;
   targetPath?: string;
+  fixture?: string;
+  fixtureMode?: string;
+  retainArtifacts?: boolean;
+  artifactDir?: string;
 }): Promise<VerifyOutcome> {
   const startedAt = new Date().toISOString();
   let finding: Finding | null = null;
   let cleanup: (() => void) | undefined;
   try {
+    if (opts.fixture) {
+      if (opts.fixture !== "cli-path-traversal") {
+        throw new Error(
+          `unsupported fixture '${opts.fixture}', supported fixtures: cli-path-traversal`,
+        );
+      }
+      if (
+        opts.fixtureMode &&
+        opts.fixtureMode !== "vulnerable" &&
+        opts.fixtureMode !== "patched"
+      ) {
+        throw new Error(
+          `unsupported --fixture-mode '${opts.fixtureMode}', expected 'vulnerable' or 'patched'`,
+        );
+      }
+      const result = await runCliPathTraversalReplayFixture({
+        fixtureMode:
+          opts.fixtureMode === "patched" ? "patched" : "vulnerable",
+        retainArtifacts: opts.retainArtifacts,
+        artifactDir: opts.artifactDir,
+        engineVersion: VERSION,
+      });
+      return { result, exitCode: exitCodeForStatus(result.status) };
+    }
+
+    if (!opts.findingPath) {
+      throw new Error("missing required flag: --finding <path>");
+    }
+
     finding = readJson<Finding>(opts.findingPath, "finding");
     if (!finding || typeof finding !== "object" || !finding.id) {
       throw new Error(
@@ -437,7 +479,13 @@ async function verifyAction(opts: VerifyOpts): Promise<void> {
       "--finding-id / --bundle is reserved for a follow-up. Use --finding <path> for now.",
     );
   }
-  if (!opts.finding) {
+  if (opts.fixture && opts.finding) {
+    throw new Error("--fixture and --finding are mutually exclusive");
+  }
+  if ((opts.retainArtifacts || opts.artifactDir) && !opts.fixture) {
+    throw new Error("--retain-artifacts / --artifact-dir are only supported with --fixture");
+  }
+  if (!opts.finding && !opts.fixture) {
     throw new Error("missing required flag: --finding <path>");
   }
   if (opts.format && opts.format !== "json") {
@@ -447,6 +495,10 @@ async function verifyAction(opts: VerifyOpts): Promise<void> {
   const outcome = await runVerify({
     findingPath: opts.finding,
     targetPath: opts.target,
+    fixture: opts.fixture,
+    fixtureMode: opts.fixtureMode,
+    retainArtifacts: opts.retainArtifacts,
+    artifactDir: opts.artifactDir,
   });
 
   const json = JSON.stringify(outcome.result, null, 2);
@@ -480,6 +532,24 @@ export function registerVerifyCommand(program: Command): void {
       "--target <path>",
       "Path to a target.json (PocExecutionTarget: baseUrl, env, cwd, timeoutMs, personas).",
     )
+    .option(
+      "--fixture <name>",
+      "Run a built-in deterministic replay fixture. Supported: cli-path-traversal.",
+    )
+    .option(
+      "--fixture-mode <mode>",
+      "Fixture behavior for --fixture: vulnerable or patched.",
+      "vulnerable",
+    )
+    .option(
+      "--retain-artifacts",
+      "Keep the fixture sandbox, harness script, and stdout/stderr logs.",
+      false,
+    )
+    .option(
+      "--artifact-dir <path>",
+      "Use this directory as the fixture sandbox root.",
+    )
     .option("--format <fmt>", "Output format. Only 'json' is supported.", "json")
     .option(
       "--output <path>",
@@ -502,6 +572,7 @@ export function registerVerifyCommand(program: Command): void {
           completed_at: now,
           commands: [],
           assertions: [],
+          artifacts: {},
           summary: "Verifier failed before reaching a verdict.",
           error_reason: reason,
         };

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -304,6 +304,7 @@ interface VerifyOpts {
   bundle?: string;
   target?: string;
   fixture?: string;
+  fixtureCommand?: string;
   fixtureMode?: string;
   retainArtifacts?: boolean;
   artifactDir?: string;
@@ -328,6 +329,26 @@ function readJson<T>(path: string, kind: string): T {
       `failed to parse ${kind} as JSON (${abs}): ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+function parseFixtureCommand(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `failed to parse --fixture-command as JSON argv array: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (
+    !Array.isArray(parsed) ||
+    parsed.length === 0 ||
+    !parsed.every((item) => typeof item === "string" && item.length > 0)
+  ) {
+    throw new Error("--fixture-command must be a non-empty JSON array of strings");
+  }
+  return parsed;
 }
 
 // ── Main entry point ────────────────────────────────────────────────────────
@@ -378,6 +399,7 @@ export async function runVerify(opts: {
   findingPath?: string;
   targetPath?: string;
   fixture?: string;
+  fixtureCommand?: string[];
   fixtureMode?: string;
   retainArtifacts?: boolean;
   artifactDir?: string;
@@ -401,7 +423,11 @@ export async function runVerify(opts: {
           `unsupported --fixture-mode '${opts.fixtureMode}', expected 'vulnerable' or 'patched'`,
         );
       }
+      if (!opts.fixtureCommand || opts.fixtureCommand.length === 0) {
+        throw new Error("--fixture-command is required with --fixture");
+      }
       const result = await runCliPathTraversalReplayFixture({
+        commandArgv: opts.fixtureCommand,
         fixtureMode:
           opts.fixtureMode === "patched" ? "patched" : "vulnerable",
         retainArtifacts: opts.retainArtifacts,
@@ -486,6 +512,9 @@ async function verifyAction(opts: VerifyOpts): Promise<void> {
   if (opts.fixture && opts.finding) {
     throw new Error("--fixture and --finding are mutually exclusive");
   }
+  if (opts.fixtureCommand && !opts.fixture) {
+    throw new Error("--fixture-command is only supported with --fixture");
+  }
   if (opts.fixtureMode && !opts.fixture) {
     throw new Error("--fixture-mode is only supported with --fixture");
   }
@@ -498,11 +527,13 @@ async function verifyAction(opts: VerifyOpts): Promise<void> {
   if (opts.format && opts.format !== "json") {
     throw new Error(`unsupported --format '${opts.format}', only 'json' is supported`);
   }
+  const fixtureCommand = parseFixtureCommand(opts.fixtureCommand);
 
   const outcome = await runVerify({
     findingPath: opts.finding,
     targetPath: opts.target,
     fixture: opts.fixture,
+    fixtureCommand,
     fixtureMode: opts.fixtureMode,
     retainArtifacts: opts.retainArtifacts,
     artifactDir: opts.artifactDir,
@@ -544,13 +575,17 @@ export function registerVerifyCommand(program: Command): void {
       "Run a built-in deterministic replay fixture. Supported: cli-path-traversal.",
     )
     .option(
+      "--fixture-command <json>",
+      "JSON argv array for the CLI under test. Supports {{apiUrl}}, {{exportDir}}, and {{fixtureMode}} placeholders.",
+    )
+    .option(
       "--fixture-mode <mode>",
       "Fixture behavior for --fixture: vulnerable or patched.",
       "vulnerable",
     )
     .option(
       "--retain-artifacts",
-      "Keep the fixture sandbox, harness script, and stdout/stderr logs.",
+      "Keep the fixture sandbox, harness metadata, and stdout/stderr logs.",
       false,
     )
     .option(

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -411,6 +411,10 @@ export async function runVerify(opts: {
       return { result, exitCode: exitCodeForStatus(result.status) };
     }
 
+    if (opts.fixtureMode) {
+      throw new Error("--fixture-mode is only supported with --fixture");
+    }
+
     if (!opts.findingPath) {
       throw new Error("missing required flag: --finding <path>");
     }
@@ -481,6 +485,9 @@ async function verifyAction(opts: VerifyOpts): Promise<void> {
   }
   if (opts.fixture && opts.finding) {
     throw new Error("--fixture and --finding are mutually exclusive");
+  }
+  if (opts.fixtureMode && !opts.fixture) {
+    throw new Error("--fixture-mode is only supported with --fixture");
   }
   if ((opts.retainArtifacts || opts.artifactDir) && !opts.fixture) {
     throw new Error("--retain-artifacts / --artifact-dir are only supported with --fixture");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,8 +158,19 @@ export type { LiveAgentState } from "./agent/live-agent-state.js";
 // finding's `verificationSpec` predicates against a repo on disk so cloud's
 // canary watcher (and any OSS caller) can deterministically decide whether
 // a finding is still real after upstream changes.
-export { evaluateVerificationSpec } from "./verification/index.js";
-export type { PredicateResult, VerificationResult } from "./verification/index.js";
+export {
+  evaluateVerificationSpec,
+  runCliPathTraversalReplayFixture,
+} from "./verification/index.js";
+export type {
+  CliPathTraversalFixtureOptions,
+  DeterministicReplayResult,
+  PredicateResult,
+  ReplayAssertion,
+  ReplayCommand,
+  ReplayStatus,
+  VerificationResult,
+} from "./verification/index.js";
 
 // Disclosure bundle assembly (finding → GHSA-ready advisory markdown)
 export { suggestCwesForCategory, formatCweSection, suggestCvss, renderAdvisoryMarkdown, renderExploitScreenshot, isFreezeAvailable, composeExploitSession, composeStepSession, verifyAgainstRef, extractFileRefs, formatPatchStatusSection, detectVersionRange, formatVersionRangeLine, extractSiblingFix, executePocSteps, setRuntimeDeps, MAX_CAPTURE_BYTES, DEFAULT_STEP_TIMEOUT_MS, decideFilingState, assembleBundleIndex, formatDroppedReason, droppedFilename, dropSlug } from "./disclose/index.js";

--- a/packages/core/src/verification/cli-path-traversal-fixture.test.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCliPathTraversalReplayFixture } from "./cli-path-traversal-fixture.js";
@@ -159,5 +159,51 @@ describe("runCliPathTraversalReplayFixture", () => {
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
     }
+  });
+
+  it("preserves command output when post-command artifact writes fail", async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "pwnkit-fixture-postcmd-error-"));
+    const cliRoot = mkdtempSync(join(tmpdir(), "pwnkit-fixture-cli-"));
+    try {
+      mkdirSync(join(sandbox, "stdout.log"));
+      const cliPath = writeTestExportCli(cliRoot);
+
+      const result = await runCliPathTraversalReplayFixture({
+        commandArgv: testExportCliArgv(cliPath),
+        artifactDir: sandbox,
+        retainArtifacts: true,
+        engineVersion: "test",
+      });
+
+      expect(result.status).toBe("error");
+      expect(result.commands).toHaveLength(1);
+      expect(result.commands[0].argv).toContain(cliPath);
+      expect(result.commands[0].exit_code).toBe(0);
+      expect(result.commands[0].stdout_excerpt).toContain("escaped-marker");
+      expect(result.error_reason).toBeTruthy();
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+      rmSync(cliRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("finishes when a command ignores SIGTERM past the timeout", async () => {
+    const result = await runCliPathTraversalReplayFixture({
+      commandArgv: [
+        process.execPath,
+        "--input-type=module",
+        "-e",
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+      ],
+      timeoutMs: 200,
+      engineVersion: "test",
+    });
+
+    expect(result.status).toBe("not_reproduced");
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0].exit_code).toBeNull();
+    expect(result.assertions.find((a) => a.kind === "command_exit_zero")?.detail).toContain(
+      "did not exit after SIGTERM",
+    );
   });
 });

--- a/packages/core/src/verification/cli-path-traversal-fixture.test.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.test.ts
@@ -4,47 +4,120 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCliPathTraversalReplayFixture } from "./cli-path-traversal-fixture.js";
 
+function writeTestExportCli(dir: string): string {
+  const path = join(dir, "test-export-cli.mjs");
+  writeFileSync(
+    path,
+    `#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    out[argv[i].slice(2)] = argv[i + 1];
+  }
+  return out;
+}
+
+function isInside(root, candidate) {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const body = await fetch(new URL("/company/export", args.api)).then((r) => r.json());
+const root = resolve(args.output);
+await mkdir(root, { recursive: true });
+let blocked = false;
+for (const [name, content] of Object.entries(body.files || {})) {
+  const destination = resolve(root, name);
+  if (args.mode === "patched" && !isInside(root, destination)) {
+    console.error("blocked path traversal: " + name);
+    blocked = true;
+    continue;
+  }
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, String(content), "utf8");
+  console.log("wrote " + destination);
+}
+if (blocked) process.exitCode = 1;
+`,
+    { encoding: "utf8", mode: 0o755 },
+  );
+  return path;
+}
+
+function testExportCliArgv(cliPath: string): string[] {
+  return [
+    process.execPath,
+    cliPath,
+    "--api",
+    "{{apiUrl}}",
+    "--output",
+    "{{exportDir}}",
+    "--mode",
+    "{{fixtureMode}}",
+  ];
+}
+
 describe("runCliPathTraversalReplayFixture", () => {
   it("reproduces the vulnerable Paperclip-style export traversal", async () => {
-    const result = await runCliPathTraversalReplayFixture({
-      fixtureMode: "vulnerable",
-      engineVersion: "test",
-    });
+    const cliRoot = mkdtempSync(join(tmpdir(), "pwnkit-fixture-cli-"));
+    try {
+      const cliPath = writeTestExportCli(cliRoot);
+      const result = await runCliPathTraversalReplayFixture({
+        commandArgv: testExportCliArgv(cliPath),
+        fixtureMode: "vulnerable",
+        engineVersion: "test",
+      });
 
-    expect(result.status).toBe("reproduced");
-    expect(result.mode).toBe("deterministic_replay");
-    expect(result.finding_id).toBe("fixture:cli-path-traversal");
-    expect(result.commands).toHaveLength(1);
-    expect(result.commands[0].argv).toContain("--output");
-    expect(result.commands[0].exit_code).toBe(0);
-    expect(result.commands[0].stdout_excerpt).toContain("escaped-marker");
-    expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(true);
-    expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(true);
-    expect(result.assertions.find((a) => a.kind === "path_inside_sandbox")?.passed).toBe(true);
-    expect(result.artifacts).toEqual({});
-    const escapedDetail = result.assertions.find((a) => a.kind === "filesystem_exists")?.detail ?? "";
-    const escapedPath = escapedDetail.replace(/^escaped marker exists at /, "");
-    const sandbox = dirname(escapedPath);
-    expect(existsSync(sandbox)).toBe(false);
+      expect(result.status).toBe("reproduced");
+      expect(result.mode).toBe("deterministic_replay");
+      expect(result.finding_id).toBe("fixture:cli-path-traversal");
+      expect(result.commands).toHaveLength(1);
+      expect(result.commands[0].argv).toContain("--output");
+      expect(result.commands[0].exit_code).toBe(0);
+      expect(result.commands[0].stdout_excerpt).toContain("escaped-marker");
+      expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(true);
+      expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(true);
+      expect(result.assertions.find((a) => a.kind === "path_inside_sandbox")?.passed).toBe(true);
+      expect(result.artifacts).toEqual({});
+      const escapedDetail = result.assertions.find((a) => a.kind === "filesystem_exists")?.detail ?? "";
+      const escapedPath = escapedDetail.replace(/^escaped marker exists at /, "");
+      const sandbox = dirname(escapedPath);
+      expect(existsSync(sandbox)).toBe(false);
+    } finally {
+      rmSync(cliRoot, { recursive: true, force: true });
+    }
   });
 
   it("returns not_reproduced when the fixture CLI rejects traversal", async () => {
-    const result = await runCliPathTraversalReplayFixture({
-      fixtureMode: "patched",
-      engineVersion: "test",
-    });
+    const cliRoot = mkdtempSync(join(tmpdir(), "pwnkit-fixture-cli-"));
+    try {
+      const cliPath = writeTestExportCli(cliRoot);
+      const result = await runCliPathTraversalReplayFixture({
+        commandArgv: testExportCliArgv(cliPath),
+        fixtureMode: "patched",
+        engineVersion: "test",
+      });
 
-    expect(result.status).toBe("not_reproduced");
-    expect(result.commands[0].exit_code).toBe(1);
-    expect(result.commands[0].stderr_excerpt).toContain("blocked path traversal");
-    expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(false);
-    expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(false);
+      expect(result.status).toBe("not_reproduced");
+      expect(result.commands[0].exit_code).toBe(1);
+      expect(result.commands[0].stderr_excerpt).toContain("blocked path traversal");
+      expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(false);
+      expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(false);
+    } finally {
+      rmSync(cliRoot, { recursive: true, force: true });
+    }
   });
 
   it("retains the sandbox and artifact refs when requested", async () => {
     const sandbox = mkdtempSync(join(tmpdir(), "pwnkit-fixture-retain-"));
+    const cliRoot = mkdtempSync(join(tmpdir(), "pwnkit-fixture-cli-"));
     try {
+      const cliPath = writeTestExportCli(cliRoot);
       const result = await runCliPathTraversalReplayFixture({
+        commandArgv: testExportCliArgv(cliPath),
         artifactDir: sandbox,
         retainArtifacts: true,
         engineVersion: "test",
@@ -61,6 +134,7 @@ describe("runCliPathTraversalReplayFixture", () => {
       expect(existsSync(result.artifacts.stderr_ref)).toBe(true);
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
+      rmSync(cliRoot, { recursive: true, force: true });
     }
   });
 
@@ -79,7 +153,7 @@ describe("runCliPathTraversalReplayFixture", () => {
       expect(result.commands).toEqual([]);
       expect(result.artifacts.sandbox_ref).toBe(sandbox);
       expect(result.artifacts.export_ref).toBe(join(sandbox, "export"));
-      expect(result.artifacts.harness_ref).toBe(join(sandbox, "harness", "paperclip-export-fixture.mjs"));
+      expect(result.artifacts.harness_ref).toBe(join(sandbox, "harness", "harness.json"));
       expect(result.artifacts.stdout_ref).toBe(join(sandbox, "stdout.log"));
       expect(result.artifacts.stderr_ref).toBe(join(sandbox, "stderr.log"));
     } finally {

--- a/packages/core/src/verification/cli-path-traversal-fixture.test.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCliPathTraversalReplayFixture } from "./cli-path-traversal-fixture.js";
@@ -35,7 +35,7 @@ describe("runCliPathTraversalReplayFixture", () => {
     });
 
     expect(result.status).toBe("not_reproduced");
-    expect(result.commands[0].exit_code).toBe(0);
+    expect(result.commands[0].exit_code).toBe(1);
     expect(result.commands[0].stderr_excerpt).toContain("blocked path traversal");
     expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(false);
     expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(false);
@@ -59,6 +59,29 @@ describe("runCliPathTraversalReplayFixture", () => {
       expect(existsSync(result.artifacts.harness_ref)).toBe(true);
       expect(existsSync(result.artifacts.stdout_ref)).toBe(true);
       expect(existsSync(result.artifacts.stderr_ref)).toBe(true);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  it("returns artifact refs on setup errors when artifact retention is requested", async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "pwnkit-fixture-error-"));
+    try {
+      writeFileSync(join(sandbox, "export"), "not a directory", "utf8");
+
+      const result = await runCliPathTraversalReplayFixture({
+        artifactDir: sandbox,
+        retainArtifacts: true,
+        engineVersion: "test",
+      });
+
+      expect(result.status).toBe("error");
+      expect(result.commands).toEqual([]);
+      expect(result.artifacts.sandbox_ref).toBe(sandbox);
+      expect(result.artifacts.export_ref).toBe(join(sandbox, "export"));
+      expect(result.artifacts.harness_ref).toBe(join(sandbox, "harness", "paperclip-export-fixture.mjs"));
+      expect(result.artifacts.stdout_ref).toBe(join(sandbox, "stdout.log"));
+      expect(result.artifacts.stderr_ref).toBe(join(sandbox, "stderr.log"));
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
     }

--- a/packages/core/src/verification/cli-path-traversal-fixture.test.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { runCliPathTraversalReplayFixture } from "./cli-path-traversal-fixture.js";
+
+describe("runCliPathTraversalReplayFixture", () => {
+  it("reproduces the vulnerable Paperclip-style export traversal", async () => {
+    const result = await runCliPathTraversalReplayFixture({
+      fixtureMode: "vulnerable",
+      engineVersion: "test",
+    });
+
+    expect(result.status).toBe("reproduced");
+    expect(result.mode).toBe("deterministic_replay");
+    expect(result.finding_id).toBe("fixture:cli-path-traversal");
+    expect(result.commands).toHaveLength(1);
+    expect(result.commands[0].argv).toContain("--output");
+    expect(result.commands[0].exit_code).toBe(0);
+    expect(result.commands[0].stdout_excerpt).toContain("escaped-marker");
+    expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(true);
+    expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(true);
+    expect(result.assertions.find((a) => a.kind === "path_inside_sandbox")?.passed).toBe(true);
+    expect(result.artifacts).toEqual({});
+    const escapedDetail = result.assertions.find((a) => a.kind === "filesystem_exists")?.detail ?? "";
+    const escapedPath = escapedDetail.replace(/^escaped marker exists at /, "");
+    const sandbox = dirname(escapedPath);
+    expect(existsSync(sandbox)).toBe(false);
+  });
+
+  it("returns not_reproduced when the fixture CLI rejects traversal", async () => {
+    const result = await runCliPathTraversalReplayFixture({
+      fixtureMode: "patched",
+      engineVersion: "test",
+    });
+
+    expect(result.status).toBe("not_reproduced");
+    expect(result.commands[0].exit_code).toBe(0);
+    expect(result.commands[0].stderr_excerpt).toContain("blocked path traversal");
+    expect(result.assertions.find((a) => a.kind === "filesystem_exists")?.passed).toBe(false);
+    expect(result.assertions.find((a) => a.kind === "path_outside_export_root")?.passed).toBe(false);
+  });
+
+  it("retains the sandbox and artifact refs when requested", async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "pwnkit-fixture-retain-"));
+    try {
+      const result = await runCliPathTraversalReplayFixture({
+        artifactDir: sandbox,
+        retainArtifacts: true,
+        engineVersion: "test",
+      });
+
+      expect(result.status).toBe("reproduced");
+      expect(result.artifacts.sandbox_ref).toBe(sandbox);
+      expect(result.artifacts.harness_ref).toBeTruthy();
+      expect(result.artifacts.stdout_ref).toBeTruthy();
+      expect(result.artifacts.stderr_ref).toBeTruthy();
+      expect(existsSync(result.artifacts.sandbox_ref)).toBe(true);
+      expect(existsSync(result.artifacts.harness_ref)).toBe(true);
+      expect(existsSync(result.artifacts.stdout_ref)).toBe(true);
+      expect(existsSync(result.artifacts.stderr_ref)).toBe(true);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/verification/cli-path-traversal-fixture.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.ts
@@ -77,6 +77,7 @@ interface CapturedCommand {
 
 const FIXTURE_ID = "fixture:cli-path-traversal";
 const DEFAULT_TIMEOUT_MS = 10_000;
+const SIGKILL_GRACE_MS = 1_000;
 const CAPTURE_BYTES = 1024 * 1024;
 const EXCERPT_BYTES = 4 * 1024;
 
@@ -114,23 +115,37 @@ async function runCommand(
     let stderr = "";
     let settled = false;
     let timedOut = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
 
     const child = spawn(argv[0], argv.slice(1), {
       cwd: options.cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
 
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-    }, options.timeoutMs);
-
     const finish = (result: CapturedCommand) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
       resolveCommand(result);
     };
+
+    timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        if (settled) return;
+        child.kill("SIGKILL");
+        finish({
+          exitCode: null,
+          stdout,
+          stderr,
+          timedOut,
+          error: `command timed out after ${options.timeoutMs}ms and did not exit after SIGTERM`,
+        });
+      }, SIGKILL_GRACE_MS);
+    }, options.timeoutMs);
 
     child.stdout?.on("data", (chunk: Buffer) => {
       stdout = appendCapped(stdout, chunk);
@@ -355,6 +370,8 @@ export async function runCliPathTraversalReplayFixture(
     artifacts.export_ref = exportDir;
   }
   let server: Server | undefined;
+  let argv: string[] = [];
+  let command: CapturedCommand | undefined;
 
   try {
     await mkdir(exportDir, { recursive: true });
@@ -366,7 +383,7 @@ export async function runCliPathTraversalReplayFixture(
         "cli-path-traversal fixture requires commandArgv for the real CLI under test",
       );
     }
-    const argv = expandCommandArgv(options.commandArgv, {
+    argv = expandCommandArgv(options.commandArgv, {
       apiUrl: fixture.baseUrl,
       exportDir,
       fixtureMode,
@@ -389,7 +406,7 @@ export async function runCliPathTraversalReplayFixture(
       "utf8",
     );
 
-    const command = await runCommand(argv, {
+    command = await runCommand(argv, {
       cwd: sandboxRoot,
       timeoutMs,
     });
@@ -447,7 +464,16 @@ export async function runCliPathTraversalReplayFixture(
       engine_version: options.engineVersion ?? "unknown",
       started_at: startedAt,
       completed_at: new Date().toISOString(),
-      commands: [],
+      commands: command
+        ? [
+            {
+              argv,
+              exit_code: command.exitCode,
+              stdout_excerpt: excerpt(command.stdout),
+              stderr_excerpt: excerpt(command.stderr),
+            },
+          ]
+        : [],
       assertions: [],
       artifacts,
       summary: summaryFor("error"),

--- a/packages/core/src/verification/cli-path-traversal-fixture.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.ts
@@ -237,16 +237,21 @@ if (!response.ok) {
 const body = await response.json();
 const root = resolve(output);
 await mkdir(root, { recursive: true });
+let blockedTraversal = false;
 
 for (const [name, content] of Object.entries(body.files || {})) {
   const destination = resolve(root, name);
   if (mode === "patched" && !isInside(root, destination)) {
     console.error("blocked path traversal: " + name);
+    blockedTraversal = true;
     continue;
   }
   await mkdir(dirname(destination), { recursive: true });
   await writeFile(destination, String(content), "utf8");
   console.log("wrote " + destination);
+}
+if (blockedTraversal) {
+  process.exitCode = 1;
 }
 `;
 }
@@ -329,10 +334,6 @@ function resultStatus(args: {
   command: CapturedCommand;
   assertions: ReplayAssertion[];
 }): ReplayStatus {
-  if (args.command.error && args.command.exitCode === null) return "error";
-  if (args.command.timedOut) return "error";
-  if (args.command.exitCode !== 0) return "error";
-
   const required = new Set([
     "filesystem_exists",
     "filesystem_not_exists",
@@ -340,10 +341,17 @@ function resultStatus(args: {
     "path_inside_sandbox",
     "no_home_profile_touch",
   ]);
-  const reproduced = args.assertions
-    .filter((a) => required.has(a.kind))
-    .every((a) => a.passed);
-  return reproduced ? "reproduced" : "not_reproduced";
+  const filesystemAssertions = args.assertions.filter((a) => required.has(a.kind));
+  if (filesystemAssertions.length > 0) {
+    return filesystemAssertions.every((a) => a.passed)
+      ? "reproduced"
+      : "not_reproduced";
+  }
+
+  if (args.command.error && args.command.exitCode === null) return "error";
+  if (args.command.timedOut) return "error";
+  if (args.command.exitCode !== 0) return "error";
+  return "inconclusive";
 }
 
 function summaryFor(status: ReplayStatus): string {
@@ -380,9 +388,17 @@ export async function runCliPathTraversalReplayFixture(
     : await mkdtemp(join(tmpdir(), "pwnkit-verify-"));
   const exportDir = join(sandboxRoot, "export");
   const harnessDir = join(sandboxRoot, "harness");
+  const harnessRef = join(harnessDir, "paperclip-export-fixture.mjs");
   const stdoutRef = join(sandboxRoot, "stdout.log");
   const stderrRef = join(sandboxRoot, "stderr.log");
   const artifacts: Record<string, string> = {};
+  if (retainArtifacts) {
+    artifacts.sandbox_ref = sandboxRoot;
+    artifacts.harness_ref = harnessRef;
+    artifacts.stdout_ref = stdoutRef;
+    artifacts.stderr_ref = stderrRef;
+    artifacts.export_ref = exportDir;
+  }
   let server: Server | undefined;
 
   try {
@@ -427,14 +443,6 @@ export async function runCliPathTraversalReplayFixture(
       assertions.unshift(
         assertion("command_exit_zero", true, "fixture command exited 0"),
       );
-    }
-
-    if (retainArtifacts) {
-      artifacts.sandbox_ref = sandboxRoot;
-      artifacts.harness_ref = cliPath;
-      artifacts.stdout_ref = stdoutRef;
-      artifacts.stderr_ref = stderrRef;
-      artifacts.export_ref = exportDir;
     }
 
     const status = resultStatus({ command, assertions });

--- a/packages/core/src/verification/cli-path-traversal-fixture.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.ts
@@ -40,6 +40,14 @@ export interface DeterministicReplayResult {
 
 export interface CliPathTraversalFixtureOptions {
   /**
+   * Command argv for the real CLI implementation under test. Arguments may
+   * contain these placeholders:
+   *   - {{apiUrl}} -> malicious local API base URL
+   *   - {{exportDir}} -> sandboxed export directory
+   *   - {{fixtureMode}} -> vulnerable or patched, for local test fixtures only
+   */
+  commandArgv?: string[];
+  /**
    * `vulnerable` writes returned file paths directly. `patched` rejects paths
    * that resolve outside the selected export directory and acts as the
    * negative control for the replay harness.
@@ -199,68 +207,16 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
-function fixtureCliSource(): string {
-  return `#!/usr/bin/env node
-import { mkdir, writeFile } from "node:fs/promises";
-import { dirname, resolve, sep } from "node:path";
-
-function parseArgs(argv) {
-  const out = {};
-  for (let i = 0; i < argv.length; i += 2) {
-    const key = argv[i];
-    const value = argv[i + 1];
-    if (!key || !key.startsWith("--") || value === undefined) {
-      throw new Error("invalid args");
-    }
-    out[key.slice(2)] = value;
-  }
-  return out;
-}
-
-function isInside(root, candidate) {
-  return candidate === root || candidate.startsWith(root + sep);
-}
-
-const args = parseArgs(process.argv.slice(2));
-const api = args.api;
-const output = args.output;
-const mode = args.mode || "vulnerable";
-
-if (!api || !output) {
-  throw new Error("--api and --output are required");
-}
-
-const response = await fetch(new URL("/company/export", api));
-if (!response.ok) {
-  throw new Error("export API failed with " + response.status);
-}
-const body = await response.json();
-const root = resolve(output);
-await mkdir(root, { recursive: true });
-let blockedTraversal = false;
-
-for (const [name, content] of Object.entries(body.files || {})) {
-  const destination = resolve(root, name);
-  if (mode === "patched" && !isInside(root, destination)) {
-    console.error("blocked path traversal: " + name);
-    blockedTraversal = true;
-    continue;
-  }
-  await mkdir(dirname(destination), { recursive: true });
-  await writeFile(destination, String(content), "utf8");
-  console.log("wrote " + destination);
-}
-if (blockedTraversal) {
-  process.exitCode = 1;
-}
-`;
-}
-
-async function writeFixtureCli(harnessDir: string): Promise<string> {
-  const cliPath = join(harnessDir, "paperclip-export-fixture.mjs");
-  await mkdir(harnessDir, { recursive: true });
-  await writeFile(cliPath, fixtureCliSource(), { encoding: "utf8", mode: 0o755 });
-  return cliPath;
+function expandCommandArgv(
+  argv: string[],
+  replacements: { apiUrl: string; exportDir: string; fixtureMode: string },
+): string[] {
+  return argv.map((arg) =>
+    arg
+      .replaceAll("{{apiUrl}}", replacements.apiUrl)
+      .replaceAll("{{exportDir}}", replacements.exportDir)
+      .replaceAll("{{fixtureMode}}", replacements.fixtureMode),
+  );
 }
 
 function assertion(
@@ -370,11 +326,10 @@ function summaryFor(status: ReplayStatus): string {
 /**
  * Run the deterministic CLI path traversal replay from pwnkit#195.
  *
- * The fixture is intentionally local and synthetic: it starts a malicious API
- * server and runs a tiny Paperclip-style export CLI that writes returned file
- * entries to disk. In `vulnerable` mode the CLI lacks path containment and
- * reproduces the escape. In `patched` mode it rejects the same payload and the
- * result becomes `not_reproduced`.
+ * The fixture starts a malicious local API server and runs the caller-supplied
+ * CLI command against a sandboxed export directory. The harness itself never
+ * implements export behavior; the verdict comes from the CLI under test plus
+ * filesystem assertions over the sandbox.
  */
 export async function runCliPathTraversalReplayFixture(
   options: CliPathTraversalFixtureOptions = {},
@@ -388,7 +343,7 @@ export async function runCliPathTraversalReplayFixture(
     : await mkdtemp(join(tmpdir(), "pwnkit-verify-"));
   const exportDir = join(sandboxRoot, "export");
   const harnessDir = join(sandboxRoot, "harness");
-  const harnessRef = join(harnessDir, "paperclip-export-fixture.mjs");
+  const harnessRef = join(harnessDir, "harness.json");
   const stdoutRef = join(sandboxRoot, "stdout.log");
   const stderrRef = join(sandboxRoot, "stderr.log");
   const artifacts: Record<string, string> = {};
@@ -405,18 +360,35 @@ export async function runCliPathTraversalReplayFixture(
     await mkdir(exportDir, { recursive: true });
     const fixture = await startMaliciousExportServer();
     server = fixture.server;
-    const cliPath = await writeFixtureCli(harnessDir);
 
-    const argv = [
-      process.execPath,
-      cliPath,
-      "--api",
-      fixture.baseUrl,
-      "--output",
+    if (!options.commandArgv || options.commandArgv.length === 0) {
+      throw new Error(
+        "cli-path-traversal fixture requires commandArgv for the real CLI under test",
+      );
+    }
+    const argv = expandCommandArgv(options.commandArgv, {
+      apiUrl: fixture.baseUrl,
       exportDir,
-      "--mode",
       fixtureMode,
-    ];
+    });
+    await mkdir(harnessDir, { recursive: true });
+    await writeFile(
+      harnessRef,
+      JSON.stringify(
+        {
+          fixture: "cli-path-traversal",
+          fixtureMode,
+          commandArgv: options.commandArgv,
+          expandedArgv: argv,
+          apiUrl: fixture.baseUrl,
+          exportDir,
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+
     const command = await runCommand(argv, {
       cwd: sandboxRoot,
       timeoutMs,

--- a/packages/core/src/verification/cli-path-traversal-fixture.ts
+++ b/packages/core/src/verification/cli-path-traversal-fixture.ts
@@ -1,0 +1,482 @@
+import { spawn } from "node:child_process";
+import { createServer, type Server } from "node:http";
+import { access, mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+
+export type ReplayStatus =
+  | "reproduced"
+  | "not_reproduced"
+  | "inconclusive"
+  | "error";
+
+export interface ReplayCommand {
+  argv: string[];
+  exit_code: number | null;
+  stdout_excerpt: string;
+  stderr_excerpt: string;
+}
+
+export interface ReplayAssertion {
+  kind: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface DeterministicReplayResult {
+  status: ReplayStatus;
+  mode: "deterministic_replay";
+  finding_id: string;
+  engine_version: string;
+  started_at: string;
+  completed_at: string;
+  commands: ReplayCommand[];
+  assertions: ReplayAssertion[];
+  artifacts: Record<string, string>;
+  summary: string;
+  error_reason: string | null;
+}
+
+export interface CliPathTraversalFixtureOptions {
+  /**
+   * `vulnerable` writes returned file paths directly. `patched` rejects paths
+   * that resolve outside the selected export directory and acts as the
+   * negative control for the replay harness.
+   */
+  fixtureMode?: "vulnerable" | "patched";
+  /** Keep the sandbox, fixture script, and stdout/stderr files after running. */
+  retainArtifacts?: boolean;
+  /**
+   * Sandbox root. When omitted, a fresh pwnkit-verify-* directory is created
+   * under os.tmpdir(). Passing an explicit directory implies artifact
+   * retention so a caller-chosen path is never deleted by surprise.
+   */
+  artifactDir?: string;
+  /** Per-command timeout. */
+  timeoutMs?: number;
+  /** Version string to record in the emitted result. */
+  engineVersion?: string;
+}
+
+interface CapturedCommand {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  error?: string;
+}
+
+const FIXTURE_ID = "fixture:cli-path-traversal";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const CAPTURE_BYTES = 1024 * 1024;
+const EXCERPT_BYTES = 4 * 1024;
+
+function excerpt(text: string, max = EXCERPT_BYTES): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + "...[truncated]";
+}
+
+function isInside(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function appendCapped(current: string, chunk: Buffer): string {
+  if (current.length >= CAPTURE_BYTES) return current;
+  const next = current + chunk.toString("utf8");
+  if (next.length <= CAPTURE_BYTES) return next;
+  return next.slice(0, CAPTURE_BYTES) + "\n...[truncated at 1MiB]";
+}
+
+async function runCommand(
+  argv: string[],
+  options: { cwd: string; timeoutMs: number },
+): Promise<CapturedCommand> {
+  return await new Promise((resolveCommand) => {
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd: options.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, options.timeoutMs);
+
+    const finish = (result: CapturedCommand) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveCommand(result);
+    };
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = appendCapped(stdout, chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = appendCapped(stderr, chunk);
+    });
+    child.on("error", (err) => {
+      finish({
+        exitCode: null,
+        stdout,
+        stderr,
+        timedOut,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    child.on("close", (code) => {
+      finish({
+        exitCode: code,
+        stdout,
+        stderr,
+        timedOut,
+        error: timedOut ? `command timed out after ${options.timeoutMs}ms` : undefined,
+      });
+    });
+  });
+}
+
+async function startMaliciousExportServer(): Promise<{
+  server: Server;
+  baseUrl: string;
+}> {
+  const payload = {
+    rootPath: "demo",
+    paperclipExtensionPath: null,
+    warnings: [],
+    files: {
+      "../escaped-marker": "pwnkit deterministic verification\n",
+      "README.md": "normal export content\n",
+    },
+  };
+
+  const server = createServer((req, res) => {
+    if (req.method === "GET" && req.url === "/company/export") {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify(payload));
+      return;
+    }
+    res.statusCode = 404;
+    res.end("not found");
+  });
+
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(0, "127.0.0.1", () => resolveListen());
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("failed to allocate fixture server port");
+  }
+
+  return {
+    server,
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolveClose) => {
+    server.close(() => resolveClose());
+  });
+}
+
+function fixtureCliSource(): string {
+  return `#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key || !key.startsWith("--") || value === undefined) {
+      throw new Error("invalid args");
+    }
+    out[key.slice(2)] = value;
+  }
+  return out;
+}
+
+function isInside(root, candidate) {
+  return candidate === root || candidate.startsWith(root + sep);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const api = args.api;
+const output = args.output;
+const mode = args.mode || "vulnerable";
+
+if (!api || !output) {
+  throw new Error("--api and --output are required");
+}
+
+const response = await fetch(new URL("/company/export", api));
+if (!response.ok) {
+  throw new Error("export API failed with " + response.status);
+}
+const body = await response.json();
+const root = resolve(output);
+await mkdir(root, { recursive: true });
+
+for (const [name, content] of Object.entries(body.files || {})) {
+  const destination = resolve(root, name);
+  if (mode === "patched" && !isInside(root, destination)) {
+    console.error("blocked path traversal: " + name);
+    continue;
+  }
+  await mkdir(dirname(destination), { recursive: true });
+  await writeFile(destination, String(content), "utf8");
+  console.log("wrote " + destination);
+}
+`;
+}
+
+async function writeFixtureCli(harnessDir: string): Promise<string> {
+  const cliPath = join(harnessDir, "paperclip-export-fixture.mjs");
+  await mkdir(harnessDir, { recursive: true });
+  await writeFile(cliPath, fixtureCliSource(), { encoding: "utf8", mode: 0o755 });
+  return cliPath;
+}
+
+function assertion(
+  kind: string,
+  passed: boolean,
+  detail: string,
+): ReplayAssertion {
+  return { kind, passed, detail };
+}
+
+async function buildAssertions(paths: {
+  sandboxRoot: string;
+  exportDir: string;
+  escapedPath: string;
+  insideExportPath: string;
+}): Promise<ReplayAssertion[]> {
+  const [sandboxReal, exportReal] = await Promise.all([
+    realpath(paths.sandboxRoot),
+    realpath(paths.exportDir),
+  ]);
+  const escapedExists = await exists(paths.escapedPath);
+  const insideExportExists = await exists(paths.insideExportPath);
+
+  let escapedReal = resolve(paths.escapedPath);
+  if (escapedExists) {
+    escapedReal = await realpath(paths.escapedPath);
+  }
+
+  const homeReal = await realpath(homedir()).catch(() => homedir());
+  const profileNames = new Set([".bashrc", ".zshrc", ".profile", ".bash_profile"]);
+  const escapedBase = escapedReal.split(sep).at(-1) ?? "";
+
+  return [
+    assertion(
+      "filesystem_exists",
+      escapedExists,
+      escapedExists
+        ? `escaped marker exists at ${escapedReal}`
+        : `escaped marker not found at ${paths.escapedPath}`,
+    ),
+    assertion(
+      "filesystem_not_exists",
+      !insideExportExists,
+      insideExportExists
+        ? `unexpected marker found inside export root at ${paths.insideExportPath}`
+        : `no escaped marker exists inside export root at ${paths.insideExportPath}`,
+    ),
+    assertion(
+      "path_outside_export_root",
+      escapedExists && !isInside(exportReal, escapedReal),
+      escapedExists
+        ? `escaped marker realpath ${escapedReal} is outside export root ${exportReal}`
+        : "escaped marker missing, so export-root escape was not reproduced",
+    ),
+    assertion(
+      "path_inside_sandbox",
+      escapedExists && isInside(sandboxReal, escapedReal),
+      escapedExists
+        ? `escaped marker stayed inside sandbox ${sandboxReal}`
+        : "escaped marker missing, so sandbox containment could not be proven",
+    ),
+    assertion(
+      "no_home_profile_touch",
+      !isInside(homeReal, escapedReal) && !profileNames.has(escapedBase),
+      `touched path ${escapedReal} is not a home directory or shell profile target`,
+    ),
+  ];
+}
+
+function resultStatus(args: {
+  command: CapturedCommand;
+  assertions: ReplayAssertion[];
+}): ReplayStatus {
+  if (args.command.error && args.command.exitCode === null) return "error";
+  if (args.command.timedOut) return "error";
+  if (args.command.exitCode !== 0) return "error";
+
+  const required = new Set([
+    "filesystem_exists",
+    "filesystem_not_exists",
+    "path_outside_export_root",
+    "path_inside_sandbox",
+    "no_home_profile_touch",
+  ]);
+  const reproduced = args.assertions
+    .filter((a) => required.has(a.kind))
+    .every((a) => a.passed);
+  return reproduced ? "reproduced" : "not_reproduced";
+}
+
+function summaryFor(status: ReplayStatus): string {
+  switch (status) {
+    case "reproduced":
+      return "CLI path traversal replay wrote a marker outside the selected export directory inside the sandbox.";
+    case "not_reproduced":
+      return "CLI path traversal replay completed but did not write outside the selected export directory.";
+    case "inconclusive":
+      return "CLI path traversal replay was inconclusive.";
+    case "error":
+      return "CLI path traversal replay failed before reaching a reliable verdict.";
+  }
+}
+
+/**
+ * Run the deterministic CLI path traversal replay from pwnkit#195.
+ *
+ * The fixture is intentionally local and synthetic: it starts a malicious API
+ * server and runs a tiny Paperclip-style export CLI that writes returned file
+ * entries to disk. In `vulnerable` mode the CLI lacks path containment and
+ * reproduces the escape. In `patched` mode it rejects the same payload and the
+ * result becomes `not_reproduced`.
+ */
+export async function runCliPathTraversalReplayFixture(
+  options: CliPathTraversalFixtureOptions = {},
+): Promise<DeterministicReplayResult> {
+  const startedAt = new Date().toISOString();
+  const fixtureMode = options.fixtureMode ?? "vulnerable";
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const retainArtifacts = options.retainArtifacts || Boolean(options.artifactDir);
+  const sandboxRoot = options.artifactDir
+    ? resolve(options.artifactDir)
+    : await mkdtemp(join(tmpdir(), "pwnkit-verify-"));
+  const exportDir = join(sandboxRoot, "export");
+  const harnessDir = join(sandboxRoot, "harness");
+  const stdoutRef = join(sandboxRoot, "stdout.log");
+  const stderrRef = join(sandboxRoot, "stderr.log");
+  const artifacts: Record<string, string> = {};
+  let server: Server | undefined;
+
+  try {
+    await mkdir(exportDir, { recursive: true });
+    const fixture = await startMaliciousExportServer();
+    server = fixture.server;
+    const cliPath = await writeFixtureCli(harnessDir);
+
+    const argv = [
+      process.execPath,
+      cliPath,
+      "--api",
+      fixture.baseUrl,
+      "--output",
+      exportDir,
+      "--mode",
+      fixtureMode,
+    ];
+    const command = await runCommand(argv, {
+      cwd: sandboxRoot,
+      timeoutMs,
+    });
+
+    await writeFile(stdoutRef, command.stdout, "utf8");
+    await writeFile(stderrRef, command.stderr, "utf8");
+
+    const assertions = await buildAssertions({
+      sandboxRoot,
+      exportDir,
+      escapedPath: join(sandboxRoot, "escaped-marker"),
+      insideExportPath: join(exportDir, "escaped-marker"),
+    });
+    if (command.exitCode !== 0 || command.error) {
+      assertions.unshift(
+        assertion(
+          "command_exit_zero",
+          false,
+          command.error ?? `fixture command exited ${String(command.exitCode)}`,
+        ),
+      );
+    } else {
+      assertions.unshift(
+        assertion("command_exit_zero", true, "fixture command exited 0"),
+      );
+    }
+
+    if (retainArtifacts) {
+      artifacts.sandbox_ref = sandboxRoot;
+      artifacts.harness_ref = cliPath;
+      artifacts.stdout_ref = stdoutRef;
+      artifacts.stderr_ref = stderrRef;
+      artifacts.export_ref = exportDir;
+    }
+
+    const status = resultStatus({ command, assertions });
+    return {
+      status,
+      mode: "deterministic_replay",
+      finding_id: FIXTURE_ID,
+      engine_version: options.engineVersion ?? "unknown",
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      commands: [
+        {
+          argv,
+          exit_code: command.exitCode,
+          stdout_excerpt: excerpt(command.stdout),
+          stderr_excerpt: excerpt(command.stderr),
+        },
+      ],
+      assertions,
+      artifacts,
+      summary: summaryFor(status),
+      error_reason: status === "error" ? command.error ?? "fixture command failed" : null,
+    };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return {
+      status: "error",
+      mode: "deterministic_replay",
+      finding_id: FIXTURE_ID,
+      engine_version: options.engineVersion ?? "unknown",
+      started_at: startedAt,
+      completed_at: new Date().toISOString(),
+      commands: [],
+      assertions: [],
+      artifacts,
+      summary: summaryFor("error"),
+      error_reason: reason,
+    };
+  } finally {
+    if (server) await closeServer(server);
+    if (!retainArtifacts) {
+      await rm(sandboxRoot, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/core/src/verification/index.ts
+++ b/packages/core/src/verification/index.ts
@@ -1,2 +1,10 @@
 export { evaluateVerificationSpec } from "./spec.js";
 export type { PredicateResult, VerificationResult } from "./spec.js";
+export { runCliPathTraversalReplayFixture } from "./cli-path-traversal-fixture.js";
+export type {
+  CliPathTraversalFixtureOptions,
+  DeterministicReplayResult,
+  ReplayAssertion,
+  ReplayCommand,
+  ReplayStatus,
+} from "./cli-path-traversal-fixture.js";


### PR DESCRIPTION
## Summary
- add a built-in deterministic replay fixture for CLI path traversal findings
- expose it through pwnkit verify --fixture cli-path-traversal
- record command argv, exit code, stdout/stderr excerpts, assertions, and optional retained artifact refs
- add vulnerable and patched fixture modes so the replay reproduces on vulnerable behavior and returns not_reproduced for the negative control
- document the verify fixture command surface

Closes #195.

## Verification
- pnpm --filter @pwnkit/core build
- pnpm --filter ./packages/cli build
- pnpm --filter @pwnkit/core exec vitest run src/verification/cli-path-traversal-fixture.test.ts
- pnpm --filter ./packages/cli exec vitest run src/commands/__tests__/verify.test.ts
- node packages/cli/dist/index.js verify --fixture cli-path-traversal
- node packages/cli/dist/index.js verify --fixture cli-path-traversal --fixture-mode patched
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verify CLI: fixture-driven deterministic replay (vulnerable/patched modes), optional artifact retention, and configurable artifact output; verification results now include artifact references.

* **Documentation**
  * Added verify command docs, flags/options table, deterministic-replay guidance, and a verification-result schema page.

* **Tests**
  * Expanded end-to-end tests for fixture replay, validation/error paths, artifact retention, timeouts, and path-traversal assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->