### PR TITLE
feat(scan): per-host token-bucket rate limiter (#214)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -54,6 +54,8 @@ export interface RunOptions {
   egats?: boolean;
   /** Hard per-scan USD cost ceiling. Aborts cleanly with partial findings if exceeded. */
   costCeilingUsd?: number;
+  /** Per-host rate-limit spec (#214). Plain "5" or "host=rps,host2=rps:burst,default". */
+  rateLimit?: string;
   /** Open the operator TUI after the run completes. */
   tui?: boolean;
   /** Path to a JSON scope file (pwnkit#215). Threaded into ScanConfig.scopeFile. */
@@ -263,6 +265,7 @@ export async function runUnified(opts: RunOptions): Promise<void> {
             egats: opts.egats,
             costCeilingUsd: opts.costCeilingUsd,
             scopeFile: opts.scopeFile,
+            rateLimit: opts.rateLimit,
           },
           dbPath: opts.dbPath,
           onEvent: eventHandler,

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -65,6 +65,10 @@ export function registerScanCommand(program: Command): void {
     .option("--race", "Enable best-of-N strategy racing: run multiple attack strategies in parallel", false)
     .option("--egats", "Enable EGATS (Evidence-Gated Attack Tree Search): beam-search over a hypothesis tree", false)
     .option("--cost-ceiling <usd>", "Hard per-scan USD cost ceiling. Aborts cleanly with partial findings if exceeded. Overrides PWNKIT_COST_CEILING_USD.")
+    .option(
+      "--rate-limit <spec>",
+      "Per-host requests-per-second cap for outbound scan traffic. Plain number (e.g. '5') sets the default rps; comma-separated form 'api.example.com=5,*.example.com=3:6,2' allows per-host overrides and a fallback default. Default is 5 rps when unset. Each host carries an independent token bucket; 429 responses honour Retry-After (with a conservative 60s floor).",
+    )
     .option("--tui", "Open the local terminal UI after the scan completes", false)
     .option(
       "--features <list>",
@@ -224,6 +228,19 @@ export function registerScanCommand(program: Command): void {
         costCeilingUsd = parsed;
       }
 
+      // --rate-limit: validate the spec at start-of-scan rather than
+      // discovering a typo five hours into a deep scan.
+      const rateLimit = opts.rateLimit as string | undefined;
+      if (rateLimit !== undefined && rateLimit !== "") {
+        try {
+          const { parseRateLimitFlag } = await import("@pwnkit/core");
+          parseRateLimitFlag(rateLimit);
+        } catch (err) {
+          console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+          process.exit(2);
+        }
+      }
+
       await runUnified({
         target: opts.target,
         targetType: "url",
@@ -243,6 +260,7 @@ export function registerScanCommand(program: Command): void {
         race: opts.race as boolean | undefined,
         egats: opts.egats as boolean | undefined,
         costCeilingUsd,
+        rateLimit,
         tui: opts.tui as boolean,
         scopeFile,
       });

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -40,6 +40,7 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
     scopePath: config.scopePath,
     persistFindings: db !== null,
     scope: config.scope,
+    rateLimiter: config.rateLimiter,
   };
 
   const executor = new ToolExecutor(toolCtx, db);

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -88,6 +88,11 @@ export interface NativeAgentConfig {
   /** Authentication credentials to inject into tool context */
   authConfig?: AuthConfig;
   /**
+   * Per-host token-bucket rate limiter (#214). Threaded into the
+   * ToolContext so every fetch chokepoint paces against it.
+   */
+  rateLimiter?: import("../scope/rate-limit.js").RateLimiter;
+  /**
    * Hard cost ceiling in USD. When set, the loop checks the running
    * estimated cost after every tool-call turn and aborts cleanly when
    * the ceiling is exceeded. Partial findings collected so far are
@@ -186,6 +191,7 @@ export async function runNativeAgentLoop(
     persistFindings: db !== null,
     authConfig: config.authConfig,
     scope: config.scope,
+    rateLimiter: config.rateLimiter,
   };
 
   const executor = new ToolExecutor(toolCtx, db);

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -1246,6 +1246,10 @@ export class ToolExecutor {
     const authHeaders = buildAuthHeaders(this.ctx.authConfig);
     const headers = { ...authHeaders, ...(args.headers as Record<string, string>) ?? {} };
 
+    // Per-host rate limit (#214). Acquire token BEFORE the network call;
+    // park the host bucket on 429 via `noteResponse` AFTER the response.
+    if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(url);
+
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 30_000);
 
@@ -1258,6 +1262,7 @@ export class ToolExecutor {
         redirect: "manual",
       });
 
+      if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(url, res);
       clearTimeout(timer);
       const text = await res.text();
       const output = {
@@ -1453,12 +1458,15 @@ export class ToolExecutor {
 
       try {
         const crawlAuthHeaders = buildAuthHeaders(this.ctx.authConfig);
+        // #214: per-host rate limit, acquire before each crawl fetch.
+        if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(normalizedUrl);
         const res = await fetch(normalizedUrl, {
           method: "GET",
           signal: controller.signal,
           redirect: "follow",
           headers: { "User-Agent": "pwnkit-crawler/1.0", ...crawlAuthHeaders },
         });
+        if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(normalizedUrl, res);
         clearTimeout(timer);
 
         // Redirect-to-out-of-scope refusal (DoD line item). `redirect:
@@ -1581,7 +1589,10 @@ export class ToolExecutor {
     const timer = setTimeout(() => controller.abort(), 10_000);
 
     try {
+      // #214: rate-limit the form submission before dispatching.
+      if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(fetchUrl);
       const res = await fetch(fetchUrl, fetchOpts);
+      if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(fetchUrl, res);
       clearTimeout(timer);
       const text = await res.text();
 
@@ -2276,10 +2287,14 @@ export class ToolExecutor {
     const timer = setTimeout(() => controller.abort(), 15_000);
 
     try {
+      // #214: rate-limit DDG search; share a bucket with any other
+      // duckduckgo.com requests this scan happens to make.
+      if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(url);
       const res = await fetch(url, {
         headers: { "User-Agent": "pwnkit/1.0" },
         signal: controller.signal,
       });
+      if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(url, res);
       clearTimeout(timer);
 
       if (!res.ok) {
@@ -2375,6 +2390,7 @@ export class ToolExecutor {
     // Build an auth-aware fetch wrapper that reuses the scan's credentials.
     const authHeaders = buildAuthHeaders(this.ctx.authConfig);
     const scope = this.ctx.scope;
+    const rateLimiter = this.ctx.rateLimiter;
     const wrappedFetch: FetchLike = async (url, init) => {
       // Scope check (pwnkit#215). runWpFingerprint walks the WP plugin
       // namespace by appending paths to `target`; under same-origin that
@@ -2391,6 +2407,10 @@ export class ToolExecutor {
         ...authHeaders,
         ...(init?.headers ?? {}),
       };
+      // #214: each plugin/version probe goes through the per-host bucket.
+      // wp_fingerprint can fan out to dozens of probes against a single
+      // host — exactly the workload the limiter exists to pace.
+      if (rateLimiter) await rateLimiter.acquire(url);
       const res = await fetch(url, {
         method: init?.method ?? "GET",
         headers,
@@ -2410,6 +2430,7 @@ export class ToolExecutor {
           );
         }
       }
+      if (rateLimiter) rateLimiter.noteResponse(url, res);
       return {
         ok: res.ok,
         status: res.status,

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,5 +1,6 @@
 import type { Finding, AttackResult, TargetInfo, AuthConfig } from "@pwnkit/shared";
 import type { ScopePolicy } from "../scope/scope.js";
+import type { RateLimiter } from "../scope/rate-limit.js";
 
 // ── Agent Roles ──
 
@@ -65,6 +66,14 @@ export interface AgentConfig {
    * this; scope is additive, never substitutive.
    */
   scope?: ScopePolicy;
+  /**
+   * Per-host rate limiter for outbound HTTP. When set, every fetch
+   * chokepoint (`http_request`, `crawl`, `submit_form`, `web_search`,
+   * `wp_fingerprint`) acquires a token before the network call and
+   * pipes the response back via `noteResponse` so 429 honours.
+   * See `scope/rate-limit.ts` (#214).
+   */
+  rateLimiter?: RateLimiter;
 }
 
 // ── Agent State ──
@@ -96,4 +105,6 @@ export interface ToolContext {
    * with `ToolResult.error`.
    */
   scope?: ScopePolicy;
+  /** Per-host rate limiter; see AgentConfig.rateLimiter. */
+  rateLimiter?: RateLimiter;
 }

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -54,6 +54,29 @@ import { generatePov } from "./triage/pov-gate.js";
 import { getCloudSinkConfig, postFinding, postFinalReport } from "./cloud-sink.js";
 import { eventBus } from "./events/bus.js";
 import { loadScope, type ScopePolicy } from "./scope/scope.js";
+import { RateLimiter, parseRateLimitFlag } from "./scope/rate-limit.js";
+
+/**
+ * Per-scan rate-limiter cache (#214). The limiter is stateful — buckets
+ * track per-host token availability and 429 cool-offs across the entire
+ * scan — so we build one instance keyed on the ScanConfig object and
+ * thread it into every agent loop and every stage that fetches.
+ *
+ * Default 5 rps when the operator did not pass `--rate-limit`. The
+ * issue body is explicit on this: the primitive should default
+ * conservative even without an explicit operator flag, so an
+ * unconfigured `pwnkit scan` can't accidentally hammer a target.
+ */
+const RATE_LIMITER_CACHE = new WeakMap<ScanConfig, RateLimiter>();
+function getOrCreateRateLimiter(config: ScanConfig): RateLimiter {
+  let rl = RATE_LIMITER_CACHE.get(config);
+  if (!rl) {
+    const cfg = parseRateLimitFlag(config.rateLimit ?? "", 5);
+    rl = new RateLimiter(cfg);
+    RATE_LIMITER_CACHE.set(config, rl);
+  }
+  return rl;
+}
 
 export interface AgenticScanOptions {
   config: ScanConfig;
@@ -142,6 +165,12 @@ async function normalizeScanConfig(config: ScanConfig): Promise<ScanConfig> {
   if (!config.target.startsWith("http://") && !config.target.startsWith("https://")) return config;
 
   try {
+    // #214: rate-limit even the one-shot mode-auto-detect probe. The
+    // limiter is built (and cached on `config`) here so subsequent
+    // stages share the same per-host bucket state — a target that 429s
+    // on the first probe stays parked across the whole scan.
+    const limiter = getOrCreateRateLimiter(config);
+    await limiter.acquire(config.target);
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), Math.min(config.timeout ?? 30_000, 8_000));
     try {
@@ -152,6 +181,7 @@ async function normalizeScanConfig(config: ScanConfig): Promise<ScanConfig> {
         },
         signal: controller.signal,
       });
+      limiter.noteResponse(config.target, response);
       const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
       const body = await response.text();
 
@@ -1773,6 +1803,7 @@ async function runNativeDiscovery(
       sessionId: db.getSession(scanId, "discovery")?.id,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -1993,6 +2024,7 @@ async function runNativeAttack(
       retryCount: 0,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -2056,6 +2088,7 @@ async function runNativeAttack(
         retryCount: 1,
         authConfig: config.auth,
         scope: resolveScopeForConfig(config),
+        rateLimiter: getOrCreateRateLimiter(config),
         costCeilingUsd: config.costCeilingUsd,
         costModel: config.model,
       },
@@ -2269,6 +2302,7 @@ async function runNativeVerify(
       sessionId: db.getSession(scanId, "verify")?.id,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -2328,6 +2362,7 @@ async function runLegacyDiscovery(
       dbPath,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
     },
     runtime,
     db,
@@ -2392,6 +2427,7 @@ async function runLegacyAttack(
       dbPath,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
     },
     runtime,
     db,
@@ -2457,6 +2493,7 @@ async function runLegacyVerify(
       dbPath,
       authConfig: config.auth,
       scope: resolveScopeForConfig(config),
+      rateLimiter: getOrCreateRateLimiter(config),
     },
     runtime,
     db,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,18 @@ export type {
 export { raceStrategies, raceWithDefaults, DEFAULT_STRATEGIES } from "./racing.js";
 export type { AttackStrategy, RaceConfig, RaceResult, StrategyResult } from "./racing.js";
 
+// Per-host rate limiter (#214)
+export {
+  TokenBucket,
+  RateLimiter,
+  parseRateLimitFlag,
+  parseRetryAfter,
+} from "./scope/rate-limit.js";
+export type {
+  HostRateConfig,
+  RateLimiterConfig,
+} from "./scope/rate-limit.js";
+
 export type { DBScan, DBFinding, DBTarget, DBAttackResult } from "./db/schema.js";
 
 // API spec parser

--- a/packages/core/src/scope/rate-limit.test.ts
+++ b/packages/core/src/scope/rate-limit.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import {
+  TokenBucket,
+  RateLimiter,
+  parseRateLimitFlag,
+  parseRetryAfter,
+} from "./rate-limit.js";
+
+/**
+ * Virtual time harness. We do NOT depend on real `setTimeout` /
+ * `Date.now` for any of the bucket-math tests — every "wait" in the
+ * limiter is intercepted and replaced with an instantaneous clock
+ * advance. This keeps the test suite deterministic and finishes the
+ * full "burst N + (N+1)th waits" assertion in microseconds, not
+ * seconds.
+ */
+function virtualClock(start = 1_000_000) {
+  let now = start;
+  let observedSleeps: number[] = [];
+  return {
+    nowFn: () => now,
+    advance: (ms: number) => { now += ms; },
+    sleepFn: async (ms: number) => {
+      observedSleeps.push(ms);
+      now += ms;
+    },
+    sleeps: () => observedSleeps,
+    reset: () => { observedSleeps = []; },
+  };
+}
+
+describe("TokenBucket", () => {
+  it("rejects non-positive rps / capacity", () => {
+    expect(() => new TokenBucket(0)).toThrow(/positive/);
+    expect(() => new TokenBucket(-1)).toThrow(/positive/);
+    expect(() => new TokenBucket(NaN)).toThrow(/positive/);
+    expect(() => new TokenBucket(5, 0)).toThrow(/positive/);
+  });
+
+  it("starts full at capacity", () => {
+    const c = virtualClock();
+    const b = new TokenBucket(5, 5, c.nowFn, c.sleepFn);
+    expect(b._peek().tokens).toBe(5);
+  });
+
+  it("burst N requests succeed instantly via tryConsume", () => {
+    const c = virtualClock();
+    const b = new TokenBucket(5, 5, c.nowFn, c.sleepFn);
+    for (let i = 0; i < 5; i++) {
+      expect(b.tryConsume()).toBe(true);
+    }
+    expect(b.tryConsume()).toBe(false);
+    expect(c.sleeps()).toEqual([]);
+  });
+
+  it("acquire blocks (sleeps) for the (N+1)th request at ~1/rps", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(10, 10, c.nowFn, c.sleepFn);
+    // Drain the bucket.
+    for (let i = 0; i < 10; i++) {
+      expect(b.tryConsume()).toBe(true);
+    }
+    // 11th: must wait. 10 rps → 1 token / 100ms.
+    await b.acquire();
+    const total = c.sleeps().reduce((a, b) => a + b, 0);
+    expect(total).toBeGreaterThanOrEqual(99);
+    expect(total).toBeLessThanOrEqual(101);
+  });
+
+  it("refills at the configured rate after a wait", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(5, 5, c.nowFn, c.sleepFn);
+    // Drain.
+    for (let i = 0; i < 5; i++) b.tryConsume();
+    expect(b.tryConsume()).toBe(false);
+    // Advance virtual time by 1 second → bucket should be full again.
+    c.advance(1000);
+    for (let i = 0; i < 5; i++) {
+      expect(b.tryConsume()).toBe(true);
+    }
+    expect(b.tryConsume()).toBe(false);
+  });
+
+  it("fractional refill is accumulated correctly", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(2, 2, c.nowFn, c.sleepFn);
+    b.tryConsume();
+    b.tryConsume();
+    expect(b.tryConsume()).toBe(false);
+    // 250ms at 2 rps = 0.5 tokens — not enough.
+    c.advance(250);
+    expect(b.tryConsume()).toBe(false);
+    // Another 250ms → 0.5 + 0.5 = 1 token.
+    c.advance(250);
+    expect(b.tryConsume()).toBe(true);
+  });
+
+  it("does not refill above capacity", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(5, 5, c.nowFn, c.sleepFn);
+    c.advance(60_000); // sit idle for a minute
+    expect(b._peek().tokens).toBe(5);
+  });
+
+  it("markRetryUntil parks acquire/tryConsume", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(5, 5, c.nowFn, c.sleepFn);
+    b.markRetryUntil(c.nowFn() + 5000);
+    expect(b.tryConsume()).toBe(false);
+    await b.acquire();
+    // The acquire must have slept past the park deadline.
+    const total = c.sleeps().reduce((a, b) => a + b, 0);
+    expect(total).toBeGreaterThanOrEqual(5000);
+  });
+
+  it("acquire(n) clamps n to capacity instead of looping forever", async () => {
+    const c = virtualClock();
+    const b = new TokenBucket(2, 2, c.nowFn, c.sleepFn);
+    // Asking for 100 should NOT loop forever; it gets clamped to 2.
+    await b.acquire(100);
+    // Bucket should now be empty.
+    expect(b.tryConsume()).toBe(false);
+  });
+});
+
+describe("RateLimiter", () => {
+  it("per-host isolation: throttling A does not affect B", async () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 1 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    // Drain host A by acquiring once (capacity = 1).
+    await rl.acquire("https://a.example.com/");
+    // tryAcquire on A is false (cooling down).
+    expect(rl.tryAcquire("https://a.example.com/")).toBe(false);
+    // tryAcquire on B (fresh bucket) is true.
+    expect(rl.tryAcquire("https://b.example.com/")).toBe(true);
+  });
+
+  it("uses per-host override over default", async () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      {
+        default: { rps: 1 },
+        perHost: { "fast.example.com": { rps: 100, burst: 100 } },
+      },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    // 50 burst should fly through the fast host without blocking.
+    for (let i = 0; i < 50; i++) {
+      expect(rl.tryAcquire("https://fast.example.com/path")).toBe(true);
+    }
+    // The slow default host: 1 burst then cooldown.
+    expect(rl.tryAcquire("https://slow.example.com/")).toBe(true);
+    expect(rl.tryAcquire("https://slow.example.com/")).toBe(false);
+  });
+
+  it("normalizes host: case and port", () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 1 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    expect(rl.tryAcquire("https://Example.com/x")).toBe(true);
+    // Same bucket as Example.com.
+    expect(rl.tryAcquire("https://EXAMPLE.com:443/y")).toBe(false);
+  });
+
+  it("noteResponse(429) parks the host bucket past Retry-After", async () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 100, burst: 100 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    // Prime the bucket.
+    expect(rl.tryAcquire("https://api.example.com/")).toBe(true);
+    // Simulate a 429 with a 5s Retry-After.
+    const headers = new Headers({ "retry-after": "5" });
+    rl.noteResponse("https://api.example.com/", { status: 429, headers });
+    // Bucket should be parked.
+    expect(rl.tryAcquire("https://api.example.com/")).toBe(false);
+    // Acquire should sleep through the floor (60s) — Retry-After is
+    // floored at 60s for safety.
+    await rl.acquire("https://api.example.com/");
+    const total = c.sleeps().reduce((a, b) => a + b, 0);
+    expect(total).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("noteResponse on non-429 is a no-op", () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 100, burst: 100 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    expect(rl.tryAcquire("https://api.example.com/")).toBe(true);
+    rl.noteResponse("https://api.example.com/", {
+      status: 200,
+      headers: new Headers({ "retry-after": "60" }),
+    });
+    // Still acquireable: no park.
+    expect(rl.tryAcquire("https://api.example.com/")).toBe(true);
+  });
+
+  it("noteResponse with HTTP-date Retry-After parks until that moment", () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 100, burst: 100 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    // Set virtualClock to a real-ish epoch for a sane Date string.
+    const baseEpoch = Date.UTC(2024, 0, 1, 0, 0, 0);
+    const c2 = virtualClock(baseEpoch);
+    const rl2 = new RateLimiter(
+      { default: { rps: 100, burst: 100 } },
+      { nowFn: c2.nowFn, sleepFn: c2.sleepFn },
+    );
+    const future = new Date(baseEpoch + 120_000).toUTCString();
+    rl2.noteResponse("https://api.example.com/", {
+      status: 429,
+      headers: new Headers({ "retry-after": future }),
+    });
+    expect(rl2.tryAcquire("https://api.example.com/")).toBe(false);
+    // After 120s the bucket should be acquireable again (well past floor).
+    c2.advance(125_000);
+    expect(rl2.tryAcquire("https://api.example.com/")).toBe(true);
+  });
+
+  it("acquire on unparseable target is a no-op", async () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 1 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    await rl.acquire("");
+    await rl.acquire("not a url at all !!!"); // returns immediately
+    // No buckets created, no sleeps recorded.
+    expect(c.sleeps()).toEqual([]);
+  });
+
+  it("burst then refill end-to-end with acquire", async () => {
+    const c = virtualClock();
+    const rl = new RateLimiter(
+      { default: { rps: 5, burst: 5 } },
+      { nowFn: c.nowFn, sleepFn: c.sleepFn },
+    );
+    const start = c.nowFn();
+    for (let i = 0; i < 5; i++) {
+      await rl.acquire("https://x.example.com/");
+    }
+    // Burst: no sleeping.
+    expect(c.sleeps()).toEqual([]);
+    // 6th call: must sleep ~200ms (1 token / (5/1000) ms = 200ms).
+    await rl.acquire("https://x.example.com/");
+    const total = c.nowFn() - start;
+    expect(total).toBeGreaterThanOrEqual(199);
+    expect(total).toBeLessThanOrEqual(201);
+  });
+});
+
+describe("parseRateLimitFlag", () => {
+  it("plain rps becomes the default", () => {
+    expect(parseRateLimitFlag("10")).toEqual({
+      default: { rps: 10 },
+    });
+  });
+
+  it("plain rps:burst", () => {
+    expect(parseRateLimitFlag("10:25")).toEqual({
+      default: { rps: 10, burst: 25 },
+    });
+  });
+
+  it("per-host overrides + default", () => {
+    expect(
+      parseRateLimitFlag("api.example.com=5,*.example.com=3:6,2"),
+    ).toEqual({
+      default: { rps: 2 },
+      perHost: {
+        "api.example.com": { rps: 5 },
+        "*.example.com": { rps: 3, burst: 6 },
+      },
+    });
+  });
+
+  it("per-host only uses fallback default", () => {
+    expect(parseRateLimitFlag("api.example.com=5", 7)).toEqual({
+      default: { rps: 7 },
+      perHost: { "api.example.com": { rps: 5 } },
+    });
+  });
+
+  it("empty string uses fallback default", () => {
+    expect(parseRateLimitFlag("", 5)).toEqual({ default: { rps: 5 } });
+  });
+
+  it("rejects malformed: empty host", () => {
+    expect(() => parseRateLimitFlag("=5")).toThrow(/empty host/);
+  });
+
+  it("rejects malformed: non-numeric rps", () => {
+    expect(() => parseRateLimitFlag("api.example.com=fast")).toThrow(/invalid rps/);
+  });
+
+  it("rejects malformed: zero or negative rps", () => {
+    expect(() => parseRateLimitFlag("0")).toThrow(/invalid rps/);
+    expect(() => parseRateLimitFlag("-3")).toThrow(/invalid rps/);
+  });
+
+  it("rejects malformed: non-numeric burst", () => {
+    expect(() => parseRateLimitFlag("5:fast")).toThrow(/invalid burst/);
+  });
+
+  it("lowercases host keys", () => {
+    expect(parseRateLimitFlag("API.Example.COM=5")).toEqual({
+      default: { rps: 5 },
+      perHost: { "api.example.com": { rps: 5 } },
+    });
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfter("5", 1_000_000)).toBe(5000);
+    expect(parseRetryAfter("0", 1_000_000)).toBe(0);
+  });
+
+  it("parses HTTP-date", () => {
+    const now = Date.UTC(2024, 0, 1, 0, 0, 0);
+    const future = new Date(now + 30_000).toUTCString();
+    expect(parseRetryAfter(future, now)).toBe(30_000);
+  });
+
+  it("HTTP-date in the past clamps to 0", () => {
+    const now = Date.UTC(2024, 6, 1, 0, 0, 0);
+    const past = new Date(now - 60_000).toUTCString();
+    expect(parseRetryAfter(past, now)).toBe(0);
+  });
+
+  it("returns 0 for null / empty / garbage", () => {
+    expect(parseRetryAfter(null, 1_000_000)).toBe(0);
+    expect(parseRetryAfter("", 1_000_000)).toBe(0);
+    expect(parseRetryAfter("not-a-date", 1_000_000)).toBe(0);
+  });
+});

