### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pwnkit-cli",
   "type": "module",
-  "version": "0.7.13",
+  "version": "0.8.0",
   "description": "The leading open-source agentic AI pentest framework. Autonomously discover, exploit, and verify vulnerabilities in web apps, AI/LLM apps, npm packages, and source code.",
   "bin": {
     "pwnkit-cli": "dist/pwnkit.js"


### PR DESCRIPTION
Minor release — substantial new functionality has accumulated since 0.7.13 (40+ non-merge commits, ~20 feat / ~20 fix), making a patch bump the wrong shape.

## Headline changes

### CLI
- **new `pwnkit-cli disclose`** — end-to-end advisory drafting with PoC step graph rendering, behavioural re-verify runtime, sibling-fix code extractor, multi-frame terminal screenshots, canary patch-status verifier, and version-range detection (#168, #169, #170, #171, #172, #178, #179, #202, #204, #206)
- **new `pwnkit-cli verify`** — wraps `executePocSteps` so cloud's worker-controller (and any OSS caller) can re-run a finding's PoC step graph against a fresh target (#194)

### TUI
- **live-agent panel** — shows what the agent is doing in real time (#192)
- **interrupt + inject** — pause a running scan and inject user messages at turn boundaries (#164)

### Advisory-quality gates (#206) — venue-neutral defaults for responsible disclosure
- Empty-PoC drop (`EmptyPocError` routes findings into `_dropped/` with `unverified-poc`)
- `could_not_run` behavioural verdicts dropped by default; `--keep-unrun` escape hatch
- `discovered` / `false-positive` excluded from batch mode
- Sensitive-data redaction in advisory + screenshots (auth headers, AWS keys, JWTs — line + inline forms)
- Canary patch-status + behavioural reverify pair required to claim "Code-verified"; otherwise `_Generated by …_`
- Per-host RPS cap + 429 cool-off (with AbortSignal-aware sleep) for reverify dispatch
- Scope allowlist (subdomain-glob semantics, IPv6-aware) refusing out-of-scope hosts as `errored`

### Finding shape (all additive — legacy findings keep working)
- `pocSteps` step graph (#170)
- `verificationSpec` machine-executable re-check contract (#193)
- `confidence` LLM self-report + PoC-status floor
- `pocExecution` captured behavioural verdict

### Runtime
- **gpt-5/o-series support** — `max_completion_tokens` flip + tool_calls batching so Azure stops 400-ing on multi-tool turns (#202)
- token-level delta event for cloud Live Trace (#186)
- legacy `scan()` now emits `scan_completed` and relays ScanEvents into the pluggable bus

### Other
- agent emits `pocSteps` from finding prose evidence (#179)
- ripgrep bundled in the runtime docker image (#188)
- kernel-validator crash taxonomy expansion (#157)
- stability + security fixes: ReDoS caps, symlink traversal block, bash subprocess wallclock ceiling, abs-path scoping

## Benchmark snapshot at release time

- XBOW retained-artifact aggregate: **103/104 = 99.0%** (only XBEN-092 unsolved in any mode)
- XBOW retained-artifact white-box: **100/104 = 96.2%** (field-leading)
- Cybench: 8/10 = 80%

## Test plan

- [x] e2e smoke: scan + disclose with `--reverify --target-url` against local target — all paths exercised, pocExecution persisted to DB, advisory rendered with step graph + behavioural verdict
- [x] `pnpm test` — 846/846 passing
- [x] `pnpm lint` clean

none