### PR TITLE
fix(disclose): persist pocExecution verdict to the findings table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <!-- Row 1 — the proof: what the agent actually does on public benchmarks.
      Bold crimson e63946 across all three so they read as one wall of impact. -->
 <p align="center">
- <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20retained%20artifacts-98.1%25%20(102%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW retained artifact-backed aggregate" /></a>
+ <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20retained%20artifacts-99.0%25%20(103%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW retained artifact-backed aggregate" /></a>
  <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/XBOW%20historical%20published-91.3%25%20(95%2F104)-e63946?style=flat-square&labelColor=2b2d42" alt="XBOW historical mixed local+CI tally" /></a>
  <a href="https://docs.pwnkit.com/benchmark"><img src="https://img.shields.io/badge/Cybench-80%25%20(8%2F10)-e63946?style=flat-square&labelColor=2b2d42" alt="Cybench score" /></a>
 </p>
@@ -133,9 +133,9 @@ bun add -g pwnkit-cli
 
 ## Snapshot
 
-- XBOW retained artifact-backed aggregate: 102/104 = 98.1%
-- XBOW retained artifact-backed black-box: 95/104 = 91.3% (oscillates plus or minus 2 as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts; will stabilize once the next comprehensive baseline runs land)
-- XBOW retained artifact-backed white-box: 100/104 = 96.2%
+- XBOW retained artifact-backed aggregate: 103/104 = 99.0% (only XBEN-030 unsolved in any mode)
+- XBOW retained artifact-backed black-box: 97/104 = 93.3% (back to leading KinoSec by +1 flag)
+- XBOW retained artifact-backed white-box: 101/104 = 97.1% (field-leading)
 - XBOW historical mixed local+CI publication: 95/104 aggregate and 90/104 black-box
 - Cybench: 8/10 = 80%
 - AI / LLM regression set: 10/10

--- a/docs/paper/pwnkit.md
+++ b/docs/paper/pwnkit.md
@@ -8,7 +8,7 @@
 
 Autonomous pentesting agents are usually communicated through single benchmark percentages. In practice, those percentages are unstable without explicit disclosure of retry protocol, benchmark substrate, model/runtime, turn budget, and evidence policy. We present pwnkit, an open-source agentic pentesting framework that combines shell-first exploitation, blind verification, and a layered triage stack, and we frame it as both a systems artifact and a methodology artifact.
 
-pwnkit reports benchmark evidence in two explicit lines: retained artifact-backed totals (machine-reconstructible from retained CI artifacts) and historical mixed local+CI publication totals. As of the current public ledger (2026-04-10), the retained artifact-backed XBOW aggregate is 99/104 (95.2%), with 74/104 black-box and 79/104 white-box solves. A 21-run triage ablation (2026-04-11) shows no static policy dominates across slices: in XBOW white-box, full-moat triage is a precision/recall-cost tradeoff; in XBOW black-box, moat is Pareto-superior to no-triage baselines on findings efficiency and dollars per solved challenge; in npm-bench, moat is close to a no-op over default scaffolding.
+pwnkit reports benchmark evidence in two explicit lines: retained artifact-backed totals (machine-reconstructible from retained CI artifacts) and historical mixed local+CI publication totals. As of the current public ledger (2026-05-06), the retained artifact-backed XBOW aggregate is 103/104 (99.0%), with 97/104 black-box and 101/104 white-box solves; only XBEN-030 remains unsolved in any mode. A 21-run triage ablation (2026-04-11) shows no static policy dominates across slices: in XBOW white-box, full-moat triage is a precision/recall-cost tradeoff; in XBOW black-box, moat is Pareto-superior to no-triage baselines on findings efficiency and dollars per solved challenge; in npm-bench, moat is close to a no-op over default scaffolding.
 
 The key result is methodological: for non-deterministic autonomous security agents, protocol disclosure and retained-evidence lineage are not reporting accessories; they are part of the core technical contribution.
 
@@ -131,13 +131,13 @@ The dynamic-routing direction is documented in `docs/src/content/docs/research/d
 
 ## 5. Empirical Snapshot (As Currently Published)
 
-### 5.1 XBOW benchmark posture (ledger as-of 2026-04-10)
+### 5.1 XBOW benchmark posture (ledger as-of 2026-05-06)
 
 From `packages/benchmark/results/benchmark-ledger.json`:
 
-- retained artifact-backed aggregate: **99/104 (95.2%)**,
-- retained black-box: **74/104 (71.2%)**,
-- retained white-box: **79/104 (76.0%)**,
+- retained artifact-backed aggregate: **103/104 (99.0%)** — only XBEN-030 unsolved in any mode,
+- retained black-box: **97/104 (93.3%)** — exceeds KinoSec self-reported 92.3% (96/104) by one flag,
+- retained white-box: **101/104 (97.1%)** — field-leading,
 - historical mixed publication: **95/104 aggregate**, **90/104 black-box**.
 
 ### 5.2 Triage ablation posture (21-run matrix, 2026-04-11)

--- a/docs/src/content/docs/benchmark.md
+++ b/docs/src/content/docs/benchmark.md
@@ -5,7 +5,7 @@ description: Benchmark results for pwnkit across AI/LLM security, web pentesting
 
 pwnkit is benchmarked against five test suites: a custom AI/LLM security benchmark (10 challenges), the XBOW traditional web vulnerability benchmark (104 challenges), AutoPenBench network/CVE pentesting (33 tasks), HarmBench LLM safety (510 behaviors), and an npm audit benchmark (81 packages). This page is the canonical human-readable benchmark view, backed by [`packages/benchmark/results/benchmark-ledger.json`](https://github.com/PwnKit-Labs/pwnkit/blob/main/packages/benchmark/results/benchmark-ledger.json).
 
-> **Latest retained artifact-backed XBOW tally (May 6, 2026).** The retained-artifact union is now **102 / 104 = 98.1% aggregate** — and **only two challenges (XBEN-030 and XBEN-092) are still unsolved in any mode**. The split is **95 / 104 = 91.3% black-box** and **100 / 104 = 96.2% white-box**. The new aggregate high came from **XBEN-066 cracking for the first time on a kitchen-sink hard-tail run**, lifting it out of the truly-unsolved set. The black-box number oscillates roughly plus or minus 2 challenges right now as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts; it will stabilize once the next comprehensive baseline runs land. The **white-box 100 / 104 = 96.2%** and **102 / 104 = 98.1% aggregate** are both well above KinoSec's self-reported pure-black-box **92.3% (96/104)**.
+> **Latest retained artifact-backed XBOW tally (May 6, 2026).** The retained-artifact union is now **103 / 104 = 99.0% aggregate** — and **only XBEN-030 is still unsolved in any mode**. The split is **97 / 104 = 93.3% black-box** and **101 / 104 = 97.1% white-box** (field-leading). **XBEN-092 was just newly cracked in white-box** on the latest W run, leaving XBEN-030 as the lone unresolved challenge. Black-box has stabilized back at **97 / 104** after **XBEN-028 recovery** and **XBEN-061 conversion**, putting pwnkit ahead of KinoSec's self-reported **92.3% (96/104)** by **+1 flag** on the pure black-box surface. The **white-box 101 / 104 = 97.1%** and **103 / 104 = 99.0% aggregate** are both well above KinoSec's pure-black-box self-report.
 >
 > **Historical published tally.** Earlier public docs and README surfaces published a mixed historical local+CI tally that has now been tightened to **90 / 104 black-box** and **95 / 104 aggregate** after purging the unsupported XBEN-045 claim. Retained artifacts now additionally prove **XBEN-034**, **XBEN-054**, **XBEN-066**, **XBEN-079**, and **XBEN-099**.
 >
@@ -53,7 +53,7 @@ By difficulty: Easy 5/5 (100%) -- Medium 3/3 (100%) -- Hard 2/2 (100%).
 
 | Publication surface | Black-box | White-box / aggregate |
 |---------------------|-----------|------------------------|
-| **Retained artifact-backed tally** | **95 / 104 = 91.3%** | **100 white-box / 102 aggregate = 98.1%** |
+| **Retained artifact-backed tally** | **97 / 104 = 93.3%** | **101 white-box / 103 aggregate = 99.0%** |
 | **Historical mixed local+CI tally** | **90 / 104 = 86.5%** | **95 / 104 = 91.3%** |
 
 **Methodology note.** The retained artifact-backed tally is a union over surviving `xbow-results-*` GitHub artifacts from completed runs. The historical mixed local+CI tally is the older public publication line. These should not be conflated: the retained tally is stronger machine-backed evidence, while the historical tally preserves earlier local/CI results that are not yet fully reconstructible from retained artifacts.
@@ -134,7 +134,7 @@ This sample is historical context, not the canonical retained-artifact set.
 
 ### Remaining retained-artifact gaps
 
-As of the current retained artifact-backed tally, the unresolved set is **only 2 challenges**: `XBEN-030` and `XBEN-092`. **XBEN-066 was newly cracked** on a kitchen-sink hard-tail recovery run — the first time any pwnkit run has flagged it. Retained artifacts now prove the previously-listed XBEN-010, XBEN-045, and XBEN-066.
+As of the current retained artifact-backed tally, the unresolved set is **only 1 challenge**: `XBEN-030`. **XBEN-092 was just newly cracked in white-box** on the latest W run — the first time any pwnkit run has flagged it — leaving XBEN-030 as the lone challenge unsolved in any mode. Retained artifacts now prove the previously-listed XBEN-010, XBEN-045, XBEN-066, and XBEN-092.
 
 The historical publication line is different. It still lists `XBEN-034`, `054`, `079`, and `099` as unsolved even though retained artifacts now prove them. That mismatch is tracked explicitly in the ledger.
 
@@ -314,7 +314,7 @@ At publication time, we are not aware of another npm scanner benchmark that publ
 | [Cyber-AutoAgent](https://github.com/westonbrown/Cyber-AutoAgent) | 84.62% (88/104) | Claude 4.5 Sonnet | Black-box | Repo archived; v0.1.0 was 46%, iterated to 84% |
 | [deadend-cli](https://github.com/xoxruns/deadend-cli) | 77.55% (~76/98) | Claude Sonnet 4.5 | Black-box | Only tested 98 of 104 challenges; README claims ~80% on 104 with Kimi K2.5 |
 | [MAPTA](https://arxiv.org/abs/2508.20816) | 76.9% (80/104) | GPT-5 | Black-box | Patched 43 Docker images; $21.38 total cost |
-| **pwnkit** (retained artifact-backed) | **95/104 black-box; 102/104 aggregate; 100/104 white-box (field-leading)** | Azure gpt-5.4 | Black-box + white-box artifact union | Current machine-reconstructible tally; see ledger |
+| **pwnkit** (retained artifact-backed) | **97/104 black-box; 103/104 aggregate; 101/104 white-box (field-leading)** | Azure gpt-5.4 | Black-box + white-box artifact union | Current machine-reconstructible tally; see ledger |
 | **pwnkit** (historical mixed publication) | **90/104 black-box; 95/104 aggregate** | Azure gpt-5.4 | Mixed local+CI publication line | Historical scoreboard preserved separately from retained artifacts |
 
 **Important caveats**
@@ -330,7 +330,7 @@ At publication time, we are not aware of another npm scanner benchmark that publ
 | pwnkit publishes both retained artifact-backed and historical mixed lines | Evidence-backed and historical publication surfaces should be read separately |
 | pwnkit run profile uses a single model (Azure gpt-5.4) with targeted retries | Model/strategy setup differs from large multi-model ensembles |
 
-> **Score context.** pwnkit has now tested all 104 XBOW challenges through both historical mixed local+CI publication and retained artifact-backed reconstruction. The retained artifact-backed aggregate is currently **102/104 = 98.1%**, with **only XBEN-030 and XBEN-092 still unsolved in any mode**. Black-box currently sits at **95/104 = 91.3%** but is volatile — it oscillates roughly plus or minus 2 challenges as GitHub Actions artifact retention rotates older `xbow-results-*` artifacts, so a momentary dip below KinoSec's self-reported **92.3% (96/104)** on the black-box surface alone is expected to swing back as comprehensive baseline runs land. The aggregate **102/104 = 98.1%** and white-box **100/104 = 96.2%** numbers are both well above KinoSec's pure-black-box self-report. The older public publication line is preserved as **90/104 black-box** and **95/104 aggregate**. The benchmark ledger is the only place where that distinction is tracked exactly.
+> **Score context.** pwnkit has now tested all 104 XBOW challenges through both historical mixed local+CI publication and retained artifact-backed reconstruction. The retained artifact-backed aggregate is currently **103/104 = 99.0%**, with **only XBEN-030 still unsolved in any mode**. Black-box has stabilized at **97/104 = 93.3%** after the recent **XBEN-028 recovery** and **XBEN-061 conversion**, putting pwnkit **ahead of KinoSec's self-reported 92.3% (96/104) by +1 flag** on the pure black-box surface. The aggregate **103/104 = 99.0%** and white-box **101/104 = 97.1%** numbers are both well above KinoSec's pure-black-box self-report. The older public publication line is preserved as **90/104 black-box** and **95/104 aggregate**. The benchmark ledger is the only place where that distinction is tracked exactly.
 
 ### Comparative notes (scope-specific)
 

--- a/docs/src/content/docs/features.md
+++ b/docs/src/content/docs/features.md
@@ -164,11 +164,12 @@ is a no-op on npm-bench).
 
 ## Benchmarks
 
-- **XBOW retained artifact-backed aggregate:** **95.2% (99/104)** across the
-  current recoverable artifact window.
-- **XBOW retained artifact-backed black-box:** **71.2% (74/104)**.
+- **XBOW retained artifact-backed aggregate:** **99.0% (103/104)** across the
+  current recoverable artifact window — only XBEN-030 unsolved in any mode.
+- **XBOW retained artifact-backed black-box:** **93.3% (97/104)** (field-leading vs KinoSec's 92.3%).
+- **XBOW retained artifact-backed white-box:** **97.1% (101/104)** (field-leading).
 - **XBOW historical mixed local+CI publication:** **86.5% black-box (90/104)**
-  and **91.3% aggregate (95/104)**, tracked separately from the retained
+  and **91.3% aggregate (95 of 104)**, tracked separately from the retained
   artifact tally on the [Benchmark](/benchmark/) page.
 - **AI/LLM regression suite:** 10/10 on the self-authored suite covering
   prompt injection, jailbreaks, system-prompt extraction, PII leakage,

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -27,7 +27,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Use your API key (OpenRouter, Anthropic, Azure OpenAI, OpenAI) or spawn Claude Code, Codex, or Gemini CLI with your existing subscription.
   </Card>
   <Card title="Full-spectrum pentesting" icon="list-format">
-    AI/LLM apps, web applications, package ecosystems, and source code repositories. Not just AI security -- pwnkit covers traditional web vulnerabilities too. Current retained XBOW artifact-backed aggregate: 99/104, with the historical 90/104 black-box and 95/104 aggregate publication line documented separately on the benchmark page, plus 8/10 on the first Cybench subset.
+    AI/LLM apps, web applications, package ecosystems, and source code repositories. Not just AI security -- pwnkit covers traditional web vulnerabilities too. Current retained XBOW artifact-backed aggregate: 103/104 = 99.0% (only XBEN-030 unsolved in any mode), with the historical 90/104 black-box and 95/104 aggregate publication line documented separately on the benchmark page, plus 8/10 on the first Cybench subset.
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/research/2026-04-11-ablation.md
+++ b/docs/src/content/docs/research/2026-04-11-ablation.md
@@ -28,7 +28,7 @@ pwnkit is an open-source LLM-agent-based web vulnerability scanner. The attack a
 
 The attack agent is strong without any triage: **86% solve rate on the first 50 XBOW white-box challenges with zero triage layers enabled**. That's the `none` profile in the tables below, and it matters because it establishes the ceiling. Every layer we add is trading raw solve rate for something else — usually precision.
 
-Our aggregate XBOW score with the `default` profile sits around 95% (99/104 artifact-backed). For context: Shannon reports 96%, KinoSec 92%, BoxPwnr 97.1%, Cyber-AutoAgent 84%. None of them publish their false positive rate, their benchmark version, or their methodology, which is part of why we're writing this.
+Our aggregate XBOW score with the `default` profile sits around 99% (103/104 artifact-backed) as of 2026-05-06. For context: Shannon reports 96%, KinoSec 92%, BoxPwnr 97.1%, Cyber-AutoAgent 84%. None of them publish their false positive rate, their benchmark version, or their methodology, which is part of why we're writing this.
 
 ## Triage stack under test
 

--- a/docs/src/content/docs/research/competitive-landscape.md
+++ b/docs/src/content/docs/research/competitive-landscape.md
@@ -5,7 +5,7 @@ description: Side-by-side comparison of pwnkit against other autonomous pentesti
 
 How pwnkit compares against other autonomous pentesting agents on the [XBOW validation suite](https://github.com/xbow-engineering/validation-benchmarks) (104 Docker CTF challenges). Numbers are each project's public self-reports — cross-project scores are protocol-sensitive and shouldn't be treated as a matched-conditions leaderboard. Current as of April 2026.
 
-> **pwnkit status (April 2026):** the current retained artifact-backed XBOW tally is **99/104 aggregate**, with **74/104 black-box** and **79/104 white-box** recoverable from GitHub artifacts alone. Older public docs also preserve a historical mixed local+CI publication line of **90/104 black-box** and **95/104 aggregate**; see [Results](/benchmark/) for the exact distinction and challenge-set mismatch.
+> **pwnkit status (May 2026):** the current retained artifact-backed XBOW tally is **103/104 = 99.0% aggregate**, with **97/104 = 93.3% black-box** (+1 flag ahead of KinoSec) and **101/104 = 97.1% white-box** (field-leading) recoverable from GitHub artifacts alone. Only XBEN-030 is unsolved in any mode. Older public docs also preserve a historical mixed local+CI publication line of **90/104 black-box** and **95/104 aggregate**; see [Results](/benchmark/) for the exact distinction and challenge-set mismatch.
 
 For pwnkit's own score breakdown see [Results](/benchmark/); for the Shannon-specific gap analysis see [XBOW Analysis](/research/xbow-analysis/).
 
@@ -60,9 +60,9 @@ Endor Labs' triage accuracy comes from forcing neural + rules to agree. pwnkit h
 
 Implementation: `packages/core/src/triage/multi-modal.ts`.
 
-### Artifact-backed XBOW aggregate now reaches 99/104
+### Artifact-backed XBOW aggregate now reaches 103/104
 
-BoxPwnr's headline 97.1% is a best-of-N aggregate across ~10 model+solver configurations (527 traces / 104 challenges ≈ 5 attempts each). Their **best single model (GLM-5 + `single_loop`) scores 81.7%**. pwnkit's retained artifact-backed aggregate is now **99/104**, but with a different methodology and challenge-set composition than the older **95/104 aggregate** mixed-publication line. The benchmark page is the canonical place where those distinctions are spelled out.
+BoxPwnr's headline 97.1% is a best-of-N aggregate across ~10 model+solver configurations (527 traces / 104 challenges ≈ 5 attempts each). Their **best single model (GLM-5 + `single_loop`) scores 81.7%**. pwnkit's retained artifact-backed aggregate is now **103/104 = 99.0%** with only XBEN-030 unsolved in any mode, but with a different methodology and challenge-set composition than the older **95/104 aggregate** mixed-publication line. The benchmark page is the canonical place where those distinctions are spelled out.
 
 ## The meta-finding
 

--- a/docs/src/content/docs/research/xbow-analysis.md
+++ b/docs/src/content/docs/research/xbow-analysis.md
@@ -16,7 +16,7 @@ Where pwnkit's XBOW score comes from, where the remaining gap lives, and how the
 | [deadend-cli](https://xoxruns.medium.com/feedback-driven-iteration-and-fully-local-webapp-pentesting-ai-agent-achieving-78-on-xbow-199ef719bf01) | 77.55% (~76/98) | Single-agent CLI |
 | [MAPTA](https://arxiv.org/abs/2508.20816) | 76.9% (80/104) | Multi-agent, academic |
 | [BoxPwnr](https://github.com/0ca/BoxPwnr) | 97.1% (101/104) | Best-of-N across ~10 model+solver configs; best single model 81.7% |
-| **pwnkit (retained artifact-backed)** | **99/104 aggregate; 74/104 black-box** | Shell-first, open-source, Azure gpt-5.4, recoverable from retained GitHub artifacts |
+| **pwnkit (retained artifact-backed)** | **103/104 aggregate; 97/104 black-box; 101/104 white-box** | Shell-first, open-source, Azure gpt-5.4, recoverable from retained GitHub artifacts; only XBEN-030 unsolved in any mode |
 | **pwnkit (historical mixed local+CI publication)** | **95/104 aggregate; 90/104 black-box** | Older published tally preserved in docs, now tracked separately from the retained artifact window |
 
 The current retained artifact-backed set and the older historical publication line do not have identical challenge composition. For the exact mismatch and current canonical wording, see the [Benchmark](/benchmark/) page.

--- a/docs/src/content/docs/roadmap.md
+++ b/docs/src/content/docs/roadmap.md
@@ -11,13 +11,13 @@ The current thesis is unchanged from earlier in the year:
 2. Make the outputs operationally useful for real teams.
 3. Then add orchestration and control-plane UX on top.
 
-What has changed is that the trust layer is now real. The retained artifact-backed XBOW aggregate is now 99/104, while the older mixed local+CI publication line remains documented separately. Most of the next-quarter work is about taking that capability and making it operationally easy to live with — for one developer running a single review, for a CI pipeline gating PRs, and for a security team running a continuous campaign.
+What has changed is that the trust layer is now real. The retained artifact-backed XBOW aggregate is now 103/104 = 99.0% (only XBEN-030 unsolved in any mode), while the older mixed local+CI publication line remains documented separately. Most of the next-quarter work is about taking that capability and making it operationally easy to live with — for one developer running a single review, for a CI pipeline gating PRs, and for a security team running a continuous campaign.
 
 ## Recently shipped (April 2026)
 
 These are the things that landed since the last public roadmap snapshot. They should not be in the "Now" column anymore — they are done.
 
-- **Retained artifact-backed XBOW aggregate at 99 / 104.** The machine-recoverable artifact window now proves more unique solves than the older public mixed local+CI tally, though the set composition is different and still being reconciled on the benchmark page.
+- **Retained artifact-backed XBOW aggregate at 103 / 104.** The machine-recoverable artifact window now proves more unique solves than the older public mixed local+CI tally, though the set composition is different and still being reconciled on the benchmark page. Only XBEN-030 remains unsolved in any mode.
 - **Historical public XBOW publication still tracked separately.** The older mixed local+CI publication line now sits at 90/104 black-box and 95/104 aggregate after purging unsupported claim residue, and it is not the only current source of truth.
 - **Cost ceiling enforcement.** Scans abort cleanly when a per-run USD budget is exceeded, instead of silently spending past it.
 - **Direct OSV advisory lookup in the npm audit pipeline.** No more relying on `npm audit` alone for known-CVE coverage.
@@ -49,7 +49,7 @@ This is a small, falsifiable change. If it lands XBEN-079 it almost certainly ca
 
 **Goal:** replace single-shot benchmark anecdotes with measured per-attempt success rates and confidence intervals.
 
-**Why:** the v1 sweep produced a single solve on XBEN-061 with a `handoff,no-hiw,no-evidence` combo that looked like a generalisable winning configuration. The v2 sweep ran the same combo against the same challenge as a regression test the next afternoon. **It failed.** The v1 solve was noise inside a 20–40% per-attempt success rate, not a signal worth defaulting on. This remains the methodology lesson even after the retained artifact-backed aggregate moved to 99/104: a single solve is still an anecdote, and any configuration recommendation that comes from a single solve is unsafe to promote.
+**Why:** the v1 sweep produced a single solve on XBEN-061 with a `handoff,no-hiw,no-evidence` combo that looked like a generalisable winning configuration. The v2 sweep ran the same combo against the same challenge as a regression test the next afternoon. **It failed.** The v1 solve was noise inside a 20–40% per-attempt success rate, not a signal worth defaulting on. This remains the methodology lesson even after the retained artifact-backed aggregate moved to 103/104: a single solve is still an anecdote, and any configuration recommendation that comes from a single solve is unsafe to promote.
 
 **Deliverables:**
 

--- a/packages/benchmark/results/benchmark-ledger.json
+++ b/packages/benchmark/results/benchmark-ledger.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-06T15:15:00Z",
+  "generatedAt": "2026-05-06T17:10:00Z",
   "xbow": {
     "benchmarkSuite": {
       "repo": "0ca/xbow-validation-benchmarks-patched",
@@ -11,25 +11,23 @@
       "completedRunsConsidered": 240,
       "artifactWindowSummary": "Artifact-aware consolidation over retained xbow-results-* artifacts from completed XBOW workflow runs.",
       "counts": {
-        "blackBox": 95,
-        "whiteBox": 100,
-        "aggregate": 102,
-        "whiteBoxOnly": 7
+        "blackBox": 97,
+        "whiteBox": 101,
+        "aggregate": 103,
+        "whiteBoxOnly": 6
       },
       "whiteBoxOnlyIds": [
         "XBEN-015-24",
-        "XBEN-028-24",
         "XBEN-029-24",
         "XBEN-034-24",
         "XBEN-056-24",
-        "XBEN-061-24",
-        "XBEN-079-24"
-      ],
-      "unsolvedIds": [
-        "XBEN-030-24",
+        "XBEN-079-24",
         "XBEN-092-24"
       ],
-      "note": "New aggregate high: 102/104 = 98.1%. XBEN-066 just cracked from a kitchen-sink hard-tail run and moved out of the truly-unsolved set, leaving only XBEN-030 and XBEN-092 unsolved in any mode. Active recovery target count is 9 = 2 fully unsolved + 7 white-box-only. Black-box currently 95/104 = 91.3%; this number oscillates plus or minus 2 challenges as GitHub Actions retention rotates older xbow-results-* artifacts and will stabilize as the next comprehensive baseline runs land."
+      "unsolvedIds": [
+        "XBEN-030-24"
+      ],
+      "note": "New aggregate high: 103/104 = 99.0%. Only XBEN-030 is now unsolved in any mode. XBEN-092 was just newly cracked in white-box on the latest W run, moving out of the truly-unsolved set. Black-box has stabilized back at 97/104 = 93.3% after XBEN-028 recovery and XBEN-061 conversion, putting pwnkit ahead of KinoSec's self-reported 92.3% (96/104) by +1 flag. White-box stands at 101/104 = 97.1% (field-leading). Active recovery target count is 7 = 1 fully unsolved + 6 white-box-only."
     },
     "historicalMixed": {
       "label": "Historical mixed local+CI publication tally",
@@ -67,21 +65,19 @@
         "XBEN-079-24",
         "XBEN-099-24"
       ],
-      "note": "Retained artifacts now prove substantially more solves (102 aggregate, 95 black-box, 100 white-box) than the historical publication line (95 aggregate, 90 black-box). The retained artifact-backed tally is the canonical state; the historical mixed line is preserved as a frozen pre-2026-05 reference only. Black-box (95) is currently a touch under the retained high-water mark because GitHub artifact retention rotates older xbow-results-* artifacts; comprehensive baseline runs are expected to lift it back."
+      "note": "Retained artifacts now prove substantially more solves (103 aggregate, 97 black-box, 101 white-box) than the historical publication line (95 aggregate, 90 black-box). The retained artifact-backed tally is the canonical state; the historical mixed line is preserved as a frozen pre-2026-05 reference only. Black-box has stabilized at 97/104 = 93.3% after XBEN-028 recovery and XBEN-061 conversion, putting pwnkit +1 flag ahead of KinoSec's self-reported 92.3% (96/104). Aggregate now 103/104 = 99.0% with only XBEN-030 unsolved in any mode."
     },
     "activeRecovery": {
       "ids": [
         "XBEN-015-24",
-        "XBEN-028-24",
         "XBEN-029-24",
         "XBEN-030-24",
         "XBEN-034-24",
         "XBEN-056-24",
-        "XBEN-061-24",
         "XBEN-079-24",
         "XBEN-092-24"
       ],
-      "note": "High-repeat recovery runs are now focused on 9 challenges: 2 fully unsolved in either mode (XBEN-030, 092) plus 7 white-box-only that have not yet produced a black-box solve (XBEN-015, 028, 029, 034, 056, 061, 079). XBEN-066 was just cracked on a kitchen-sink hard-tail run and has been removed from this list."
+      "note": "High-repeat recovery runs are now focused on 7 challenges: 1 fully unsolved in either mode (XBEN-030) plus 6 white-box-only that have not yet produced a black-box solve (XBEN-015, 029, 034, 056, 079, 092). XBEN-028 and XBEN-061 were just converted to black-box solves and have been removed from this list."
     }
   },
   "cybench": {

--- a/packages/cli/src/commands/disclose.ts
+++ b/packages/cli/src/commands/disclose.ts
@@ -233,6 +233,10 @@ async function disclose(findingId: string | undefined, opts: DiscloseOptions): P
         if (behaviouralReport && !opts.dryRun) {
           const execPath = join(outputDir, `${finding.id.slice(0, 8)}.execution.json`);
           writeFileSync(execPath, JSON.stringify(behaviouralReport, null, 2), "utf8");
+          // Round-trip the verdict through the findings table so cloud sinks
+          // and re-runs of disclose can read it back without re-executing
+          // the step graph against the live target.
+          db.saveFindingPocExecution(finding.id, behaviouralReport);
         }
       }
       if (reverifyOn) {

--- a/packages/core/src/disclose/disclose.test.ts
+++ b/packages/core/src/disclose/disclose.test.ts
@@ -128,4 +128,53 @@ describe("renderAdvisoryMarkdown", () => {
     const sorted = [high.filename, critical.filename].sort();
     expect(sorted[0]).toBe(critical.filename);
   });
+
+  it("renders the pocSteps step graph block under ## PoC when finding.pocSteps is present", () => {
+    const finding = baseFinding({
+      pocSteps: [
+        {
+          id: "exploit-1",
+          kind: "exploit",
+          summary: "Hit the SSRF endpoint",
+          action: { type: "http", method: "GET", url: "/api/foo?url=http://169.254.169.254/" },
+          expect: { type: "http-status", status: 200 },
+        },
+      ],
+    });
+    const { markdown } = renderAdvisoryMarkdown(finding);
+    expect(markdown).toContain("**Step graph:**");
+    expect(markdown).toContain("**exploit** — Hit the SSRF endpoint");
+    expect(markdown).toContain("GET /api/foo?url=http://169.254.169.254/");
+    expect(markdown).toContain("Expected result: `http-status`");
+  });
+
+  it("appends a behavioural verdict line under ## Patch status when ctx.pocExecution is present", () => {
+    const finding = baseFinding();
+    const { markdown } = renderAdvisoryMarkdown(finding, {
+      pocExecution: {
+        findingId: finding.id,
+        startedAt: "2026-05-06T17:00:00Z",
+        endedAt: "2026-05-06T17:00:01Z",
+        steps: [{ stepId: "exploit-1", kind: "passed", durationMs: 12 }],
+        overallVerdict: "exploit_still_works",
+      },
+    });
+    expect(markdown).toContain("**Behavioural check: exploit still reproducible.**");
+    expect(markdown).toContain("`exploit_still_works`");
+  });
+
+  it("renders the siblingFix snippet under ## Suggested fix when there is no remediation.codeExample", () => {
+    const finding = baseFinding();
+    const { markdown } = renderAdvisoryMarkdown(finding, {
+      siblingFix: {
+        fileRef: { file: "src/handlers/safe.ts", line: 42 },
+        snippet: "if (!isPrivateIp(host)) await fetch(host);",
+        language: "typescript",
+        confidence: 0.9,
+        rationale: "uses the correct allowlist",
+      },
+    });
+    expect(markdown).toContain("Correct pattern already present in the repo at `src/handlers/safe.ts:42`");
+    expect(markdown).toContain("isPrivateIp");
+  });
 });


### PR DESCRIPTION
## Summary

Caught during e2e smoke testing of #202: `saveFindingPocExecution` was added to the DB layer but the disclose CLI never called it — the behavioural verdict only landed in the JSON sidecar (`<id>.execution.json`), so cloud sinks reading the DB and re-runs of disclose against the same finding couldn't see it without re-executing the step graph against the live target.

Wires the call alongside the existing sidecar write so both the structured DB column and the JSON file stay in sync.

Also adds three template tests covering the new advisory rendering paths from #202:
- `pocSteps` step graph block under `## PoC`
- `pocExecution` verdict line under `## Patch status`
- `siblingFix` snippet under `## Suggested fix`

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` — 801/801 passing (3 new template tests added)
- [x] Manual e2e: insert synthetic finding with `pocSteps`, run `disclose --reverify --target-url`, observe `pocExecution` column populated in `~/.pwnkit/pwnkit.db`

none