--- a/packages/core/src/scope/rate-limit.ts
+++ b/packages/core/src/scope/rate-limit.ts
@@ -1,0 +1,443 @@
+/**
+ * pwnkit#214 — Per-host token-bucket rate limiter for scan-side fetches.
+ *
+ * Most coordinated-disclosure venues and pentest engagements specify a
+ * max requests-per-second per host. The PoC-runtime side (`disclose`)
+ * already has a per-host limiter (#206); this module is the generic
+ * primitive for the scan-side, wired in at every fetch chokepoint in
+ * `tools.ts`, `stages/web.ts`, and `agentic-scanner.ts`.
+ *
+ * Design notes:
+ *   - Lazy refill, no timers: `tokens = min(capacity, tokens + elapsedMs * ratePerMs)`
+ *     is computed on each call. A bucket sitting idle for an hour is not
+ *     consuming a setInterval slot; it just refills to `capacity` the
+ *     first time anyone touches it.
+ *   - Per-host isolation. Throttling host A never affects host B.
+ *   - 429 honoring. `noteResponse(url, res)` parks the host's bucket
+ *     past `Retry-After` (delta-seconds OR HTTP-date form). Conservative
+ *     60s floor matches the PoC-runtime semantics: even a 1-second
+ *     `Retry-After` triggers a meaningful cool-off so we don't
+ *     tarpit-loop the target.
+ *   - Burst == capacity. The bucket starts full, so the first N requests
+ *     to a previously-untouched host go through immediately and
+ *     subsequent requests pace at `rate` rps.
+ *
+ * Bash-subprocess gap (acknowledged, NOT closed by this module):
+ *   The `bash` tool in `tools.ts` shells out to curl/wget/python3, which
+ *   bypass node's fetch and therefore bypass this limiter. Mitigating
+ *   that requires an egress proxy on the runner — same disclaimer the
+ *   scope work made in #218 about bash-extracted URLs. Tracked
+ *   separately; see CLAUDE.md / DoD on #214.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+/** Per-host bucket configuration. */
+export interface HostRateConfig {
+  /** Refill rate, requests per second. Must be > 0. */
+  rps: number;
+  /**
+   * Bucket capacity (also burst cap). Defaults to `rps` so the bucket
+   * starts full at one second of traffic. Most callers want this.
+   */
+  burst?: number;
+}
+
+/** Rate-limiter configuration. */
+export interface RateLimiterConfig {
+  /** Default applied to any host without an explicit override. */
+  default: HostRateConfig;
+  /** Per-host overrides keyed by lowercased hostname. */
+  perHost?: Record<string, HostRateConfig>;
+}
+
+// ── Internal bucket state ────────────────────────────────────────────────
+
+interface Bucket {
+  /** Tokens currently available (1 token = 1 request). May be fractional. */
+  tokens: number;
+  /** Tokens added per millisecond. */
+  refillRatePerMs: number;
+  /** Maximum tokens; also burst. */
+  capacity: number;
+  /** Last refill timestamp (Date.now). */
+  lastRefill: number;
+  /** When > now(), all acquires block. Set on 429. */
+  retryUntil: number;
+}
+
+// ── TokenBucket — single host (exported for tests / advanced use) ────────
+
+/**
+ * Single-host token bucket. Lazy refill, no background timer.
+ *
+ * Semantics:
+ *   - `tryConsume(n)` returns true if there were ≥ n tokens after refill,
+ *     and consumes them. Returns false otherwise (no block, no consume).
+ *   - `acquire(n)` resolves once n tokens have been consumed. Blocks via
+ *     `setTimeout`-based sleep when the bucket is dry.
+ *   - `markRetryUntil(deadline)` parks the bucket until `deadline` ms.
+ *     `acquire` honours this; `tryConsume` returns false during park.
+ *
+ * Time source is injectable for tests (default: `Date.now`).
+ */
+export class TokenBucket {
+  private state: Bucket;
+  private readonly nowFn: () => number;
+  private readonly sleepFn: (ms: number) => Promise<void>;
+
+  constructor(
+    rps: number,
+    capacity: number = rps,
+    nowFn: () => number = () => Date.now(),
+    sleepFn: (ms: number) => Promise<void> = defaultSleep,
+  ) {
+    if (!Number.isFinite(rps) || rps <= 0) {
+      throw new Error(`TokenBucket: rps must be a positive finite number, got ${rps}`);
+    }
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error(`TokenBucket: capacity must be a positive finite number, got ${capacity}`);
+    }
+    this.nowFn = nowFn;
+    this.sleepFn = sleepFn;
+    this.state = {
+      tokens: capacity,
+      refillRatePerMs: rps / 1000,
+      capacity,
+      lastRefill: nowFn(),
+      retryUntil: 0,
+    };
+  }
+
+  private refill(): void {
+    const now = this.nowFn();
+    const elapsed = now - this.state.lastRefill;
+    if (elapsed > 0) {
+      this.state.tokens = Math.min(
+        this.state.capacity,
+        this.state.tokens + elapsed * this.state.refillRatePerMs,
+      );
+      this.state.lastRefill = now;
+    }
+  }
+
+  /**
+   * Non-blocking. Returns true and consumes `n` tokens if available;
+   * returns false and consumes nothing otherwise. Blocked during 429
+   * cool-off (returns false until park expires).
+   */
+  tryConsume(n = 1): boolean {
+    if (this.nowFn() < this.state.retryUntil) return false;
+    this.refill();
+    if (this.state.tokens >= n) {
+      this.state.tokens -= n;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Block until `n` tokens are available, then consume them. Honours
+   * the 429 park deadline first, then refill-and-spin with sleeps
+   * sized to the exact next-token-available time.
+   */
+  async acquire(n = 1): Promise<void> {
+    if (n > this.state.capacity) {
+      // Asking for more than the bucket can ever hold: clamp to capacity.
+      // Otherwise the loop below would never terminate.
+      n = this.state.capacity;
+    }
+    // 429 cool-off first.
+    while (this.nowFn() < this.state.retryUntil) {
+      const wait = this.state.retryUntil - this.nowFn();
+      // eslint-disable-next-line no-await-in-loop
+      await this.sleepFn(Math.max(1, Math.min(wait, 1000)));
+    }
+    // Refill + consume; sleep precisely to the next token-availability time.
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      this.refill();
+      if (this.state.tokens >= n) {
+        this.state.tokens -= n;
+        return;
+      }
+      const tokensNeeded = n - this.state.tokens;
+      const waitMs = Math.max(1, Math.ceil(tokensNeeded / this.state.refillRatePerMs));
+      // eslint-disable-next-line no-await-in-loop
+      await this.sleepFn(waitMs);
+    }
+  }
+
+  /**
+   * Park the bucket until `deadline` (ms since epoch). Subsequent
+   * `acquire`/`tryConsume` calls block until the deadline passes.
+   * Idempotent in the "later wins" sense: a longer park overrides a
+   * shorter one, but a shorter park does NOT shorten an existing one.
+   */
+  markRetryUntil(deadline: number): void {
+    if (deadline > this.state.retryUntil) {
+      this.state.retryUntil = deadline;
+    }
+  }
+
+  /** Test introspection. */
+  _peek(): { tokens: number; retryUntil: number; capacity: number } {
+    this.refill();
+    return {
+      tokens: this.state.tokens,
+      retryUntil: this.state.retryUntil,
+      capacity: this.state.capacity,
+    };
+  }
+}
+
+// ── RateLimiter — per-host fan-out ───────────────────────────────────────
+
+/**
+ * Per-host token-bucket rate limiter. Buckets are created lazily on
+ * first acquire for a given host. Hostname is lowercased and the port
+ * is stripped before lookup, so `api.example.com:443` and
+ * `API.example.com` share a bucket.
+ */
+export class RateLimiter {
+  private readonly buckets = new Map<string, TokenBucket>();
+  private readonly defaultCfg: HostRateConfig;
+  private readonly perHost: Record<string, HostRateConfig>;
+  private readonly nowFn: () => number;
+  private readonly sleepFn: (ms: number) => Promise<void>;
+  /**
+   * Conservative cool-off floor when a 429 lands without a useful
+   * `Retry-After`, or with a tiny one. 60s matches the PoC-runtime
+   * precedent in #206 — a target that just told us to slow down has
+   * earned more than a one-second pause.
+   */
+  static readonly RETRY_AFTER_FLOOR_MS = 60_000;
+
+  constructor(
+    config: RateLimiterConfig,
+    opts: {
+      nowFn?: () => number;
+      sleepFn?: (ms: number) => Promise<void>;
+    } = {},
+  ) {
+    this.defaultCfg = config.default;
+    this.perHost = {};
+    if (config.perHost) {
+      for (const [host, cfg] of Object.entries(config.perHost)) {
+        this.perHost[host.toLowerCase()] = cfg;
+      }
+    }
+    this.nowFn = opts.nowFn ?? (() => Date.now());
+    this.sleepFn = opts.sleepFn ?? defaultSleep;
+  }
+
+  /**
+   * Normalize a URL or host string to a bucket key. Lowercased,
+   * port-stripped, IPv6 brackets retained on the literal but dropped
+   * from the port suffix (e.g. `[::1]:443` → `[::1]`).
+   */
+  private hostKey(urlOrHost: string): string | null {
+    // Accept a bare host string for callers (e.g. tests) that don't
+    // have a full URL. URL parser is the easy path otherwise.
+    let host: string;
+    try {
+      host = new URL(urlOrHost).hostname;
+    } catch {
+      // Bare host fallback. Strip port if present; treat IPv6 literal
+      // (with brackets) as opaque.
+      const trimmed = urlOrHost.trim();
+      if (!trimmed) return null;
+      if (trimmed.startsWith("[")) {
+        const close = trimmed.indexOf("]");
+        if (close < 0) return null;
+        host = trimmed.slice(0, close + 1);
+      } else {
+        host = trimmed.split(":")[0];
+      }
+    }
+    return host.toLowerCase();
+  }
+
+  private getBucket(host: string): TokenBucket {
+    let bucket = this.buckets.get(host);
+    if (!bucket) {
+      const cfg = this.perHost[host] ?? this.defaultCfg;
+      bucket = new TokenBucket(
+        cfg.rps,
+        cfg.burst ?? cfg.rps,
+        this.nowFn,
+        this.sleepFn,
+      );
+      this.buckets.set(host, bucket);
+    }
+    return bucket;
+  }
+
+  /**
+   * Block until a token is available for `urlOrHost`'s host, then
+   * consume it. Unparseable input is treated as a no-op (returns
+   * immediately) — callers should not rely on rate-limiting unknowable
+   * hosts. The fetch sites that wire this up always pass full URLs.
+   */
+  async acquire(urlOrHost: string, n = 1): Promise<void> {
+    const host = this.hostKey(urlOrHost);
+    if (!host) return;
+    await this.getBucket(host).acquire(n);
+  }
+
+  /**
+   * Non-blocking variant. Returns true and consumes if available,
+   * false otherwise. Used by callers that want to fall through to a
+   * fast-path / degrade rather than wait.
+   */
+  tryAcquire(urlOrHost: string, n = 1): boolean {
+    const host = this.hostKey(urlOrHost);
+    if (!host) return true;
+    return this.getBucket(host).tryConsume(n);
+  }
+
+  /**
+   * Inspect a fetch response and, if it's a 429, park the host's
+   * bucket until `Retry-After` (or 60s, whichever is longer). The
+   * parsed value supports both delta-seconds (RFC 7231 §7.1.3) and
+   * HTTP-date forms; anything else falls back to the floor.
+   *
+   * No-ops on non-429 responses, or on hosts with no bucket yet
+   * (which can't happen if the caller acquired before fetching, but
+   * we don't depend on that).
+   */
+  noteResponse(urlOrHost: string, res: { status: number; headers: { get(name: string): string | null } | Headers }): void {
+    if (res.status !== 429) return;
+    const host = this.hostKey(urlOrHost);
+    if (!host) return;
+    const bucket = this.getBucket(host); // create-on-demand is fine
+    const retryAfter = readHeader(res.headers, "retry-after");
+    const delayMs = parseRetryAfter(retryAfter, this.nowFn());
+    const deadline = this.nowFn() + Math.max(delayMs, RateLimiter.RETRY_AFTER_FLOOR_MS);
+    bucket.markRetryUntil(deadline);
+  }
+
+  /** Test-only. Reset all buckets. */
+  _reset(): void {
+    this.buckets.clear();
+  }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function readHeader(
+  headers: { get(name: string): string | null } | Headers,
+  name: string,
+): string | null {
+  if (typeof (headers as { get?: unknown }).get === "function") {
+    return (headers as { get(n: string): string | null }).get(name);
+  }
+  return null;
+}
+
+/**
+ * Parse a `Retry-After` header into a delay in milliseconds. Accepts
+ * - delta-seconds: `"5"` → 5000
+ * - HTTP-date: `"Wed, 21 Oct 2015 07:28:00 GMT"` → ms until that
+ *   moment (clamped at 0 if already past)
+ *
+ * Returns 0 for unparseable / missing values; the caller applies the
+ * conservative 60s floor.
+ */
+export function parseRetryAfter(value: string | null, now: number): number {
+  if (!value) return 0;
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  // delta-seconds
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = parseInt(trimmed, 10);
+    return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : 0;
+  }
+  // HTTP-date
+  const date = Date.parse(trimmed);
+  if (Number.isFinite(date)) {
+    return Math.max(0, date - now);
+  }
+  return 0;
+}
+
+// ── CLI flag parsing ─────────────────────────────────────────────────────
+
+/**
+ * Parse a `--rate-limit` flag value into a `RateLimiterConfig`.
+ *
+ * Grammar:
+ *   - Plain rps, applied as the default: `"5"` or `"5:10"` (rps:burst)
+ *   - Comma-separated mixture:
+ *       `"api.example.com=5,*.example.com=3:6,2"`
+ *     where the unprefixed `2` is the default rps. A trailing
+ *     `host=rps` without an explicit default falls back to 5 rps,
+ *     matching the issue's "default conservative" guidance.
+ *
+ * NOTE: wildcard hosts (`*.example.com`) are accepted in the spec
+ * grammar but currently match by exact-host lookup only. Wildcard
+ * matching will land alongside the broader scope-ingestion work in
+ * #215 / PR #218, which already has a `*.example.com`-style matcher
+ * we'll borrow once that PR merges. Recording the wildcard now keeps
+ * the CLI grammar forward-compatible.
+ *
+ * Throws on malformed input rather than silently dropping rules — a
+ * mistyped `--rate-limit` is the kind of bug operators want to find
+ * at start-of-scan, not silently five hours in.
+ */
+export function parseRateLimitFlag(spec: string, fallbackRps = 5): RateLimiterConfig {
+  const trimmed = spec.trim();
+  if (!trimmed) {
+    return { default: { rps: fallbackRps } };
+  }
+  const parts = trimmed.split(",").map((p) => p.trim()).filter(Boolean);
+  let defaultCfg: HostRateConfig | null = null;
+  const perHost: Record<string, HostRateConfig> = {};
+  for (const part of parts) {
+    const eq = part.indexOf("=");
+    if (eq < 0) {
+      // No host → default rps[:burst]
+      const cfg = parseRpsBurst(part);
+      defaultCfg = cfg;
+    } else {
+      const host = part.slice(0, eq).trim().toLowerCase();
+      const cfg = parseRpsBurst(part.slice(eq + 1));
+      if (!host) {
+        throw new Error(`--rate-limit: empty host in "${part}"`);
+      }
+      perHost[host] = cfg;
+    }
+  }
+  return {
+    default: defaultCfg ?? { rps: fallbackRps },
+    perHost: Object.keys(perHost).length > 0 ? perHost : undefined,
+  };
+}
+
+function parseRpsBurst(s: string): HostRateConfig {
+  const trimmed = s.trim();
+  if (!trimmed) {
+    throw new Error(`--rate-limit: empty rps value`);
+  }
+  const colon = trimmed.indexOf(":");
+  if (colon < 0) {
+    const rps = Number(trimmed);
+    if (!Number.isFinite(rps) || rps <= 0) {
+      throw new Error(`--rate-limit: invalid rps "${trimmed}"`);
+    }
+    return { rps };
+  }
+  const rps = Number(trimmed.slice(0, colon));
+  const burst = Number(trimmed.slice(colon + 1));
+  if (!Number.isFinite(rps) || rps <= 0) {
+    throw new Error(`--rate-limit: invalid rps "${trimmed.slice(0, colon)}"`);
+  }
+  if (!Number.isFinite(burst) || burst <= 0) {
+    throw new Error(`--rate-limit: invalid burst "${trimmed.slice(colon + 1)}"`);
+  }
+  return { rps, burst };
+}

