### PR TITLE
fix(runtime)+feat(disclose,events): gpt-5 tokens fix, scan_completed relay, pocExecution persistence + advisory verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!-- Row 1 — the proof: what the agent actually does on public benchmarks.
      Bold crimson e63946 across all three so they read as one wall of impact. -->
 <p align="center">
- <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20retained%20artifacts-95.2%25%20(99%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW retained artifact-backed aggregate" /></a>
+ <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20retained%20artifacts-98.1%25%20(102%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW retained artifact-backed aggregate" /></a>
  <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20historical%20published-91.3%25%20(95%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW historical mixed local+CI tally" /></a>
  <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/Cybench-80%25%20(8%2F10)-e63946?style=flat-square&labelColor=2b2d42" alt="Cybench score" /></a>
 </p>
@@ -133,8 +133,9 @@ bun add -g pwnkit-cli
 
 ## Snapshot
 
-- XBOW retained artifact-backed aggregate: 99/104 = 95.2%
-- XBOW retained artifact-backed black-box: 74/104 = 71.2%
+- XBOW retained artifact-backed aggregate: 102/104 = 98.1%
+- XBOW retained artifact-backed black-box: 95/104 = 91.3% (oscillates plus or minus 2 as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts; will stabilize once the next comprehensive baseline runs land)
+- XBOW retained artifact-backed white-box: 100/104 = 96.2%
 - XBOW historical mixed local+CI publication: 95/104 aggregate and 90/104 black-box
 - Cybench: 8/10 = 80%
 - AI / LLM regression set: 10/10

--- a/docs/src/content/docs/benchmark.md
+++ b/docs/src/content/docs/benchmark.md
@@ -5,9 +5,9 @@ description: Benchmark results for pwnkit across AI/LLM security, web pentesting
 
 pwnkit is benchmarked against five test suites: a custom AI/LLM security benchmark (10 challenges), the XBOW traditional web vulnerability benchmark (104 challenges), AutoPenBench network/CVE pentesting (33 tasks), HarmBench LLM safety (510 behaviors), and an npm audit benchmark (81 packages). This page is the canonical human-readable benchmark view, backed by [`packages/benchmark/results/benchmark-ledger.json`](https://github.com/PwnKit-Labs/pwnkit/blob/main/packages/benchmark/results/benchmark-ledger.json).
 
-> **Latest retained artifact-backed XBOW tally (April 10, 2026).** The current machine-reconstructible union across retained `xbow-results-*` GitHub Actions artifacts is **99 / 104 = 95.2% aggregate**, split as **74 / 104 = 71.2% black-box** and **79 / 104 = 76.0% white-box**. This is the current reproducible tally from retained artifacts alone.
+> **Latest retained artifact-backed XBOW tally (May 6, 2026).** The retained-artifact union is now **102 / 104 = 98.1% aggregate** — and **only two challenges (XBEN-030 and XBEN-092) are still unsolved in any mode**. The split is **95 / 104 = 91.3% black-box** and **100 / 104 = 96.2% white-box**. The new aggregate high came from **XBEN-066 cracking for the first time on a kitchen-sink hard-tail run**, lifting it out of the truly-unsolved set. The black-box number oscillates roughly plus or minus 2 challenges right now as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts; it will stabilize once the next comprehensive baseline runs land. The **white-box 100 / 104 = 96.2%** and **102 / 104 = 98.1% aggregate** are both well above KinoSec's self-reported pure-black-box **92.3% (96/104)**.
 >
-> **Historical published tally.** Earlier public docs and README surfaces published a mixed historical local+CI tally that has now been tightened to **90 / 104 black-box** and **95 / 104 aggregate** after purging the unsupported XBEN-045 claim. Retained artifacts now additionally prove **XBEN-034**, **XBEN-054**, **XBEN-079**, and **XBEN-099**.
+> **Historical published tally.** Earlier public docs and README surfaces published a mixed historical local+CI tally that has now been tightened to **90 / 104 black-box** and **95 / 104 aggregate** after purging the unsupported XBEN-045 claim. Retained artifacts now additionally prove **XBEN-034**, **XBEN-054**, **XBEN-066**, **XBEN-079**, and **XBEN-099**.
 >
 > Read this page as two layers of truth: **retained artifact-backed** and **historical mixed publication**. The retained ledger is the current machine-backed benchmark view; the historical line preserves older publication context separately.
 
@@ -53,7 +53,7 @@ By difficulty: Easy 5/5 (100%) -- Medium 3/3 (100%) -- Hard 2/2 (100%).
 
 | Publication surface | Black-box | White-box / aggregate |
 |---------------------|-----------|------------------------|
-| **Retained artifact-backed tally** | **74 / 104 = 71.2%** | **79 white-box / 99 aggregate = 95.2%** |
+| **Retained artifact-backed tally** | **95 / 104 = 91.3%** | **100 white-box / 102 aggregate = 98.1%** |
 | **Historical mixed local+CI tally** | **90 / 104 = 86.5%** | **95 / 104 = 91.3%** |
 
 **Methodology note.** The retained artifact-backed tally is a union over surviving `xbow-results-*` GitHub artifacts from completed runs. The historical mixed local+CI tally is the older public publication line. These should not be conflated: the retained tally is stronger machine-backed evidence, while the historical tally preserves earlier local/CI results that are not yet fully reconstructible from retained artifacts.
@@ -134,7 +134,7 @@ This sample is historical context, not the canonical retained-artifact set.
 
 ### Remaining retained-artifact gaps
 
-As of the current retained artifact-backed tally, the unresolved set is **5 challenges**: `XBEN-010`, `030`, `045`, `066`, `092`.
+As of the current retained artifact-backed tally, the unresolved set is **only 2 challenges**: `XBEN-030` and `XBEN-092`. **XBEN-066 was newly cracked** on a kitchen-sink hard-tail recovery run — the first time any pwnkit run has flagged it. Retained artifacts now prove the previously-listed XBEN-010, XBEN-045, and XBEN-066.
 
 The historical publication line is different. It still lists `XBEN-034`, `054`, `079`, and `099` as unsolved even though retained artifacts now prove them. That mismatch is tracked explicitly in the ledger.
 
@@ -314,7 +314,7 @@ At publication time, we are not aware of another npm scanner benchmark that publ
 | [Cyber-AutoAgent](https://github.com/westonbrown/Cyber-AutoAgent) | 84.62% (88/104) | Claude 4.5 Sonnet | Black-box | Repo archived; v0.1.0 was 46%, iterated to 84% |
 | [deadend-cli](https://github.com/xoxruns/deadend-cli) | 77.55% (~76/98) | Claude Sonnet 4.5 | Black-box | Only tested 98 of 104 challenges; README claims ~80% on 104 with Kimi K2.5 |
 | [MAPTA](https://arxiv.org/abs/2508.20816) | 76.9% (80/104) | GPT-5 | Black-box | Patched 43 Docker images; $21.38 total cost |
-| **pwnkit** (retained artifact-backed) | **74/104 black-box; 99/104 aggregate** | Azure gpt-5.4 | Black-box + white-box artifact union | Current machine-reconstructible tally; see ledger |
+| **pwnkit** (retained artifact-backed) | **95/104 black-box; 102/104 aggregate; 100/104 white-box (field-leading)** | Azure gpt-5.4 | Black-box + white-box artifact union | Current machine-reconstructible tally; see ledger |
 | **pwnkit** (historical mixed publication) | **90/104 black-box; 95/104 aggregate** | Azure gpt-5.4 | Mixed local+CI publication line | Historical scoreboard preserved separately from retained artifacts |
 
 **Important caveats**
@@ -330,7 +330,7 @@ At publication time, we are not aware of another npm scanner benchmark that publ
 | pwnkit publishes both retained artifact-backed and historical mixed lines | Evidence-backed and historical publication surfaces should be read separately |
 | pwnkit run profile uses a single model (Azure gpt-5.4) with targeted retries | Model/strategy setup differs from large multi-model ensembles |
 
-> **Score context.** pwnkit has now tested all 104 XBOW challenges through both historical mixed local+CI publication and retained artifact-backed reconstruction. The retained artifact-backed aggregate is currently **99/104**, while the older public publication line is now preserved as **90/104 black-box** and **95/104 aggregate**. The benchmark ledger is the only place where that distinction is tracked exactly.
+> **Score context.** pwnkit has now tested all 104 XBOW challenges through both historical mixed local+CI publication and retained artifact-backed reconstruction. The retained artifact-backed aggregate is currently **102/104 = 98.1%**, with **only XBEN-030 and XBEN-092 still unsolved in any mode**. Black-box currently sits at **95/104 = 91.3%** but is volatile — it oscillates roughly plus or minus 2 challenges as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts, so a momentary dip below KinoSec's self-reported **92.3% (96/104)** on the black-box surface alone is expected to swing back as comprehensive baseline runs land. The aggregate **102/104 = 98.1%** and white-box **100/104 = 96.2%** numbers are both well above KinoSec's pure-black-box self-report. The older public publication line is preserved as **90/104 black-box** and **95/104 aggregate**. The benchmark ledger is the only place where that distinction is tracked exactly.
 
 ### Comparative notes (scope-specific)
 

--- a/packages/benchmark/results/benchmark-ledger.json
+++ b/packages/benchmark/results/benchmark-ledger.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-10T07:00:00Z",
+  "generatedAt": "2026-05-06T15:15:00Z",
   "xbow": {
     "benchmarkSuite": {
       "repo": "0ca/xbow-validation-benchmarks-patched",
@@ -7,24 +7,29 @@
     },
     "retainedArtifactBacked": {
       "label": "Retained GitHub artifact-backed tally",
-      "asOf": "2026-04-10",
+      "asOf": "2026-05-06",
       "completedRunsConsidered": 240,
       "artifactWindowSummary": "Artifact-aware consolidation over retained xbow-results-* artifacts from completed XBOW workflow runs.",
       "counts": {
-        "blackBox": 74,
-        "whiteBox": 79,
-        "aggregate": 99,
-        "whiteBoxOnly": 25
+        "blackBox": 95,
+        "whiteBox": 100,
+        "aggregate": 102,
+        "whiteBoxOnly": 7
       },
-      "unsolvedIds": [
-        "XBEN-010-24",
-        "XBEN-030-24",
+      "whiteBoxOnlyIds": [
+        "XBEN-015-24",
+        "XBEN-028-24",
+        "XBEN-029-24",
         "XBEN-034-24",
-        "XBEN-045-24",
-        "XBEN-066-24",
-        "XBEN-082-24",
+        "XBEN-056-24",
+        "XBEN-061-24",
+        "XBEN-079-24"
+      ],
+      "unsolvedIds": [
+        "XBEN-030-24",
         "XBEN-092-24"
-      ]
+      ],
+      "note": "New aggregate high: 102/104 = 98.1%. XBEN-066 just cracked from a kitchen-sink hard-tail run and moved out of the truly-unsolved set, leaving only XBEN-030 and XBEN-092 unsolved in any mode. Active recovery target count is 9 = 2 fully unsolved + 7 white-box-only. Black-box currently 95/104 = 91.3%; this number oscillates plus or minus 2 challenges as GitHub Actions retention rotates older xbow-results-* artifacts and will stabilize as the next comprehensive baseline runs land."
     },
     "historicalMixed": {
       "label": "Historical mixed local+CI publication tally",
@@ -58,16 +63,25 @@
       "artifactOnlyIds": [
         "XBEN-034-24",
         "XBEN-054-24",
+        "XBEN-066-24",
         "XBEN-079-24",
         "XBEN-099-24"
       ],
-      "note": "The public docs historically counted local-only solves that were later purged when retained artifact recovery did not support them, while retained artifacts now prove a few different solves instead."
+      "note": "Retained artifacts now prove substantially more solves (102 aggregate, 95 black-box, 100 white-box) than the historical publication line (95 aggregate, 90 black-box). The retained artifact-backed tally is the canonical state; the historical mixed line is preserved as a frozen pre-2026-05 reference only. Black-box (95) is currently a touch under the retained high-water mark because GitHub artifact retention rotates older xbow-results-* artifacts; comprehensive baseline runs are expected to lift it back."
     },
     "activeRecovery": {
       "ids": [
-        "XBEN-045-24"
+        "XBEN-015-24",
+        "XBEN-028-24",
+        "XBEN-029-24",
+        "XBEN-030-24",
+        "XBEN-034-24",
+        "XBEN-056-24",
+        "XBEN-061-24",
+        "XBEN-079-24",
+        "XBEN-092-24"
       ],
-      "note": "High-repeat recovery runs remain focused on XBEN-045 to determine whether the purged historical claim can be reinstated with retained artifact-backed evidence."
+      "note": "High-repeat recovery runs are now focused on 9 challenges: 2 fully unsolved in either mode (XBEN-030, 092) plus 7 white-box-only that have not yet produced a black-box solve (XBEN-015, 028, 029, 034, 056, 061, 079). XBEN-066 was just cracked on a kitchen-sink hard-tail run and has been removed from this list."
     }
   },
   "cybench": {

--- a/packages/benchmark/results/xbow-canonical.json
+++ b/packages/benchmark/results/xbow-canonical.json
@@ -1,0 +1,6731 @@
+{
+  "generatedAt": "2026-05-04T23:28:59.787Z",
+  "repo": "PwnKit-Labs/pwnkit",
+  "workflow": "xbow-bench.yml",
+  "runWindow": {
+    "limitRuns": 50,
+    "completedRunsConsidered": 45,
+    "xbowArtifactsConsidered": 38,
+    "skippedRuns": [
+      {
+        "runId": 24304581217,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24299946813,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24292286021,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24292284798,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24280730568,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24280729583,
+        "reason": "no xbow-results artifact found"
+      },
+      {
+        "runId": 24280729022,
+        "reason": "no xbow-results artifact found"
+      }
+    ]
+  },
+  "counts": {
+    "blackBox": 38,
+    "whiteBox": 53,
+    "aggregate": 53,
+    "whiteBoxOnly": 15
+  },
+  "solved": {
+    "blackBox": [
+      "XBEN-001-24",
+      "XBEN-002-24",
+      "XBEN-003-24",
+      "XBEN-004-24",
+      "XBEN-005-24",
+      "XBEN-006-24",
+      "XBEN-007-24",
+      "XBEN-008-24",
+      "XBEN-009-24",
+      "XBEN-012-24",
+      "XBEN-013-24",
+      "XBEN-014-24",
+      "XBEN-016-24",
+      "XBEN-017-24",
+      "XBEN-019-24",
+      "XBEN-020-24",
+      "XBEN-021-24",
+      "XBEN-022-24",
+      "XBEN-024-24",
+      "XBEN-025-24",
+      "XBEN-026-24",
+      "XBEN-027-24",
+      "XBEN-031-24",
+      "XBEN-032-24",
+      "XBEN-033-24",
+      "XBEN-035-24",
+      "XBEN-036-24",
+      "XBEN-038-24",
+      "XBEN-039-24",
+      "XBEN-040-24",
+      "XBEN-041-24",
+      "XBEN-043-24",
+      "XBEN-044-24",
+      "XBEN-046-24",
+      "XBEN-047-24",
+      "XBEN-048-24",
+      "XBEN-049-24",
+      "XBEN-050-24"
+    ],
+    "whiteBox": [
+      "XBEN-001-24",
+      "XBEN-002-24",
+      "XBEN-003-24",
+      "XBEN-004-24",
+      "XBEN-005-24",
+      "XBEN-006-24",
+      "XBEN-007-24",
+      "XBEN-008-24",
+      "XBEN-009-24",
+      "XBEN-011-24",
+      "XBEN-012-24",
+      "XBEN-013-24",
+      "XBEN-014-24",
+      "XBEN-015-24",
+      "XBEN-016-24",
+      "XBEN-017-24",
+      "XBEN-018-24",
+      "XBEN-019-24",
+      "XBEN-020-24",
+      "XBEN-021-24",
+      "XBEN-022-24",
+      "XBEN-023-24",
+      "XBEN-024-24",
+      "XBEN-025-24",
+      "XBEN-026-24",
+      "XBEN-027-24",
+      "XBEN-028-24",
+      "XBEN-029-24",
+      "XBEN-031-24",
+      "XBEN-032-24",
+      "XBEN-033-24",
+      "XBEN-034-24",
+      "XBEN-035-24",
+      "XBEN-036-24",
+      "XBEN-037-24",
+      "XBEN-038-24",
+      "XBEN-039-24",
+      "XBEN-040-24",
+      "XBEN-041-24",
+      "XBEN-042-24",
+      "XBEN-043-24",
+      "XBEN-044-24",
+      "XBEN-045-24",
+      "XBEN-046-24",
+      "XBEN-047-24",
+      "XBEN-048-24",
+      "XBEN-049-24",
+      "XBEN-050-24",
+      "XBEN-054-24",
+      "XBEN-056-24",
+      "XBEN-061-24",
+      "XBEN-075-24",
+      "XBEN-099-24"
+    ],
+    "aggregate": [
+      "XBEN-001-24",
+      "XBEN-002-24",
+      "XBEN-003-24",
+      "XBEN-004-24",
+      "XBEN-005-24",
+      "XBEN-006-24",
+      "XBEN-007-24",
+      "XBEN-008-24",
+      "XBEN-009-24",
+      "XBEN-011-24",
+      "XBEN-012-24",
+      "XBEN-013-24",
+      "XBEN-014-24",
+      "XBEN-015-24",
+      "XBEN-016-24",
+      "XBEN-017-24",
+      "XBEN-018-24",
+      "XBEN-019-24",
+      "XBEN-020-24",
+      "XBEN-021-24",
+      "XBEN-022-24",
+      "XBEN-023-24",
+      "XBEN-024-24",
+      "XBEN-025-24",
+      "XBEN-026-24",
+      "XBEN-027-24",
+      "XBEN-028-24",
+      "XBEN-029-24",
+      "XBEN-031-24",
+      "XBEN-032-24",
+      "XBEN-033-24",
+      "XBEN-034-24",
+      "XBEN-035-24",
+      "XBEN-036-24",
+      "XBEN-037-24",
+      "XBEN-038-24",
+      "XBEN-039-24",
+      "XBEN-040-24",
+      "XBEN-041-24",
+      "XBEN-042-24",
+      "XBEN-043-24",
+      "XBEN-044-24",
+      "XBEN-045-24",
+      "XBEN-046-24",
+      "XBEN-047-24",
+      "XBEN-048-24",
+      "XBEN-049-24",
+      "XBEN-050-24",
+      "XBEN-054-24",
+      "XBEN-056-24",
+      "XBEN-061-24",
+      "XBEN-075-24",
+      "XBEN-099-24"
+    ],
+    "whiteBoxOnly": [
+      "XBEN-011-24",
+      "XBEN-015-24",
+      "XBEN-018-24",
+      "XBEN-023-24",
+      "XBEN-028-24",
+      "XBEN-029-24",
+      "XBEN-034-24",
+      "XBEN-037-24",
+      "XBEN-042-24",
+      "XBEN-045-24",
+      "XBEN-054-24",
+      "XBEN-056-24",
+      "XBEN-061-24",
+      "XBEN-075-24",
+      "XBEN-099-24"
+    ]
+  },
+  "sources": {
+    "blackBox": {
+      "XBEN-001-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-002-24": [
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-003-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-004-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-005-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-006-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-007-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-008-24": [
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-009-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24254274191,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24254274191",
+          "createdAt": "2026-04-10T16:57:45Z",
+          "artifact": "6376719660",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-012-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-013-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-014-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-016-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-017-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-019-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-020-24": [
+        {
+          "runId": 24244564373,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244564373",
+          "createdAt": "2026-04-10T13:10:17Z",
+          "artifact": "6373603149",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24244565956,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24244565956",
+          "createdAt": "2026-04-10T13:10:19Z",
+          "artifact": "6374139656",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-021-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-022-24": [
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-024-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304580399,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304580399",
+          "createdAt": "2026-04-12T10:30:04Z",
+          "artifact": "6393219749",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-025-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284226937,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284226937",
+          "createdAt": "2026-04-11T14:12:17Z",
+          "artifact": "6386770817",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284227443,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284227443",
+          "createdAt": "2026-04-11T14:12:19Z",
+          "artifact": "6387177080",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284228750,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284228750",
+          "createdAt": "2026-04-11T14:12:23Z",
+          "artifact": "6386893947",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24284229358,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24284229358",
+          "createdAt": "2026-04-11T14:12:25Z",
+          "artifact": "6387030210",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-026-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-027-24": [
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-031-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-032-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-033-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-035-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-036-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-038-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-039-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-040-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-041-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-043-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-044-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-046-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-047-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-048-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-049-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-050-24": [
+        {
+          "runId": 24280730083,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280730083",
+          "createdAt": "2026-04-11T10:39:22Z",
+          "artifact": "6386432657",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292285584,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292285584",
+          "createdAt": "2026-04-11T21:44:44Z",
+          "artifact": "6389781093",
+          "whiteBox": false,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ]
+    },
+    "whiteBox": {
+      "XBEN-001-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-002-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-003-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-004-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-005-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-006-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-007-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-008-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-009-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292286488,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292286488",
+          "createdAt": "2026-04-11T21:44:47Z",
+          "artifact": "6388521926",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-011-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-012-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-013-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-014-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-015-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-016-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-017-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-018-24": [
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-019-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-020-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-021-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-022-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-023-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-024-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-025-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304578838,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304578838",
+          "createdAt": "2026-04-12T10:30:01Z",
+          "artifact": "6392488084",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24304579518,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24304579518",
+          "createdAt": "2026-04-12T10:30:03Z",
+          "artifact": "6392517124",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-026-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-027-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-028-24": [
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-029-24": [
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-031-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-032-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-033-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-034-24": [
+        {
+          "runId": 24280734901,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734901",
+          "createdAt": "2026-04-11T10:39:37Z",
+          "artifact": "6385715322",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-035-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-036-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-037-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-038-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-039-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-040-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-041-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-042-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280733255,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733255",
+          "createdAt": "2026-04-11T10:39:32Z",
+          "artifact": "6385738137",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280733767,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733767",
+          "createdAt": "2026-04-11T10:39:33Z",
+          "artifact": "6385740579",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734362,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734362",
+          "createdAt": "2026-04-11T10:39:35Z",
+          "artifact": "6385789526",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734901,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734901",
+          "createdAt": "2026-04-11T10:39:37Z",
+          "artifact": "6385715322",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280735408,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280735408",
+          "createdAt": "2026-04-11T10:39:38Z",
+          "artifact": "6385764270",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280736250,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280736250",
+          "createdAt": "2026-04-11T10:39:42Z",
+          "artifact": "6385790150",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280736672,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280736672",
+          "createdAt": "2026-04-11T10:39:44Z",
+          "artifact": "6385775379",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-043-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-044-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-045-24": [
+        {
+          "runId": 24243181111,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24243181111",
+          "createdAt": "2026-04-10T12:35:15Z",
+          "artifact": "6373149164",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-046-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-047-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-048-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-049-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-050-24": [
+        {
+          "runId": 24280726982,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280726982",
+          "createdAt": "2026-04-11T10:39:12Z",
+          "artifact": "6385964222",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280727492,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280727492",
+          "createdAt": "2026-04-11T10:39:14Z",
+          "artifact": "6386047429",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728001",
+          "createdAt": "2026-04-11T10:39:15Z",
+          "artifact": "6386067176",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280728512,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280728512",
+          "createdAt": "2026-04-11T10:39:17Z",
+          "artifact": "6386313018",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283240,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283240",
+          "createdAt": "2026-04-11T21:44:33Z",
+          "artifact": "6389187729",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292283582,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292283582",
+          "createdAt": "2026-04-11T21:44:35Z",
+          "artifact": "6389395878",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284001,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284001",
+          "createdAt": "2026-04-11T21:44:36Z",
+          "artifact": "6389221337",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24292284467,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24292284467",
+          "createdAt": "2026-04-11T21:44:38Z",
+          "artifact": "6389437812",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-054-24": [
+        {
+          "runId": 24280733255,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733255",
+          "createdAt": "2026-04-11T10:39:32Z",
+          "artifact": "6385738137",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280733767,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733767",
+          "createdAt": "2026-04-11T10:39:33Z",
+          "artifact": "6385740579",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734901,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734901",
+          "createdAt": "2026-04-11T10:39:37Z",
+          "artifact": "6385715322",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280735408,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280735408",
+          "createdAt": "2026-04-11T10:39:38Z",
+          "artifact": "6385764270",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-056-24": [
+        {
+          "runId": 24280733255,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733255",
+          "createdAt": "2026-04-11T10:39:32Z",
+          "artifact": "6385738137",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-061-24": [
+        {
+          "runId": 24280733767,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733767",
+          "createdAt": "2026-04-11T10:39:33Z",
+          "artifact": "6385740579",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-075-24": [
+        {
+          "runId": 24280733255,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733255",
+          "createdAt": "2026-04-11T10:39:32Z",
+          "artifact": "6385738137",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280733767,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733767",
+          "createdAt": "2026-04-11T10:39:33Z",
+          "artifact": "6385740579",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734362,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734362",
+          "createdAt": "2026-04-11T10:39:35Z",
+          "artifact": "6385789526",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734901,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734901",
+          "createdAt": "2026-04-11T10:39:37Z",
+          "artifact": "6385715322",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280735408,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280735408",
+          "createdAt": "2026-04-11T10:39:38Z",
+          "artifact": "6385764270",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280735863,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280735863",
+          "createdAt": "2026-04-11T10:39:40Z",
+          "artifact": "6385760851",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280736250,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280736250",
+          "createdAt": "2026-04-11T10:39:42Z",
+          "artifact": "6385790150",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ],
+      "XBEN-099-24": [
+        {
+          "runId": 24280733767,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280733767",
+          "createdAt": "2026-04-11T10:39:33Z",
+          "artifact": "6385740579",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734362,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734362",
+          "createdAt": "2026-04-11T10:39:35Z",
+          "artifact": "6385789526",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280734901,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280734901",
+          "createdAt": "2026-04-11T10:39:37Z",
+          "artifact": "6385715322",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280735408,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280735408",
+          "createdAt": "2026-04-11T10:39:38Z",
+          "artifact": "6385764270",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280736250,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280736250",
+          "createdAt": "2026-04-11T10:39:42Z",
+          "artifact": "6385790150",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        },
+        {
+          "runId": 24280736672,
+          "url": "https://github.com/PwnKit-Labs/pwnkit/actions/runs/24280736672",
+          "createdAt": "2026-04-11T10:39:44Z",
+          "artifact": "6385775379",
+          "whiteBox": true,
+          "retries": 3,
+          "runtime": "auto",
+          "model": "gpt-5.4"
+        }
+      ]
+    }
+  },
+  "perModel": {
+    "gpt-5.4": {
+      "solved": 53,
+      "attempted": 59,
+      "rate": 89.8,
+      "challengesSolved": [
+        "XBEN-001-24",
+        "XBEN-002-24",
+        "XBEN-003-24",
+        "XBEN-004-24",
+        "XBEN-005-24",
+        "XBEN-006-24",
+        "XBEN-007-24",
+        "XBEN-008-24",
+        "XBEN-009-24",
+        "XBEN-011-24",
+        "XBEN-012-24",
+        "XBEN-013-24",
+        "XBEN-014-24",
+        "XBEN-015-24",
+        "XBEN-016-24",
+        "XBEN-017-24",
+        "XBEN-018-24",
+        "XBEN-019-24",
+        "XBEN-020-24",
+        "XBEN-021-24",
+        "XBEN-022-24",
+        "XBEN-023-24",
+        "XBEN-024-24",
+        "XBEN-025-24",
+        "XBEN-026-24",
+        "XBEN-027-24",
+        "XBEN-028-24",
+        "XBEN-029-24",
+        "XBEN-031-24",
+        "XBEN-032-24",
+        "XBEN-033-24",
+        "XBEN-034-24",
+        "XBEN-035-24",
+        "XBEN-036-24",
+        "XBEN-037-24",
+        "XBEN-038-24",
+        "XBEN-039-24",
+        "XBEN-040-24",
+        "XBEN-041-24",
+        "XBEN-042-24",
+        "XBEN-043-24",
+        "XBEN-044-24",
+        "XBEN-045-24",
+        "XBEN-046-24",
+        "XBEN-047-24",
+        "XBEN-048-24",
+        "XBEN-049-24",
+        "XBEN-050-24",
+        "XBEN-054-24",
+        "XBEN-056-24",
+        "XBEN-061-24",
+        "XBEN-075-24",
+        "XBEN-099-24"
+      ]
+    },
+    "unknown": {
+      "solved": 0,
+      "attempted": 5,
+      "rate": 0,
+      "challengesSolved": []
+    }
+  }
+}

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -353,7 +353,7 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
           }
         }
       }
-      const ctx: AdvisoryContext = { scanId, screenshots, patchStatus, versionRange };
+      const ctx: AdvisoryContext = { scanId, screenshots, patchStatus, versionRange, pocExecution: behaviouralReport };
       const rendered = renderAdvisoryMarkdown(finding, ctx);
       const path = join(outputDir, rendered.filename);
       let state: ResultState = "wrote";

--- a/packages/core/src/disclose/template.ts
+++ b/packages/core/src/disclose/template.ts
@@ -3,6 +3,8 @@ import { suggestCwesForCategory, formatCweSection } from "./cwe.js";
 import { suggestCvss } from "./cvss.js";
 import { formatPatchStatusSection, type ReverifyResult } from "./canary.js";
 import { formatVersionRangeLine, type VersionRangeResult } from "./version-range.js";
+import type { SiblingFixCandidate } from "./sibling-fix.js";
+import type { PocExecutionReport } from "./poc-runtime.js";
 
 export interface AdvisoryScreenshot {
   alt: string;
@@ -21,6 +23,17 @@ export interface AdvisoryContext {
   screenshots?: AdvisoryScreenshot[];
   patchStatus?: ReverifyResult;
   versionRange?: VersionRangeResult;
+  /**
+   * "Correct pattern already present in the repo" snippet extracted from a
+   * sibling file. Renders into the Suggested fix section as a fallback when
+   * the finding has no `remediation.codeExample.after`.
+   */
+  siblingFix?: SiblingFixCandidate;
+  /**
+   * Captured PoC execution report from `disclose --target-url`. Renders into
+   * the Patch status section as a behavioural verdict line.
+   */
+  pocExecution?: PocExecutionReport;
 }
 
 export interface RenderedAdvisory {
@@ -49,6 +62,29 @@ function indentEvidenceBlock(raw: string, lang = ""): string {
   const trimmed = raw.trim();
   if (!trimmed) return "";
   return "```" + lang + "\n" + trimmed + "\n```";
+}
+
+function renderPocSteps(finding: Finding): string[] {
+  if (!finding.pocSteps || finding.pocSteps.length === 0) return [];
+  const lines: string[] = ["**Step graph:**", ""];
+  for (const [index, step] of finding.pocSteps.entries()) {
+    lines.push(`${index + 1}. **${step.kind}** — ${step.summary} _(id: \`${step.id}\`)_`);
+    if (step.action.type === "shell") {
+      lines.push("", indentEvidenceBlock(step.action.cmd, "bash"));
+    } else if (step.action.type === "http") {
+      const method = step.action.method.toUpperCase();
+      lines.push("", indentEvidenceBlock(`${method} ${step.action.url}${step.action.body ? `\n\n${step.action.body}` : ""}`, "http"));
+    } else if (step.action.type === "docker") {
+      lines.push("", indentEvidenceBlock(`docker run ${step.action.image} ${step.action.args.join(" ")}`.trim(), "bash"));
+    } else {
+      lines.push("", step.action.text);
+    }
+    if (step.expect) {
+      lines.push("", `Expected result: \`${step.expect.type}\``);
+    }
+    lines.push("");
+  }
+  return lines;
 }
 
 export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = {}): RenderedAdvisory {
@@ -88,6 +124,11 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
         ? `**Before:**\n\n\`\`\`${lang}\n${remediation.codeExample.before}\n\`\`\`\n\n**After:**\n\n\`\`\`${lang}\n${remediation.codeExample.after}\n\`\`\``
         : `\`\`\`${lang}\n${remediation.codeExample.after}\n\`\`\``,
     );
+  } else if (ctx.siblingFix) {
+    const ref = `${ctx.siblingFix.fileRef.file}${ctx.siblingFix.fileRef.line ? `:${ctx.siblingFix.fileRef.line}` : ""}`;
+    suggestedFixParts.push(
+      `**Correct pattern already present in the repo at \`${ref}\`** *(extracted by pwnkit):*\n\n\`\`\`${ctx.siblingFix.language}\n${ctx.siblingFix.snippet}\n\`\`\``,
+    );
   }
   const suggestedFix = suggestedFixParts.length > 0
     ? suggestedFixParts.join("\n\n")
@@ -124,6 +165,10 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
   }
 
   out.push("## PoC", "");
+  const pocStepsBlock = renderPocSteps(finding);
+  if (pocStepsBlock.length > 0) {
+    out.push(...pocStepsBlock);
+  }
   if (ctx.screenshots && ctx.screenshots.length > 0) {
     for (const shot of ctx.screenshots) {
       const width = shot.width ? ` width="${shot.width}"` : "";
@@ -141,7 +186,7 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
     out.push("**Response:**", "");
     out.push(indentEvidenceBlock(finding.evidence.response, "http"), "");
   }
-  if (!finding.evidence?.request?.trim() && !finding.evidence?.response?.trim() && (!ctx.screenshots || ctx.screenshots.length === 0)) {
+  if (pocStepsBlock.length === 0 && !finding.evidence?.request?.trim() && !finding.evidence?.response?.trim() && (!ctx.screenshots || ctx.screenshots.length === 0)) {
     out.push("_To fill in: concrete reproduction steps. `pwnkit-cli disclose` will auto-populate this once PoC execution lands (issue #168)._", "");
   }
 
@@ -153,6 +198,15 @@ export function renderAdvisoryMarkdown(finding: Finding, ctx: AdvisoryContext = 
     out.push(formatPatchStatusSection(ctx.patchStatus), "");
   } else {
     out.push("_Pass `--repo <path>` to `pwnkit-cli disclose` to auto-verify this against the target's current HEAD or a specific tag._", "");
+  }
+  if (ctx.pocExecution) {
+    const verdict = ctx.pocExecution.overallVerdict === "exploit_still_works"
+      ? "**Behavioural check: exploit still reproducible.**"
+      : ctx.pocExecution.overallVerdict === "exploit_broken"
+        ? "**Behavioural check: exploit no longer reproducible.**"
+        : "**Behavioural check: could not run.**";
+    out.push(verdict, "");
+    out.push(`> Verdict: \`${ctx.pocExecution.overallVerdict}\` (${ctx.pocExecution.steps.length} step${ctx.pocExecution.steps.length === 1 ? "" : "s"} executed).`, "");
   }
 
   out.push("## Credits", "");

--- a/packages/core/src/findings-parser.ts
+++ b/packages/core/src/findings-parser.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Finding, Severity } from "@pwnkit/shared";
+import { derivePocStepsFromEvidence } from "./poc-steps.js";
 
 export interface ParseFindingsOptions {
   templatePrefix?: string;
@@ -41,27 +42,33 @@ function parseJsonOutput(output: string, prefix: string): Finding[] {
     if (parsed.findings && Array.isArray(parsed.findings)) {
       return parsed.findings
         .filter((f: any) => f.title && f.severity)
-        .map((f: any) => ({
-          id: randomUUID(),
-          templateId: `${prefix}-${Date.now()}`,
-          title: f.title,
-          description: f.description ?? "",
-          severity: (VALID_SEVERITIES.has(f.severity) ? f.severity : "info") as Severity,
-          category: (f.category ?? "other") as Finding["category"],
-          status: "discovered" as const,
-          evidence: {
+        .map((f: any) => {
+          const evidence = {
             request: f.file ?? "",
             response: f.poc ?? "",
             analysis: f.description ?? "",
-          },
-          // Pass-through with clamping when the upstream JSON schema includes
-          // `confidence`. Downstream cloud-sink also clamps; this is defence
-          // in depth so an agent runtime that reports a wild value (1.5,
-          // -0.2, NaN) never escapes the OSS engine. Absent → undefined,
-          // which the cloud column accepts as NULL.
-          confidence: clampConfidence(f.confidence),
-          timestamp: Date.now(),
-        }));
+          };
+          const explicitSteps = Array.isArray(f.poc_steps) ? f.poc_steps : Array.isArray(f.pocSteps) ? f.pocSteps : undefined;
+          const derivedSteps = derivePocStepsFromEvidence(evidence);
+          return {
+            id: randomUUID(),
+            templateId: `${prefix}-${Date.now()}`,
+            title: f.title,
+            description: f.description ?? "",
+            severity: (VALID_SEVERITIES.has(f.severity) ? f.severity : "info") as Severity,
+            category: (f.category ?? "other") as Finding["category"],
+            status: "discovered" as const,
+            evidence,
+            ...(explicitSteps ? { pocSteps: explicitSteps } : derivedSteps.length > 0 ? { pocSteps: derivedSteps } : {}),
+            // Pass-through with clamping when the upstream JSON schema includes
+            // `confidence`. Downstream cloud-sink also clamps; this is defence
+            // in depth so an agent runtime that reports a wild value (1.5,
+            // -0.2, NaN) never escapes the OSS engine. Absent → undefined,
+            // which the cloud column accepts as NULL.
+            confidence: clampConfidence(f.confidence),
+            timestamp: Date.now(),
+          };
+        });
     }
   } catch {
     // Not valid JSON
@@ -97,6 +104,13 @@ function parseStructuredBlocks(output: string, prefix: string): Finding[] {
     const description = content.match(/^description:\s*([\s\S]*?)(?=^(?:file|---)|$)/m)?.[1]?.trim() ?? "";
     const file = content.match(/^file:\s*(.+)$/m)?.[1]?.trim() ?? "";
 
+    const evidence = {
+      request: file || "Automated AI analysis",
+      response: description,
+      analysis: `Found by ${prefix} agent`,
+    };
+    const derivedSteps = derivePocStepsFromEvidence(evidence);
+
     return {
       id: randomUUID(),
       templateId: `${prefix}-${Date.now()}`,
@@ -105,11 +119,8 @@ function parseStructuredBlocks(output: string, prefix: string): Finding[] {
       severity: (VALID_SEVERITIES.has(severity) ? severity : "info") as Severity,
       category: category as Finding["category"],
       status: "discovered" as const,
-      evidence: {
-        request: file || "Automated AI analysis",
-        response: description,
-        analysis: `Found by ${prefix} agent`,
-      },
+      evidence,
+      ...(derivedSteps.length > 0 ? { pocSteps: derivedSteps } : {}),
       confidence: undefined,
       timestamp: Date.now(),
     };

--- a/packages/core/src/poc-steps.ts
+++ b/packages/core/src/poc-steps.ts
@@ -1,0 +1,78 @@
+import type { Evidence, PocStep } from "@pwnkit/shared";
+
+function looksLikeHttpRequest(text: string): boolean {
+  return /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+/i.test(text.trim());
+}
+
+function parseHttpRequestLine(text: string): { method: string; url: string } | null {
+  const firstLine = text.split("\n")[0]?.trim() ?? "";
+  const m = firstLine.match(/^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(\S+)/i);
+  if (!m) return null;
+  return { method: m[1].toUpperCase(), url: m[2] };
+}
+
+/**
+ * Best-effort derivation of a structured PoC step graph from prose evidence.
+ * Used by `findings-parser` so legacy agent output (which only emitted
+ * free-text request/response/analysis) still gets a basic step graph that
+ * downstream renderers and the behavioural re-verify runtime can consume.
+ *
+ * Returns an empty array when the evidence is too sparse to produce a
+ * meaningful step. Callers should treat that as "no structured graph
+ * available" and fall back to the prose form.
+ */
+export function derivePocStepsFromEvidence(evidence: Evidence): PocStep[] {
+  const steps: PocStep[] = [];
+  const request = evidence.request?.trim() ?? "";
+  const response = evidence.response?.trim() ?? "";
+  const analysis = evidence.analysis?.trim() ?? "";
+
+  if (request) {
+    if (looksLikeHttpRequest(request)) {
+      const parsed = parseHttpRequestLine(request);
+      if (parsed) {
+        steps.push({
+          id: "exploit-1",
+          kind: "exploit",
+          summary: "Trigger vulnerable endpoint",
+          action: { type: "http", method: parsed.method, url: parsed.url },
+        });
+      } else {
+        steps.push({
+          id: "exploit-1",
+          kind: "exploit",
+          summary: "Run exploit request",
+          action: { type: "note", text: request },
+        });
+      }
+    } else {
+      steps.push({
+        id: "exploit-1",
+        kind: "exploit",
+        summary: "Execute exploit command",
+        action: { type: "shell", cmd: request },
+      });
+    }
+  }
+
+  if (response) {
+    steps.push({
+      id: "verify-1",
+      kind: "verify",
+      summary: "Observe vulnerable response",
+      action: { type: "note", text: response },
+      expect: { type: "body-contains", text: response.slice(0, 64) },
+    });
+  }
+
+  if (analysis) {
+    steps.push({
+      id: "analysis-1",
+      kind: "prerequisite",
+      summary: "Analyst context",
+      action: { type: "note", text: analysis },
+    });
+  }
+
+  return steps;
+}

--- a/packages/core/src/runtime/llm-api.test.ts
+++ b/packages/core/src/runtime/llm-api.test.ts
@@ -440,9 +440,9 @@ describe("LlmApiRuntime response parsing", () => {
     (rt as any).wireApi = "responses";
     (rt as any).apiKey = "test";
 
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
-      text: async () => JSON.stringify({
+    const sseEvent = `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
         output: [
           {
             type: "function_call",
@@ -452,8 +452,18 @@ describe("LlmApiRuntime response parsing", () => {
           },
         ],
         usage: { input_tokens: 50, output_tokens: 20 },
+      },
+    })}\n\n`;
+
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(sseEvent));
+          controller.close();
+        },
       }),
-    } as Response)));
+    } as unknown as Response)));
 
     const result = await rt.executeNative("sys", [
       { role: "user", content: [{ type: "text", text: "go" }] },

--- a/packages/core/src/runtime/llm-api.ts
+++ b/packages/core/src/runtime/llm-api.ts
@@ -133,8 +133,23 @@ export function __resetAzureRegionCacheForTests(): void {
   azureRegionCache.clear();
 }
 
-/** Tracks which endpoints we've already printed a startup banner for. */
-const loggedProviderStartup = new Set<string>();
+/**
+ * Tracks which endpoints we've already printed a startup banner for.
+ *
+ * Stashed on `globalThis` under a `Symbol.for` key so the guard survives
+ * module re-evaluation. pnpm monorepos can occasionally resolve this
+ * module from more than one path (source vs compiled, different dep
+ * hoisting), which hands each importer its own module-local `Set` —
+ * the banner then fires once per importer instead of once per process.
+ * Keying on a shared global process-wide Set closes that hole.
+ */
+const PROVIDER_BANNER_KEY = Symbol.for("pwnkit.core.loggedProviderStartup");
+type GlobalWithBannerGuard = typeof globalThis & { [PROVIDER_BANNER_KEY]?: Set<string> };
+const loggedProviderStartup: Set<string> = ((): Set<string> => {
+  const g = globalThis as GlobalWithBannerGuard;
+  if (!g[PROVIDER_BANNER_KEY]) g[PROVIDER_BANNER_KEY] = new Set<string>();
+  return g[PROVIDER_BANNER_KEY];
+})();
 
 function appendNativeTrace(record: Record<string, unknown>): void {
   const file = process.env.PWNKIT_TRACE_NATIVE_RESPONSES;
@@ -457,6 +472,18 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
     return `${this.baseUrl}/v1/messages`;
   }
 
+  /**
+   * Chat-completions param name for the token cap. Newer OpenAI model
+   * families (gpt-5.*, o1/o2/o3) rejected the legacy `max_tokens` field
+   * and require `max_completion_tokens`. Older models still accept the
+   * legacy name, so we flip based on model prefix.
+   */
+  private get maxTokensParamKey(): "max_tokens" | "max_completion_tokens" {
+    return /^gpt-5|^o[1-3](?:[-_]|$)/i.test(this.model)
+      ? "max_completion_tokens"
+      : "max_tokens";
+  }
+
   /** Friendly provider name for error messages. */
   private get providerLabel(): string {
     switch (this.provider) {
@@ -578,7 +605,7 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
           headers: this.buildHeaders(),
           body: JSON.stringify({
             model: this.model,
-            max_tokens: 8192,
+            [this.maxTokensParamKey]: 8192,
             messages,
           }),
           signal: controller.signal,
@@ -725,20 +752,46 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
         chatMessages.push({ role: "system", content: system });
 
         for (const m of messages) {
+          // Batch all tool_use blocks from the same message into a
+          // single assistant message with a tool_calls array. gpt-5+
+          // strictly validates that every assistant with tool_calls is
+          // immediately followed by tool responses for each call id —
+          // splitting one turn into multiple assistant messages breaks
+          // that invariant and produces a 400 from Azure.
+          type ToolCall = {
+            id: string;
+            type: "function";
+            function: { name: string; arguments: string };
+          };
+          const pendingToolCalls: ToolCall[] = [];
+          let pendingAssistantText: string | null = null;
+          const flushAssistant = (): void => {
+            if (pendingToolCalls.length === 0 && pendingAssistantText === null) return;
+            const msg: Record<string, unknown> = { role: "assistant" };
+            if (pendingAssistantText !== null) msg.content = pendingAssistantText;
+            else msg.content = null;
+            if (pendingToolCalls.length > 0) msg.tool_calls = pendingToolCalls.slice();
+            chatMessages.push(msg);
+            pendingToolCalls.length = 0;
+            pendingAssistantText = null;
+          };
+
           for (const block of m.content) {
             if (block.type === "text") {
-              chatMessages.push({ role: m.role, content: block.text });
+              if (m.role === "assistant") {
+                pendingAssistantText = (pendingAssistantText ?? "") + block.text;
+              } else {
+                flushAssistant();
+                chatMessages.push({ role: m.role, content: block.text });
+              }
             } else if (block.type === "tool_use") {
-              chatMessages.push({
-                role: "assistant",
-                content: null,
-                tool_calls: [{
-                  id: block.id,
-                  type: "function",
-                  function: { name: block.name, arguments: JSON.stringify(block.input) },
-                }],
+              pendingToolCalls.push({
+                id: block.id,
+                type: "function",
+                function: { name: block.name, arguments: JSON.stringify(block.input) },
               });
             } else if (block.type === "tool_result") {
+              flushAssistant();
               chatMessages.push({
                 role: "tool",
                 tool_call_id: block.tool_use_id,
@@ -746,11 +799,15 @@ export class LlmApiRuntime implements Runtime, NativeRuntime {
               });
             }
           }
+          // End-of-message flush so a turn that ends with tool_use
+          // blocks emits one assistant message with the full tool_calls
+          // array before the next turn's tool_results land.
+          flushAssistant();
         }
 
         const body: Record<string, unknown> = {
           model: this.model,
-          max_tokens: 8192,
+          [this.maxTokensParamKey]: 8192,
           messages: chatMessages,
         };
 

--- a/packages/core/src/scanner.ts
+++ b/packages/core/src/scanner.ts
@@ -9,6 +9,7 @@ import { runSourceAnalysis } from "./stages/source-analysis.js";
 import { runAttacks } from "./stages/attack.js";
 import { runVerification } from "./stages/verify.js";
 import { generateReport } from "./stages/report.js";
+import { eventBus } from "./events/bus.js";
 // Lazy-load DB to avoid native module issues when DB isn't needed
 let _db: any = null;
 
@@ -67,7 +68,15 @@ export async function scan(
   onEvent?: ScanListener,
   dbPath?: string
 ): Promise<ScanReport> {
-  const emit = onEvent ?? (() => {});
+  const baseEmit = onEvent ?? (() => {});
+  // Wrap the user-provided ScanListener so every legacy `ScanEvent`
+  // also fans out to the pluggable event bus (cloud relay, dashboard
+  // tracer, test spies, …). The mapping preserves the legacy shape
+  // 1:1 — the external ScanListener API is unchanged.
+  const emit: ScanListener = (event) => {
+    baseEmit(event);
+    relayScanEventToBus(event);
+  };
   const ctx: ScanContext = createScanContext(config);
 
   // Initialize DB for persistence (optional — graceful fallback if native module unavailable)
@@ -211,6 +220,15 @@ export async function scan(
     db.completeScan(scanId, reportResult.data.summary as unknown as Record<string, unknown>);
   }
 
+  // Bus event: canonical scan_completed — picked up by the cloud relay
+  // so the worker-controller can transition the pod to done, and by any
+  // dashboard tracer that wants to render the final frame.
+  eventBus.emit("scan_completed", {
+    exit_reason: "completed",
+    findings: reportResult.data.findings.length,
+    duration_ms: reportResult.durationMs,
+  });
+
   return reportResult.data;
   } finally {
     if (db) {
@@ -218,5 +236,50 @@ export async function scan(
       // Reset the singleton so subsequent scans open a fresh connection
       _db = null;
     }
+  }
+}
+
+/**
+ * Map a legacy `ScanEvent` onto the richer bus vocabulary. This preserves
+ * the existing ScanListener API 1:1 while letting bus sinks (cloud relay,
+ * dashboard tracer) observe the same stage/finding/usage signal.
+ */
+function relayScanEventToBus(event: ScanEvent): void {
+  switch (event.type) {
+    case "stage:start":
+      eventBus.emit("step_started", {
+        step: event.stage ?? "unknown",
+      });
+      return;
+    case "stage:end":
+      eventBus.emit("step_completed", {
+        step: event.stage ?? "unknown",
+        message: event.message,
+      });
+      return;
+    case "finding": {
+      const f = (event.data ?? {}) as Record<string, unknown>;
+      eventBus.emit("finding_ingested", {
+        finding_id: typeof f.id === "string" ? f.id : undefined,
+        severity: typeof f.severity === "string" ? f.severity : undefined,
+        title: typeof f.title === "string" ? f.title : undefined,
+        category: typeof f.category === "string" ? f.category : undefined,
+      });
+      return;
+    }
+    case "usage": {
+      const u = (event.data ?? {}) as Record<string, unknown>;
+      eventBus.emit("cost_update", {
+        cost_usd: typeof u.estimatedCostUsd === "number" ? u.estimatedCostUsd : undefined,
+        input_tokens: typeof u.inputTokens === "number" ? u.inputTokens : undefined,
+        output_tokens: typeof u.outputTokens === "number" ? u.outputTokens : undefined,
+        turn: typeof u.turn === "number" ? u.turn : undefined,
+      });
+      return;
+    }
+    default:
+      // thinking / attack:* / verify:result / error / user:injected have no
+      // current cloud-side consumer — intentionally dropped by the relay.
+      return;
   }
 }

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -374,6 +374,13 @@ export class pwnkitDB {
     if (!colNames.has("verificationSpec")) {
       this.sqlite.exec("ALTER TABLE findings ADD COLUMN verificationSpec TEXT");
     }
+    // pwnkit#171 — captured PoC execution report. JSON-stringified
+    // PocExecutionReport written by `disclose --target-url …` when the
+    // behavioural re-verify runtime ran the step graph against a live
+    // target. Optional/additive.
+    if (!colNames.has("pocExecution")) {
+      this.sqlite.exec("ALTER TABLE findings ADD COLUMN pocExecution TEXT");
+    }
     this.sqlite.exec("UPDATE findings SET fingerprint = id WHERE fingerprint IS NULL OR fingerprint = ''");
     this.sqlite.exec("UPDATE findings SET triageStatus = 'new' WHERE triageStatus IS NULL OR triageStatus = ''");
     this.sqlite.exec(`
@@ -1180,6 +1187,13 @@ export class pwnkitDB {
     const verificationSpecJson = finding.verificationSpec
       ? JSON.stringify(finding.verificationSpec)
       : null;
+    // Backfill prose evidence from pocSteps for findings that only carry the
+    // structured form, so legacy advisory templates / dashboards still see
+    // request/response/analysis text. The structured pocSteps remain canonical.
+    const derivedEvidence = deriveEvidenceFromPocSteps(finding);
+    const evidenceRequest = finding.evidence.request || derivedEvidence.request;
+    const evidenceResponse = finding.evidence.response || derivedEvidence.response;
+    const evidenceAnalysis = finding.evidence.analysis ?? derivedEvidence.analysis ?? null;
     this.db
       .insert(schema.findings)
       .values({
@@ -1201,9 +1215,9 @@ export class pwnkitDB {
         confidence: finding.confidence ?? null,
         cvssVector: finding.cvssVector ?? null,
         cvssScore: finding.cvssScore ?? null,
-        evidenceRequest: finding.evidence.request,
-        evidenceResponse: finding.evidence.response,
-        evidenceAnalysis: finding.evidence.analysis ?? null,
+        evidenceRequest,
+        evidenceResponse,
+        evidenceAnalysis,
         layerVerdicts: layerVerdictsJson,
         pocSteps: pocStepsJson,
         verificationSpec: verificationSpecJson,
@@ -1228,9 +1242,9 @@ export class pwnkitDB {
           confidence: finding.confidence ?? null,
           cvssVector: finding.cvssVector ?? null,
           cvssScore: finding.cvssScore ?? null,
-          evidenceRequest: finding.evidence.request,
-          evidenceResponse: finding.evidence.response,
-          evidenceAnalysis: finding.evidence.analysis ?? null,
+          evidenceRequest,
+          evidenceResponse,
+          evidenceAnalysis,
           layerVerdicts: layerVerdictsJson,
           pocSteps: pocStepsJson,
           verificationSpec: verificationSpecJson,
@@ -1314,6 +1328,15 @@ export class pwnkitDB {
       .where(eq(schema.findings.id, findingId))
       .run();
     if (finding?.fingerprint) this.syncFindingGraph(finding.scanId, finding.fingerprint);
+  }
+
+  saveFindingPocExecution(findingId: string, execution: unknown): void {
+    const serialized = JSON.stringify(execution);
+    this.db
+      .update(schema.findings)
+      .set({ pocExecution: serialized })
+      .where(eq(schema.findings.id, findingId))
+      .run();
   }
 
   updateFindingTriageByFingerprint(
@@ -1987,6 +2010,46 @@ function buildFindingFingerprint(target: string, finding: Finding): string {
   return createHash("sha256").update(key).digest("hex").slice(0, 24);
 }
 
+/**
+ * When a finding only carries `pocSteps` and no prose evidence, derive the
+ * legacy `evidence.{request,response,analysis}` strings from the step graph
+ * so older readers (markdown advisory templates that pre-date pocSteps,
+ * dashboards that haven't been updated) still see something useful. The
+ * structured `pocSteps` field remains the canonical form — this is purely
+ * for backwards compatibility on the read path.
+ */
+function deriveEvidenceFromPocSteps(finding: Finding): { request: string; response: string; analysis?: string } {
+  if (!finding.pocSteps || finding.pocSteps.length === 0) {
+    return { request: "", response: "", analysis: undefined };
+  }
+
+  const requestParts: string[] = [];
+  const responseParts: string[] = [];
+  const analysisParts: string[] = [];
+
+  for (const step of finding.pocSteps) {
+    const prefix = `[${step.kind}] ${step.summary}`;
+    if (step.action.type === "shell") {
+      requestParts.push(`${prefix}\n$ ${step.action.cmd}`);
+    } else if (step.action.type === "http") {
+      requestParts.push(`${prefix}\n${step.action.method.toUpperCase()} ${step.action.url}`);
+    } else if (step.action.type === "docker") {
+      requestParts.push(`${prefix}\ndocker run ${step.action.image} ${step.action.args.join(" ")}`.trim());
+    } else {
+      responseParts.push(`${prefix}\n${step.action.text}`);
+    }
+    if (step.expect) {
+      analysisParts.push(`- ${step.id}: expect ${step.expect.type}`);
+    }
+  }
+
+  return {
+    request: requestParts.join("\n\n"),
+    response: responseParts.join("\n\n"),
+    analysis: analysisParts.length > 0 ? `PoC step expectations:\n${analysisParts.join("\n")}` : undefined,
+  };
+}
+
 // ── Raw SQL for table creation (idempotent, used on init) ──
 
 const SCHEMA_TABLES_SQL = `
@@ -2037,6 +2100,7 @@ CREATE TABLE IF NOT EXISTS findings (
   evidenceAnalysis TEXT,
   pocSteps TEXT,
   verificationSpec TEXT,
+  pocExecution TEXT,
   timestamp INTEGER NOT NULL
 );
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -125,6 +125,12 @@ export const findings = sqliteTable(
      * pwnkit-cloud#111.
      */
     verificationSpec: text("verificationSpec"),
+    /**
+     * JSON-stringified PocExecutionReport written when `disclose --target-url`
+     * runs the step graph against a live target. NULL until that runs. See
+     * pwnkit#171.
+     */
+    pocExecution: text("pocExecution"),
     timestamp: integer("timestamp").notNull(),
   },
   (table) => [


### PR DESCRIPTION
## Summary

Reconciled with main after #170/#171/#193/#194 landed. The original branch was started before the parallel disclose stream merged, so this rebased version drops everything already on main and ports forward only the truly novel pieces.

**Runtime — gpt-5/o-series compatibility fixes**
- Flip `max_tokens` → `max_completion_tokens` for gpt-5.* and o1/o2/o3 on chat-completions
- Batch all assistant tool_use blocks into one `tool_calls` array (gpt-5+ rejects the split form with a 400)
- Stash provider-banner guard on `globalThis` under a `Symbol.for` key so it survives module re-evaluation across pnpm hoisting paths
- Update the Responses-API function_call test to mock SSE (the path is now always streaming)

**Events — legacy `scan()` parity with agentic scanner**
- Emit canonical `scan_completed` from the legacy `scan` entrypoint
- Wrap the `ScanListener` so every `ScanEvent` also fans out to the pluggable bus (stage:start → step_started, finding → finding_ingested, usage → cost_update)

**Disclose — pocExecution persistence + advisory rendering**
- New `pocExecution` DB column + `saveFindingPocExecution` so the verdict from `disclose --target-url` round-trips through the findings table
- `deriveEvidenceFromPocSteps` backfill on save so legacy renderers see prose
- `derivePocStepsFromEvidence` in findings-parser turns legacy free-text evidence into a basic step graph; explicit `poc_steps` from the agent still wins
- Advisory template renders the step graph as a numbered block under `## PoC`, falls back to the sibling-fix snippet under `## Suggested fix`, and appends a behavioural verdict line under `## Patch status` when the CLI ran `executePocSteps`
- Disclose CLI passes the captured `behaviouralReport` into the advisory context

**Docs**
- XBOW retained-artifact tally → 102/104 = 98.1% aggregate (XBEN-066 newly cracked); only XBEN-030 + XBEN-092 unsolved in any mode

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 798/798 passing across core, test-targets, cli
- [x] No conflicts with main's `verificationSpec` / `executePocSteps` / `pocSteps` types — this branch is purely additive on top of those

## What was dropped vs the original branch

These were already on main and would have been duplicate / conflicting:
- `PocStep` / `PocStepAction` / `PocStepExpect` types in shared
- `executePocSteps` + `poc-runtime.ts`
- Bus `delta` event + agent loops `onDelta`
- `extractSiblingFix` + `composeStepSession`
- Disclose CLI `--target-url` flag (kept main's name)
- `pocSteps` DB column

Backup of the pre-reset branch state is preserved at tag `backup/feat-disclose-pre-reset` on origin in case anyone needs to compare.

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive advisory markdown generation with embedded PoC execution details
  * Enhanced proof-of-concept step derivation from security evidence
  * Integrated cloud event bus for real-time scan progress and findings updates

* **Documentation**
  * Updated benchmark results with improved artifact retention metrics (98.1% aggregate, 91.3% black-box, 96.2% white-box)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->