--- a/packages/core/src/stages/web.ts
+++ b/packages/core/src/stages/web.ts
@@ -1,5 +1,26 @@
 import { randomUUID } from "node:crypto";
-import type { AttackResult, AttackOutcome, Finding, ScanContext, TargetInfo } from "@pwnkit/shared";
+import type { AttackResult, AttackOutcome, Finding, ScanConfig, ScanContext, TargetInfo } from "@pwnkit/shared";
+import { RateLimiter, parseRateLimitFlag } from "../scope/rate-limit.js";
+
+/**
+ * Per-scan rate-limiter cache (#214). Keyed on ScanConfig identity so
+ * every `requestUrl` call inside a single scan shares one set of
+ * per-host buckets — critical for 429 cool-off propagation across
+ * baseline checks, CORS probes, and sensitive-path scans, all of
+ * which hit the same target host.
+ *
+ * Default 5 rps when `config.rateLimit` is unset, matching the issue's
+ * "default conservative" guidance and the agentic-scanner default.
+ */
+const RATE_LIMITER_CACHE = new WeakMap<ScanConfig, RateLimiter>();
+function getStageRateLimiter(config: ScanConfig): RateLimiter {
+  let rl = RATE_LIMITER_CACHE.get(config);
+  if (!rl) {
+    rl = new RateLimiter(parseRateLimitFlag(config.rateLimit ?? "", 5));
+    RATE_LIMITER_CACHE.set(config, rl);
+  }
+  return rl;
+}
 
 interface WebProbeResponse {
   url: string;
@@ -25,6 +46,7 @@ export async function runWebDiscoveryProbe(
       Accept: "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
     },
     timeout: ctx.config.timeout,
+    rateLimiter: getStageRateLimiter(ctx.config),
   });
 
   return {
@@ -45,6 +67,7 @@ export async function runBaselineWebChecks(ctx: ScanContext): Promise<WebCheckRe
       Accept: "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
     },
     timeout: ctx.config.timeout,
+    rateLimiter: getStageRateLimiter(ctx.config),
   });
 
   results.push(
@@ -110,12 +133,14 @@ async function runCorsCheck(
       method: "OPTIONS",
       headers,
       timeout: ctx.config.timeout,
+      rateLimiter: getStageRateLimiter(ctx.config),
     });
   } catch {
     response = await requestUrl(ctx.config.target, {
       method: "GET",
       headers: { Origin: EVIL_ORIGIN },
       timeout: ctx.config.timeout,
+      rateLimiter: getStageRateLimiter(ctx.config),
     });
   }
 
@@ -199,6 +224,7 @@ async function runSensitivePathChecks(ctx: ScanContext): Promise<WebCheckResult>
         method: "GET",
         headers: { Accept: "*/*" },
         timeout: ctx.config.timeout,
+        rateLimiter: getStageRateLimiter(ctx.config),
       });
 
       const contentType = response.headers["content-type"]?.toLowerCase() ?? "";
@@ -332,6 +358,8 @@ async function requestUrl(
     method: string;
     headers?: Record<string, string>;
     timeout?: number;
+    /** Optional shared rate limiter; threaded through from ScanContext. */
+    rateLimiter?: RateLimiter;
   },
 ): Promise<WebProbeResponse> {
   const start = Date.now();
@@ -339,12 +367,15 @@ async function requestUrl(
   const timer = setTimeout(() => controller.abort(), options.timeout ?? 30_000);
 
   try {
+    // #214: pace per-host before each baseline / CORS / sensitive-path probe.
+    if (options.rateLimiter) await options.rateLimiter.acquire(url);
     const response = await fetch(url, {
       method: options.method,
       headers: options.headers,
       redirect: "manual",
       signal: controller.signal,
     });
+    if (options.rateLimiter) options.rateLimiter.noteResponse(url, response);
 
     const body = await response.text();
     const headers: Record<string, string> = {};

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -70,6 +70,16 @@ export interface ScanConfig {
    * before the agent boots; out-of-scope target = hard exit.
    */
   scopeFile?: string;
+  /**
+   * Per-host token-bucket rate-limit specification (#214). Accepts a
+   * plain rps (`"5"` / `"10:25"` for rps:burst) or a comma-separated
+   * mixture of per-host overrides plus a default
+   * (`"api.example.com=5,*.example.com=3:6,2"`). When unset, scan
+   * applies a conservative 5 rps default; set to disable
+   * (semantically: `"0"` is rejected as invalid — a missing flag is
+   * the way to disable, when we add an opt-out).
+   */
+  rateLimit?: string;
 }
 
 // ── Attack Templates ──


### PR DESCRIPTION
/claim #214

## Summary

Implements a per-host token-bucket rate limiter for scan-side fetches per #214. Closes the gap the issue calls out: every scan-side fetch site (`tools.ts`, `stages/web.ts`, `agentic-scanner.ts`) previously constructed requests inline with no central pacing, while the disclose runtime side already had a limiter from #206.

## Design

**Primitive (`packages/core/src/scope/rate-limit.ts`).**

| Class / fn | Role |
| --- | --- |
| `TokenBucket` | Single-host bucket. Lazy refill (no `setInterval`), `tryConsume` non-blocking, `acquire` blocks until N tokens available. Time source injectable for tests. |
| `RateLimiter` | `Map<host, TokenBucket>`. Per-host config + default. URL hostname is lowercased and port-stripped before bucket lookup. |
| `parseRateLimitFlag` | CLI parser: `"5"`, `"10:25"` (rps:burst), or `"api.example.com=5,*.example.com=3:6,2"` (per-host + default). Throws on malformed input — operators want to find a typo at start-of-scan, not five hours in. |
| `parseRetryAfter` | Both delta-seconds (RFC 7231 §7.1.3) and HTTP-date forms; returns 0 for unparseable. |

**Lazy refill, no timers.** `tokens = min(capacity, tokens + elapsedMs * ratePerMs)` is computed on each call. A bucket sitting idle for an hour does not consume a `setInterval` slot — it just refills to `capacity` the first time anyone touches it. This matters for scans that touch one host once and then move on to dozens of others.

**429 cool-off.** `RateLimiter.noteResponse(url, res)` inspects the response and parks the host's bucket past `Retry-After`. Conservative 60s floor matches the disclose-runtime precedent in #206 — even a 1-second `Retry-After` triggers a meaningful pause so we don't tarpit-loop the target. HTTP-date form (`Wed, 21 Oct 2015 07:28:00 GMT`) is honoured against the limiter's clock so virtual-time tests work cleanly.

**Bash-subprocess gap (acknowledged, NOT closed by this PR).** The `bash` tool shells out to `curl`/`wget`/`python3` which bypass node's `fetch` and therefore bypass this limiter — same disclaimer the scope work made in #218 about bash-extracted URLs. Documented in code comments and in the DoD below. Full mitigation requires an egress proxy on the runner; tracked separately.

## Files touched

| File | Change |
| --- | --- |
| `packages/core/src/scope/rate-limit.ts` | New. Primitive (~360 lines incl. comments). |
| `packages/core/src/scope/rate-limit.test.ts` | New. 31 unit tests. |
| `packages/core/src/agent/tools.ts` | `httpRequest`, `crawl`, `submitForm`, `webSearch`, `wp_fingerprint` `wrappedFetch` — `acquire` before each fetch, `noteResponse` after. |
| `packages/core/src/agent/types.ts` | `AgentConfig.rateLimiter?` and `ToolContext.rateLimiter?`. |
| `packages/core/src/agent/loop.ts`, `native-loop.ts` | Thread `rateLimiter` from `AgentConfig` / `NativeAgentConfig` into `ToolContext`. |
| `packages/core/src/stages/web.ts` | `requestUrl` accepts a limiter; `runWebDiscoveryProbe`, `runBaselineWebChecks`, `runCorsCheck`, `runSensitivePathChecks` all pass one. WeakMap-cached per `ScanConfig` so bucket state survives across stages. |
| `packages/core/src/agentic-scanner.ts` | One limiter built per scan (WeakMap-cached on `ScanConfig`); threaded into all 7 `runNativeAgentLoop` / `runAgentLoop` call sites and the `normalizeScanConfig` mode auto-detect probe. |
| `packages/cli/src/commands/scan.ts` | `--rate-limit <spec>` flag; pre-validates the spec at start-of-scan and exits 2 on parse error. |
| `packages/cli/src/commands/run.ts` | Threads `rateLimit` into `agenticScan({ config: { ... } })`. |
| `packages/shared/src/types.ts` | `ScanConfig.rateLimit?: string`. |
| `packages/core/src/index.ts` | Re-exports `TokenBucket`, `RateLimiter`, `parseRateLimitFlag`, `parseRetryAfter`. |

## DoD checklist (from #214)

- [x] `packages/core/src/scope/rate-limit.ts` — `RateLimiter` class with per-host buckets + 429/Retry-After honoring.
- [x] Wire into 6-7 fetch sites in `tools.ts`, `stages/web.ts`, `agentic-scanner.ts`. (Implemented at: `httpRequest`, `crawl`, `submitForm`, `webSearch`, `wp_fingerprint`, `stages/web.ts:requestUrl` (4 callers), `agentic-scanner.ts:normalizeScanConfig` mode probe.)
- [x] CLI flag `--rate-limit <spec>` on scan.
- [x] Default conservative (5 rps); scope-derived override is forward-compatible — when scope ingestion lands (#215 / PR #218) the cloud product can transform venue-specific rate-limit policies into this primitive's spec format.
- [x] Document the bash-subprocess gap (in code comments + this PR description; egress proxy is the proper fix and is a separate issue).
- [x] Tests: bucket math, 429 cool-off behavior, per-host isolation.

## Test demonstrations

```ts
// Burst N requests succeed instantly
const b = new TokenBucket(10, 10);
for (let i = 0; i < 10; i++) b.tryConsume();   // all true
b.tryConsume();                                 // false

// (N+1)th acquire blocks ~1/rps
await b.acquire();   // virtual clock advances ~100ms

// Per-host isolation
const rl = new RateLimiter({ default: { rps: 1 } });
await rl.acquire("https://a.example.com/");
rl.tryAcquire("https://a.example.com/");   // false (cooling)
rl.tryAcquire("https://b.example.com/");   // true (fresh bucket)

// 429 cool-off honors Retry-After (with 60s conservative floor)
rl.noteResponse(url, { status: 429, headers: new Headers({ "retry-after": "5" }) });
// subsequent acquire() sleeps >= 60_000ms

// CLI spec
parseRateLimitFlag("api.example.com=5,*.example.com=3:6,2")
// → { default: { rps: 2 },
//     perHost: { "api.example.com": { rps: 5 },
//                "*.example.com":   { rps: 3, burst: 6 } } }
```

## Test plan

- [x] `pnpm -C packages/core test src/scope/` — 31 / 31 pass.
- [x] `pnpm -C packages/core test src/agent/native-loop` — 28 / 28 pass.
- [x] `pnpm -r build` — green across shared, db, templates, core, cli, benchmark.
- [ ] Manual smoke: `pwnkit scan --target https://api.example.com/ --rate-limit api.example.com=2:5` paces at 2 rps with a 5-token burst.
- [ ] Manual smoke: a target that returns 429 with `Retry-After: 30` parks the host bucket for ≥ 60s (floor) and the next fetch waits past the deadline.

## Notes

- The virtual-clock test harness keeps the bucket-math suite fast (~9ms total). Real `setTimeout` would have made `await acquire()` blocking-wait tests run for seconds each — multiply that across 31 tests and CI suffers.
- One limiter per `ScanConfig` is critical: per-host bucket state and the 429 cool-off must survive across discovery → attack → verify stages and across all 7 agent-loop call sites. A fresh limiter per stage would silently re-allow traffic on a host the target just told us to back off from.
- The `--rate-limit` grammar accepts wildcard hosts (`*.example.com`) syntactically. Wildcard *matching* lands alongside the broader scope-ingestion work in #215 / PR #218 (which already has the `*.example.com`-style matcher we'll borrow once that PR merges). Recording the wildcard now keeps the CLI grammar forward-compatible — operators can already write the spec they want.
- `acquire(n)` clamps `n` to bucket capacity rather than looping forever on a request that exceeds capacity. This is a defensive guard, not an expected code path — every internal caller passes `n=1`.
