### PR TITLE
feat(scan): configurable attribution-header injection (#216)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -62,6 +62,10 @@ export interface RunOptions {
   scopeFile?: string;
   /** Opt-out for the scanner-binary suppression gate (pwnkit#217). Threaded into ScanConfig.allowScanners. */
   allowScanners?: boolean;
+  /** Repeatable `--attribution-header NAME=VALUE` (pwnkit#216). */
+  attributionHeaders?: string[];
+  /** `--attribution-ua <token>` (pwnkit#216). */
+  attributionUaToken?: string;
   sessionUiFactory?: (options: {
     target: string;
     depth: string;
@@ -269,6 +273,8 @@ export async function runUnified(opts: RunOptions): Promise<void> {
             scopeFile: opts.scopeFile,
             rateLimit: opts.rateLimit,
             allowScanners: opts.allowScanners,
+            attributionHeaders: opts.attributionHeaders,
+            attributionUaToken: opts.attributionUaToken,
           },
           dbPath: opts.dbPath,
           onEvent: eventHandler,

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -61,6 +61,15 @@ export function registerScanCommand(program: Command): void {
     .option("--auth <json>", "Auth credentials as JSON string or path to JSON file (types: bearer, cookie, basic, header)")
     .option("--scope <path>", "Path to a JSON scope file ({in_scope, out_of_scope} arrays of host / *.domain / cidr rules). Out-of-scope URLs return as ToolResult.error at every fetch site. See pwnkit#215.")
     .option("--allow-scanners", "Disable the generic-scanner suppression gate (pwnkit#217). When --scope is set, the agent refuses to spawn sqlmap/nikto/gobuster/dirb/wfuzz/ffuf/`nmap -sV`/`nmap -A` by default; pass this flag only when the engagement explicitly permits generic-scanner traffic.", false)
+    .option(
+      "--attribution-header <name=value>",
+      "Attribution header to attach to in-scope outbound requests (pwnkit#216). Repeatable: pass `--attribution-header X-A=1 --attribution-header X-B=2`. Lower precedence than the scope file's `attribution.headers` block and PWNKIT_ATTRIBUTION_HEADERS env var. NEVER attached to out-of-scope traffic.",
+      (value: string, prev: string[] = []) => [...prev, value],
+    )
+    .option(
+      "--attribution-ua <token>",
+      "Engagement token to embed in the User-Agent on in-scope traffic (pwnkit#216). Resulting UA: `pwnkit/<ver> (engagement: <token>)`. Lower precedence than the scope file's `attribution.user_agent_token` and PWNKIT_ATTRIBUTION_UA_TOKEN env var.",
+    )
     .option("--api-spec <path>", "Path to OpenAPI 3.x / Swagger 2.0 spec file (JSON or YAML) for pre-loaded endpoint knowledge")
     .option("--export <target>", "Export findings to issue tracker (e.g. github:owner/repo)")
     .option("--race", "Enable best-of-N strategy racing: run multiple attack strategies in parallel", false)
@@ -212,6 +221,28 @@ export function registerScanCommand(program: Command): void {
         }
       }
 
+      // Pre-validate attribution config (pwnkit#216). Same rationale as
+      // the --scope pre-flight: a malformed PWNKIT_ATTRIBUTION_HEADERS
+      // env var or an invalid scope-file `attribution` block is a config
+      // error, and the operator should see it before the scan boots.
+      try {
+        const {
+          loadScope,
+          resolveAttribution,
+          extractAttributionFromScopeJson,
+        } = await import("@pwnkit/core");
+        const policy = scopeFile ? loadScope(scopeFile) : undefined;
+        resolveAttribution({
+          scopeFileBlock: policy ? extractAttributionFromScopeJson(policy.raw) : undefined,
+          env: process.env,
+          cliHeaders: opts.attributionHeader as string[] | undefined,
+          cliUaToken: opts.attributionUa as string | undefined,
+        });
+      } catch (err) {
+        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+        process.exit(2);
+      }
+
       // Resolve cost ceiling: --cost-ceiling flag wins over PWNKIT_COST_CEILING_USD env.
       let costCeilingUsd: number | undefined;
       const ceilingSource =
@@ -265,6 +296,8 @@ export function registerScanCommand(program: Command): void {
         tui: opts.tui as boolean,
         scopeFile,
         allowScanners: opts.allowScanners as boolean | undefined,
+        attributionHeaders: opts.attributionHeader as string[] | undefined,
+        attributionUaToken: opts.attributionUa as string | undefined,
       });
     });
 }

--- a/packages/core/src/agent/loop.ts
+++ b/packages/core/src/agent/loop.ts
@@ -42,6 +42,7 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentState> 
     scope: config.scope,
     rateLimiter: config.rateLimiter,
     allowScanners: config.allowScanners,
+    attribution: config.attribution,
   };
 
   const executor = new ToolExecutor(toolCtx, db);

--- a/packages/core/src/agent/native-loop.ts
+++ b/packages/core/src/agent/native-loop.ts
@@ -10,6 +10,7 @@ import type {
 import type { AuthConfig } from "@pwnkit/shared";
 import type { ToolDefinition, ToolCall, ToolResult, ToolContext, AgentRole } from "./types.js";
 import type { ScopePolicy } from "../scope/scope.js";
+import type { AttributionConfig } from "../scope/attribution.js";
 import { ToolExecutor, getToolsForRole } from "./tools.js";
 import { features } from "./features.js";
 import { detectPlaybooks, buildPlaybookInjection } from "./playbooks.js";
@@ -113,6 +114,13 @@ export interface NativeAgentConfig {
    * to false. Only consulted when `scope` is set.
    */
   allowScanners?: boolean;
+  /**
+   * Resolved attribution-header config (pwnkit#216). Same propagation
+   * shape as `scope` — set once at agentic-scanner top-level and passed
+   * through to every fetch site so in-scope traffic is identifiable
+   * without leaking attribution to out-of-scope hosts.
+   */
+  attribution?: AttributionConfig;
 }
 
 export interface NativeAgentLoopOptions {
@@ -198,6 +206,7 @@ export async function runNativeAgentLoop(
     scope: config.scope,
     rateLimiter: config.rateLimiter,
     allowScanners: config.allowScanners,
+    attribution: config.attribution,
   };
 
   const executor = new ToolExecutor(toolCtx, db);

--- a/packages/core/src/agent/tools.test.ts
+++ b/packages/core/src/agent/tools.test.ts
@@ -963,3 +963,126 @@ describe("ToolExecutor — scanner suppression (pwnkit#217)", () => {
     expect(result.error).toMatch(/--allow-scanners/);
   });
 });
+
+// ── Attribution-header injection at the executor surface (pwnkit#216) ──
+//
+// The unit tests in attribution.test.ts cover the helper directly. These
+// integration tests pin that http_request actually attaches the configured
+// headers to its outbound fetch when scope + attribution are wired through
+// ToolContext. We mock global `fetch` so we can inspect the RequestInit
+// the executor passes into it without actually hitting the network.
+
+describe("ToolExecutor — attribution-header injection (pwnkit#216)", () => {
+  it("http_request attaches configured attribution headers on in-scope traffic", async () => {
+    const { ScopePolicy } = await import("../scope/scope.js");
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    try {
+      const ctx: ToolContext = {
+        target: "https://api.example.com",
+        scanId: "test-attr-1",
+        findings: [],
+        attackResults: [],
+        targetInfo: {},
+        scope,
+        attribution: {
+          headers: { "X-Pentest": "engagement-123" },
+          userAgentToken: "engagement-123",
+        },
+      };
+      const ex = new ToolExecutor(ctx, null);
+      const result = await ex.execute({
+        name: "http_request",
+        arguments: { url: "https://api.example.com/health", method: "GET" },
+      });
+      expect(result.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      const sentHeaders = calls[0].init!.headers as Record<string, string>;
+      expect(sentHeaders["X-Pentest"]).toBe("engagement-123");
+      // UA must contain the engagement token.
+      expect(sentHeaders["User-Agent"]).toMatch(/engagement: engagement-123/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("http_request does NOT attach attribution when no attribution is configured", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    try {
+      const ctx: ToolContext = {
+        target: "https://api.example.com",
+        scanId: "test-attr-2",
+        findings: [],
+        attackResults: [],
+        targetInfo: {},
+        // No scope, no attribution → identical to pre-#216 behaviour.
+      };
+      const ex = new ToolExecutor(ctx, null);
+      await ex.execute({
+        name: "http_request",
+        arguments: { url: "https://api.example.com/health", method: "GET" },
+      });
+      const sentHeaders = calls[0].init!.headers as Record<string, string>;
+      expect(sentHeaders["X-Pentest"]).toBeUndefined();
+      // No engagement token configured → no engagement-tagged UA.
+      expect(sentHeaders["User-Agent"]).toBeUndefined();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("submit_form attaches configured attribution headers on in-scope traffic", async () => {
+    // Mirrors the http_request integration test above. submit_form receives
+    // identical applyAttribution wiring, so we pin the same invariant at the
+    // executor surface so a future refactor can't quietly drop it.
+    const { ScopePolicy } = await import("../scope/scope.js");
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: any, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return new Response("ok", { status: 200 });
+    }) as any;
+
+    try {
+      const ctx: ToolContext = {
+        target: "https://api.example.com",
+        scanId: "test-attr-form",
+        findings: [],
+        attackResults: [],
+        targetInfo: {},
+        scope,
+        attribution: {
+          headers: { "X-Pentest": "engagement-123" },
+          userAgentToken: "engagement-123",
+        },
+      };
+      const ex = new ToolExecutor(ctx, null);
+      const result = await ex.execute({
+        name: "submit_form",
+        arguments: { url: "https://api.example.com/login", fields: { user: "test" } },
+      });
+      expect(result.success).toBe(true);
+      expect(calls).toHaveLength(1);
+      const sentHeaders = calls[0].init!.headers as Record<string, string>;
+      expect(sentHeaders["X-Pentest"]).toBe("engagement-123");
+      expect(sentHeaders["User-Agent"]).toMatch(/engagement: engagement-123/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -17,6 +17,7 @@ import type { ToolDefinition, ToolCall, ToolResult, ToolContext } from "./types.
 import type { ScopePolicy } from "../scope/scope.js";
 import { extractUrls } from "../scope/scope.js";
 import { detectScannerBinary } from "../scope/scanner-binaries.js";
+import { applyAttribution, formatUserAgent } from "../scope/attribution.js";
 import { sendPrompt, extractResponseText } from "../http.js";
 import { buildAuthHeaders } from "./prompts.js";
 import type { pwnkitDB } from "@pwnkit/db";
@@ -1255,13 +1256,23 @@ export class ToolExecutor {
     const timer = setTimeout(() => controller.abort(), 30_000);
 
     try {
-      const res = await fetch(url, {
-        method,
-        headers: { "Content-Type": "application/json", ...headers },
-        body: body ?? undefined,
-        signal: controller.signal,
-        redirect: "manual",
-      });
+      // Attribution-header injection (pwnkit#216). Merged before the call
+      // so the on-the-wire request carries the engagement identifier on
+      // every in-scope hop. Out-of-scope hosts are already refused above
+      // by validateTargetUrl; applyAttribution defends in depth.
+      const fetchInit = applyAttribution(
+        url,
+        {
+          method,
+          headers: { "Content-Type": "application/json", ...headers },
+          body: body ?? undefined,
+          signal: controller.signal,
+          redirect: "manual",
+        },
+        this.ctx.attribution,
+        this.ctx.scope,
+      )!;
+      const res = await fetch(url, fetchInit);
 
       if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(url, res);
       clearTimeout(timer);
@@ -1272,9 +1283,16 @@ export class ToolExecutor {
         body: text.slice(0, 10_000), // cap response size
       };
 
-      // Persist as run artifact
+      // Persist as run artifact (record the headers actually sent so the
+      // operator can confirm attribution was attached on engagement-tagged
+      // traffic).
       this.persistToolArtifact("http_request", {
-        request: { url, method, headers, body: body?.slice(0, 2_000) },
+        request: {
+          url,
+          method,
+          headers: fetchInit.headers as Record<string, string>,
+          body: body?.slice(0, 2_000),
+        },
         response: { status: output.status, body: output.body.slice(0, 5_000) },
       });
 
@@ -1459,15 +1477,35 @@ export class ToolExecutor {
 
       try {
         const crawlAuthHeaders = buildAuthHeaders(this.ctx.authConfig);
+        // Attribution-header injection (pwnkit#216). Crawler hits every
+        // discovered link, so this is the highest-volume fetch site —
+        // attribution here is what most defenders will see in their logs.
+        // The default `pwnkit-crawler/1.0` UA is replaced with the
+        // engagement-tagged UA inside applyAttribution when configured.
+        const crawlInit = applyAttribution(
+          normalizedUrl,
+          {
+            method: "GET",
+            signal: controller.signal,
+            redirect: "follow",
+            headers: { "User-Agent": "pwnkit-crawler/1.0", ...crawlAuthHeaders },
+          },
+          this.ctx.attribution,
+          this.ctx.scope,
+        )!;
+        // crawl explicitly wants the engagement-tagged UA (not the
+        // generic crawler one) when attribution is configured. We
+        // overwrite here because the attribution path keeps caller UA
+        // for principle-of-least-surprise in other call sites.
+        if (this.ctx.attribution?.userAgentToken) {
+          (crawlInit.headers as Record<string, string>)["User-Agent"] =
+            formatUserAgent(this.ctx.attribution.userAgentToken);
+        }
         // #214: per-host rate limit, acquire before each crawl fetch.
         if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(normalizedUrl);
-        const res = await fetch(normalizedUrl, {
-          method: "GET",
-          signal: controller.signal,
-          redirect: "follow",
-          headers: { "User-Agent": "pwnkit-crawler/1.0", ...crawlAuthHeaders },
-        });
+        const res = await fetch(normalizedUrl, crawlInit);
         if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(normalizedUrl, res);
+
         clearTimeout(timer);
 
         // Redirect-to-out-of-scope refusal (DoD line item). `redirect:
@@ -1590,9 +1628,13 @@ export class ToolExecutor {
     const timer = setTimeout(() => controller.abort(), 10_000);
 
     try {
+      // Attribution-header injection (pwnkit#216). submit_form is one
+      // of the noisier fetch sites in pen-test contexts (login attempts,
+      // CSRF probes), so attribution here is critical for deconfliction.
+      const submitInit = applyAttribution(fetchUrl, fetchOpts, this.ctx.attribution, this.ctx.scope)!;
       // #214: rate-limit the form submission before dispatching.
       if (this.ctx.rateLimiter) await this.ctx.rateLimiter.acquire(fetchUrl);
-      const res = await fetch(fetchUrl, fetchOpts);
+      const res = await fetch(fetchUrl, submitInit);
       if (this.ctx.rateLimiter) this.ctx.rateLimiter.noteResponse(fetchUrl, res);
       clearTimeout(timer);
       const text = await res.text();
@@ -1604,7 +1646,7 @@ export class ToolExecutor {
       };
 
       this.persistToolArtifact("submit_form", {
-        request: { url: fetchUrl, method, fields },
+        request: { url: fetchUrl, method, headers: submitInit.headers as Record<string, string>, fields },
         response: { status: output.status, body: output.body.slice(0, 5_000) },
       });
 
@@ -1721,9 +1763,24 @@ export class ToolExecutor {
     // @ts-ignore — playwright is an optional dependency
     const { chromium } = await import("playwright");
     this._browser = await chromium.launch({ headless: true });
+    // Attribution-header injection (pwnkit#216). Playwright doesn't run
+    // through `applyAttribution` — it has its own request pipeline — so
+    // we set `extraHTTPHeaders` on the context, which Chrome attaches to
+    // every outgoing request. The browser only navigates to in-scope
+    // hosts (validateTargetUrl is enforced before goto), so attribution
+    // here is bounded to in-scope traffic in the same way as the fetch
+    // sites. Same UA-override rule: when an engagement token is set, it
+    // replaces the default `pwnkit-browser/1.0`.
+    const attribution = this.ctx.attribution;
+    const browserUa = attribution?.userAgentToken
+      ? formatUserAgent(attribution.userAgentToken)
+      : "pwnkit-browser/1.0";
     const context = await this._browser.newContext({
       ignoreHTTPSErrors: true,
-      userAgent: "pwnkit-browser/1.0",
+      userAgent: browserUa,
+      ...(attribution && Object.keys(attribution.headers).length > 0
+        ? { extraHTTPHeaders: attribution.headers }
+        : {}),
     });
     this._browserPage = await context.newPage();
 
@@ -2412,6 +2469,7 @@ export class ToolExecutor {
     const authHeaders = buildAuthHeaders(this.ctx.authConfig);
     const scope = this.ctx.scope;
     const rateLimiter = this.ctx.rateLimiter;
+    const attribution = this.ctx.attribution;
     const wrappedFetch: FetchLike = async (url, init) => {
       // Scope check (pwnkit#215). runWpFingerprint walks the WP plugin
       // namespace by appending paths to `target`; under same-origin that
@@ -2428,15 +2486,21 @@ export class ToolExecutor {
         ...authHeaders,
         ...(init?.headers ?? {}),
       };
+      // Attribution-header injection (pwnkit#216). wp_fingerprint runs
+      // dozens of plugin probes in a tight loop, so attribution on
+      // every probe is what tells defenders this is engagement traffic
+      // rather than a botnet pulling /wp-content/plugins/* paths.
+      const fetchInit = applyAttribution(
+        url,
+        { method: init?.method ?? "GET", headers, body: init?.body },
+        attribution,
+        scope,
+      )!;
       // #214: each plugin/version probe goes through the per-host bucket.
       // wp_fingerprint can fan out to dozens of probes against a single
       // host — exactly the workload the limiter exists to pace.
       if (rateLimiter) await rateLimiter.acquire(url);
-      const res = await fetch(url, {
-        method: init?.method ?? "GET",
-        headers,
-        body: init?.body,
-      });
+      const res = await fetch(url, fetchInit);
       // Post-redirect scope check (pwnkit#218 review). `fetch` follows
       // redirects by default, so an in-scope WordPress endpoint that
       // 302s to a foreign host would otherwise complete against the

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -1,6 +1,7 @@
 import type { Finding, AttackResult, TargetInfo, AuthConfig } from "@pwnkit/shared";
 import type { ScopePolicy } from "../scope/scope.js";
 import type { RateLimiter } from "../scope/rate-limit.js";
+import type { AttributionConfig } from "../scope/attribution.js";
 
 // ── Agent Roles ──
 
@@ -84,6 +85,14 @@ export interface AgentConfig {
    * explicitly permits generic-scanner traffic).
    */
   allowScanners?: boolean;
+  /**
+   * Resolved attribution-header config (pwnkit#216). When set, every
+   * fetch site merges these headers + applies the User-Agent override on
+   * IN-SCOPE requests. Out-of-scope hosts are never tagged. When `scope`
+   * is also undefined, attribution behaves as opt-in: present here means
+   * the operator explicitly configured it (env or CLI) and wants it on.
+   */
+  attribution?: AttributionConfig;
 }
 
 // ── Agent State ──
@@ -122,4 +131,6 @@ export interface ToolContext {
    * suppression gate (pwnkit#217). Only consulted when `scope` is set.
    */
   allowScanners?: boolean;
+  /** See `AgentConfig.attribution` (pwnkit#216). */
+  attribution?: AttributionConfig;
 }

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -55,6 +55,11 @@ import { getCloudSinkConfig, postFinding, postFinalReport } from "./cloud-sink.j
 import { eventBus } from "./events/bus.js";
 import { loadScope, type ScopePolicy } from "./scope/scope.js";
 import { RateLimiter, parseRateLimitFlag } from "./scope/rate-limit.js";
+import {
+  resolveAttribution,
+  extractAttributionFromScopeJson,
+} from "./scope/attribution.js";
+import type { AttributionConfig } from "./scope/attribution.js";
 
 /**
  * Per-scan rate-limiter cache (#214). The limiter is stateful — buckets
@@ -278,6 +283,14 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       );
     }
   }
+
+  // Attribution-header config (pwnkit#216). Resolved by every per-stage
+  // helper below via `buildAttributionForConfig(config)` — see that
+  // function for the actual three-source merge. We pre-flight here so a
+  // malformed `attribution` block in the scope file or a malformed
+  // `PWNKIT_ATTRIBUTION_HEADERS` env var fails the scan loudly at boot
+  // instead of crashing inside the discovery agent's first fetch.
+  buildAttributionForConfig(config);
 
   const db = await (async () => {
     try {
@@ -1772,6 +1785,23 @@ function resolveScopeForConfig(config: ScanConfig): ScopePolicy | undefined {
   return policy;
 }
 
+/**
+ * Resolve the attribution config (pwnkit#216) from a ScanConfig. Called
+ * inline at every helper-function call site that constructs an
+ * `AgentConfig`/`NativeAgentConfig`. Reuses the cached `ScopePolicy`
+ * via `resolveScopeForConfig` so the scope file isn't reparsed.
+ * Returns `undefined` when no source contributed anything.
+ */
+function buildAttributionForConfig(config: ScanConfig): AttributionConfig | undefined {
+  const scope = resolveScopeForConfig(config);
+  return resolveAttribution({
+    scopeFileBlock: scope ? extractAttributionFromScopeJson(scope.raw) : undefined,
+    env: process.env,
+    cliHeaders: config.attributionHeaders,
+    cliUaToken: config.attributionUaToken,
+  });
+}
+
 async function runNativeDiscovery(
   runtime: NativeRuntime,
   db: any,
@@ -1805,6 +1835,7 @@ async function runNativeDiscovery(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -2027,6 +2058,7 @@ async function runNativeAttack(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -2092,6 +2124,7 @@ async function runNativeAttack(
         scope: resolveScopeForConfig(config),
         rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
         costCeilingUsd: config.costCeilingUsd,
         costModel: config.model,
       },
@@ -2307,6 +2340,7 @@ async function runNativeVerify(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
       costCeilingUsd: config.costCeilingUsd,
       costModel: config.model,
     },
@@ -2368,6 +2402,7 @@ async function runLegacyDiscovery(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
     },
     runtime,
     db,
@@ -2434,6 +2469,7 @@ async function runLegacyAttack(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
     },
     runtime,
     db,
@@ -2501,6 +2537,7 @@ async function runLegacyVerify(
       scope: resolveScopeForConfig(config),
       rateLimiter: getOrCreateRateLimiter(config),
       allowScanners: config.allowScanners,
+      attribution: buildAttributionForConfig(config),
     },
     runtime,
     db,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,23 @@
 export { loadScope, matchUrl, ScopePolicy, extractUrls } from "./scope/scope.js";
 export type { ScopeJson, ScopeMatch, ScopeRule } from "./scope/scope.js";
 
+// Attribution-header injection (pwnkit#216). Builds on scope ingestion:
+// configures per-engagement headers + UA override that get merged into
+// every in-scope outbound request, so coordinated-disclosure venues can
+// deconflict pwnkit traffic from real attacks.
+export {
+  resolveAttribution,
+  applyAttribution,
+  extractAttributionFromScopeJson,
+  formatUserAgent,
+} from "./scope/attribution.js";
+export type {
+  AttributionConfig,
+  AttributionInputs,
+  AttributionScopeBlock,
+  AttributionScopeJson,
+} from "./scope/attribution.js";
+
 export { scan } from "./scanner.js";
 export type { ScanEvent, ScanListener, ScanEventType } from "./scanner.js";
 export { agenticScan } from "./agentic-scanner.js";

--- a/packages/core/src/scope/attribution.test.ts
+++ b/packages/core/src/scope/attribution.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveAttribution,
+  applyAttribution,
+  extractAttributionFromScopeJson,
+  formatUserAgent,
+} from "./attribution.js";
+import { ScopePolicy } from "./scope.js";
+import { VERSION } from "@pwnkit/shared";
+
+// ── resolveAttribution ──
+
+describe("resolveAttribution — config sources & precedence (pwnkit#216)", () => {
+  it("returns undefined when no source contributes anything", () => {
+    expect(resolveAttribution()).toBeUndefined();
+    expect(resolveAttribution({ env: {} })).toBeUndefined();
+    expect(resolveAttribution({ cliHeaders: [] })).toBeUndefined();
+  });
+
+  it("loads CLI headers from repeatable --attribution-header tokens", () => {
+    const cfg = resolveAttribution({
+      cliHeaders: ["X-Pentest=engagement-123", "X-Researcher=brian"],
+    });
+    expect(cfg?.headers).toEqual({
+      "X-Pentest": "engagement-123",
+      "X-Researcher": "brian",
+    });
+  });
+
+  it("preserves the value verbatim past the first `=` (allows base64 etc.)", () => {
+    const cfg = resolveAttribution({ cliHeaders: ["X-Token=a=b=c"] });
+    expect(cfg?.headers["X-Token"]).toBe("a=b=c");
+  });
+
+  it("rejects malformed CLI tokens silently (no name, no equals)", () => {
+    const cfg = resolveAttribution({
+      cliHeaders: ["no-equals", "=just-value", "X-Good=ok"],
+    });
+    expect(cfg?.headers).toEqual({ "X-Good": "ok" });
+  });
+
+  it("loads env headers from PWNKIT_ATTRIBUTION_HEADERS JSON", () => {
+    const cfg = resolveAttribution({
+      env: { PWNKIT_ATTRIBUTION_HEADERS: '{"X-Pentest":"env-engagement"}' },
+    });
+    expect(cfg?.headers["X-Pentest"]).toBe("env-engagement");
+  });
+
+  it("throws on malformed PWNKIT_ATTRIBUTION_HEADERS JSON", () => {
+    expect(() =>
+      resolveAttribution({ env: { PWNKIT_ATTRIBUTION_HEADERS: "{not json" } }),
+    ).toThrow(/PWNKIT_ATTRIBUTION_HEADERS/);
+  });
+
+  it("throws when env headers is not an object of strings", () => {
+    expect(() =>
+      resolveAttribution({ env: { PWNKIT_ATTRIBUTION_HEADERS: '["array"]' } }),
+    ).toThrow();
+    expect(() =>
+      resolveAttribution({ env: { PWNKIT_ATTRIBUTION_HEADERS: '{"X-Bad":42}' } }),
+    ).toThrow();
+  });
+
+  it("loads UA token from env PWNKIT_ATTRIBUTION_UA_TOKEN", () => {
+    const cfg = resolveAttribution({
+      env: { PWNKIT_ATTRIBUTION_UA_TOKEN: "env-eng-42" },
+    });
+    expect(cfg?.userAgentToken).toBe("env-eng-42");
+  });
+
+  it("scope file beats env beats CLI on the same header name", () => {
+    const cfg = resolveAttribution({
+      scopeFileBlock: { headers: { "X-Pentest": "from-file" } },
+      env: { PWNKIT_ATTRIBUTION_HEADERS: '{"X-Pentest":"from-env"}' },
+      cliHeaders: ["X-Pentest=from-cli"],
+    });
+    expect(cfg?.headers["X-Pentest"]).toBe("from-file");
+  });
+
+  it("env beats CLI on the same header name when no scope file value", () => {
+    const cfg = resolveAttribution({
+      env: { PWNKIT_ATTRIBUTION_HEADERS: '{"X-Pentest":"from-env"}' },
+      cliHeaders: ["X-Pentest=from-cli"],
+    });
+    expect(cfg?.headers["X-Pentest"]).toBe("from-env");
+  });
+
+  it("merges across sources for distinct keys", () => {
+    const cfg = resolveAttribution({
+      scopeFileBlock: { headers: { "X-Pentest": "file-pin" } },
+      env: { PWNKIT_ATTRIBUTION_HEADERS: '{"X-Engagement-ID":"env-42"}' },
+      cliHeaders: ["X-Researcher=brian"],
+    });
+    expect(cfg?.headers).toEqual({
+      "X-Pentest": "file-pin",
+      "X-Engagement-ID": "env-42",
+      "X-Researcher": "brian",
+    });
+  });
+
+  it("UA token follows the same precedence (file > env > CLI)", () => {
+    const cfg1 = resolveAttribution({
+      scopeFileBlock: { user_agent_token: "file-ua" },
+      env: { PWNKIT_ATTRIBUTION_UA_TOKEN: "env-ua" },
+      cliUaToken: "cli-ua",
+    });
+    expect(cfg1?.userAgentToken).toBe("file-ua");
+
+    const cfg2 = resolveAttribution({
+      env: { PWNKIT_ATTRIBUTION_UA_TOKEN: "env-ua" },
+      cliUaToken: "cli-ua",
+    });
+    expect(cfg2?.userAgentToken).toBe("env-ua");
+
+    const cfg3 = resolveAttribution({ cliUaToken: "cli-ua" });
+    expect(cfg3?.userAgentToken).toBe("cli-ua");
+  });
+
+  it("ignores blank UA token strings (treats them as not-set)", () => {
+    const cfg = resolveAttribution({
+      scopeFileBlock: { user_agent_token: "   " },
+      env: { PWNKIT_ATTRIBUTION_UA_TOKEN: "real-token" },
+    });
+    expect(cfg?.userAgentToken).toBe("real-token");
+  });
+});
+
+// ── applyAttribution ──
+
+describe("applyAttribution — header injection", () => {
+  const attribution = {
+    headers: { "X-Pentest": "engagement-123" },
+    userAgentToken: "engagement-123",
+  };
+
+  it("returns init untouched when attribution is undefined", () => {
+    const init = { method: "POST" };
+    expect(applyAttribution("https://api.example.com/", init, undefined, undefined)).toBe(init);
+  });
+
+  it("injects headers on in-scope hosts", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/health",
+      { method: "GET" },
+      attribution,
+      scope,
+    );
+    const headers = out!.headers as Record<string, string>;
+    expect(headers["X-Pentest"]).toBe("engagement-123");
+  });
+
+  it("does NOT inject on out-of-scope hosts even when somehow reached", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://evil.com/exfil",
+      { method: "GET" },
+      attribution,
+      scope,
+    );
+    // `init.headers` was not set — applyAttribution must not have added any.
+    expect((out as RequestInit | undefined)?.headers).toBeUndefined();
+  });
+
+  it("does NOT inject on out-of-scope hosts when caller had headers", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const callerHeaders = { Authorization: "Bearer x" };
+    const out = applyAttribution(
+      "https://evil.com/exfil",
+      { headers: callerHeaders },
+      attribution,
+      scope,
+    );
+    // Caller headers preserved, no attribution merged.
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers).toEqual(callerHeaders);
+    expect(headers["X-Pentest"]).toBeUndefined();
+  });
+
+  it("injects when no scope is loaded but attribution is configured (opt-in)", () => {
+    // The "opt-in" behaviour is: if the caller went to the trouble of
+    // configuring attribution despite no scope file, they want it on.
+    // Out-of-scope leakage prevention happens via scope; without scope
+    // there are no out-of-scope hosts.
+    const out = applyAttribution(
+      "https://anywhere.com/",
+      undefined,
+      attribution,
+      undefined,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Pentest"]).toBe("engagement-123");
+  });
+
+  it("overrides User-Agent when token is configured", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/",
+      undefined,
+      attribution,
+      scope,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe(`pwnkit/${VERSION} (engagement: engagement-123)`);
+  });
+
+  it("preserves caller-supplied User-Agent (caller wins)", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/",
+      { headers: { "User-Agent": "pwnkit-crawler/1.0" } },
+      attribution,
+      scope,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("pwnkit-crawler/1.0");
+  });
+
+  it("caller-supplied attribution-shaped headers win over the resolved config", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/",
+      { headers: { "X-Pentest": "caller-wins" } },
+      attribution,
+      scope,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Pentest"]).toBe("caller-wins");
+  });
+
+  it("merges with caller headers in plain-object form", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/",
+      { headers: { "Content-Type": "application/json" } },
+      attribution,
+      scope,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Pentest"]).toBe("engagement-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("merges with caller headers in array-of-pairs form", () => {
+    const scope = ScopePolicy.fromJson({ in_scope: ["api.example.com"] });
+    const out = applyAttribution(
+      "https://api.example.com/",
+      { headers: [["Content-Type", "application/json"]] as [string, string][] },
+      attribution,
+      scope,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["X-Pentest"]).toBe("engagement-123");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("only applies UA token (no headers) when only UA configured", () => {
+    const onlyUa = { headers: {}, userAgentToken: "engagement-only" };
+    const out = applyAttribution(
+      "https://api.example.com/",
+      undefined,
+      onlyUa,
+      undefined,
+    );
+    const headers = (out as RequestInit).headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe(`pwnkit/${VERSION} (engagement: engagement-only)`);
+    expect(Object.keys(headers).filter((k) => k.toLowerCase() !== "user-agent")).toHaveLength(0);
+  });
+});
+
+// ── extractAttributionFromScopeJson ──
+
+describe("extractAttributionFromScopeJson — scope file ingestion", () => {
+  it("returns undefined when no attribution block exists", () => {
+    expect(extractAttributionFromScopeJson({ in_scope: ["api.example.com"] })).toBeUndefined();
+  });
+
+  it("extracts headers + user_agent_token", () => {
+    const block = extractAttributionFromScopeJson({
+      in_scope: ["api.example.com"],
+      attribution: {
+        headers: { "X-Pentest": "engagement-99" },
+        user_agent_token: "engagement-99",
+      },
+    });
+    expect(block).toEqual({
+      headers: { "X-Pentest": "engagement-99" },
+      user_agent_token: "engagement-99",
+    });
+  });
+
+  it("rejects non-object attribution block", () => {
+    expect(() => extractAttributionFromScopeJson({ attribution: "nope" })).toThrow();
+    expect(() => extractAttributionFromScopeJson({ attribution: ["bad"] })).toThrow();
+  });
+
+  it("rejects non-string header values", () => {
+    expect(() =>
+      extractAttributionFromScopeJson({ attribution: { headers: { "X-Bad": 42 } } }),
+    ).toThrow();
+  });
+
+  it("rejects non-string user_agent_token", () => {
+    expect(() =>
+      extractAttributionFromScopeJson({ attribution: { user_agent_token: 42 } }),
+    ).toThrow();
+  });
+
+  it("rejects invalid header names", () => {
+    expect(() =>
+      extractAttributionFromScopeJson({
+        attribution: { headers: { "X Bad Spaces": "v" } },
+      }),
+    ).toThrow();
+  });
+});
+
+// ── formatUserAgent ──
+
+describe("formatUserAgent", () => {
+  it("formats as `pwnkit/<ver> (engagement: <token>)`", () => {
+    expect(formatUserAgent("eng-1")).toBe(`pwnkit/${VERSION} (engagement: eng-1)`);
+  });
+});

--- a/packages/core/src/scope/attribution.ts
+++ b/packages/core/src/scope/attribution.ts
@@ -1,0 +1,299 @@
+// ── Attribution-header injection (pwnkit#216) ──
+//
+// Coordinated-disclosure venues and pentest engagements commonly require an
+// identifying header on test traffic so the receiving party can deconflict
+// (i.e. distinguish authorized testing from real attack traffic). Without
+// attribution, scan traffic looks indistinguishable from a malicious scan,
+// reports get closed as "could not deconflict", and anti-abuse systems
+// trigger on legitimate engagement traffic.
+//
+// This module provides the primitive: a configurable set of headers (plus
+// an optional User-Agent override) that gets attached to every outbound
+// request to in-scope hosts, and to in-scope hosts ONLY. Out-of-scope
+// hosts must not have attribution attached — leaking an engagement
+// identifier to an unrelated third party is a real harm, so we err on
+// the side of NOT tagging.
+//
+// ── Configuration sources & precedence ──
+//
+// Per the issue's DoD, attribution is sourced from three places, with the
+// scope file winning over env, and env winning over CLI:
+//
+//   1. Scope file: an optional `attribution` block alongside `in_scope` /
+//      `out_of_scope` in the JSON file. This is the natural unit because
+//      the scope file already binds to a specific engagement, and per-
+//      program override is exactly what venues need (HackerOne uses
+//      `X-HackerOne-Research`, Bugcrowd uses different fields, internal
+//      programs invent their own).
+//   2. Env vars: `PWNKIT_ATTRIBUTION_HEADERS` (JSON object of name→value)
+//      and `PWNKIT_ATTRIBUTION_UA_TOKEN` (string).
+//   3. CLI flags: repeatable `--attribution-header NAME=VALUE` and
+//      `--attribution-ua TOKEN`.
+//
+// "Precedence" here means "a key set by an earlier source wins on conflict".
+// Sources still merge for distinct keys — if the scope file sets
+// `X-Pentest: foo` and the CLI adds `X-Engagement-ID: 42`, both end up on
+// the wire. This matches operator intent: the scope file pins the per-
+// program override, env/CLI add ad-hoc fields without replacing the file.
+//
+// ── No-scope behaviour ──
+//
+// When NO scope file is loaded, attribution is opt-in: only injected when
+// the operator explicitly set it via env or CLI. This avoids leaking
+// engagement headers when pwnkit is used outside an engagement (e.g.
+// against a personal target). The DoD calls this out:
+// "never injected on out-of-scope traffic".
+
+import type { ScopePolicy, ScopeJson } from "./scope.js";
+import { VERSION } from "@pwnkit/shared";
+
+export interface AttributionConfig {
+  /** Headers to attach to every in-scope outbound request. */
+  headers: Record<string, string>;
+  /** Optional engagement token to embed in the User-Agent override. */
+  userAgentToken?: string;
+}
+
+/**
+ * Shape of the optional `attribution` block inside a scope JSON file.
+ * Both fields are optional; either may be absent.
+ */
+export interface AttributionScopeBlock {
+  headers?: Record<string, string>;
+  user_agent_token?: string;
+}
+
+export interface AttributionScopeJson extends ScopeJson {
+  attribution?: AttributionScopeBlock;
+}
+
+export interface AttributionInputs {
+  /** Already-parsed `attribution` block from the scope file, if any. */
+  scopeFileBlock?: AttributionScopeBlock;
+  /** Env-var inputs, normally read from `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** CLI inputs (repeatable `--attribution-header NAME=VALUE` etc.). */
+  cliHeaders?: string[];
+  cliUaToken?: string;
+}
+
+const ENV_HEADERS_KEY = "PWNKIT_ATTRIBUTION_HEADERS";
+const ENV_UA_TOKEN_KEY = "PWNKIT_ATTRIBUTION_UA_TOKEN";
+
+/**
+ * Build an `AttributionConfig` from the three configured sources, applying
+ * the documented precedence (scope file > env > CLI on conflicts) and
+ * merging across sources for distinct keys. Returns `undefined` when no
+ * source contributed anything — callers can short-circuit injection in
+ * that case.
+ */
+export function resolveAttribution(inputs: AttributionInputs = {}): AttributionConfig | undefined {
+  const headers: Record<string, string> = {};
+
+  // Apply LOWEST priority FIRST so higher-priority sources overwrite.
+  // CLI is lowest, env is middle, scope file is highest. This is
+  // backwards from how a naive reader might write it — be careful when
+  // editing.
+
+  // CLI (lowest)
+  for (const raw of inputs.cliHeaders ?? []) {
+    const parsed = parseCliHeader(raw);
+    if (parsed) headers[parsed.name] = parsed.value;
+  }
+
+  // Env (middle)
+  const envHeadersRaw = inputs.env?.[ENV_HEADERS_KEY];
+  if (envHeadersRaw && envHeadersRaw.trim().length > 0) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(envHeadersRaw);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`${ENV_HEADERS_KEY} must be a JSON object of header→value: ${msg}`);
+    }
+    assertHeaderObject(parsed, ENV_HEADERS_KEY);
+    for (const [k, v] of Object.entries(parsed as Record<string, string>)) {
+      headers[normalizeHeaderName(k)] = v;
+    }
+  }
+
+  // Scope file (highest)
+  if (inputs.scopeFileBlock?.headers) {
+    assertHeaderObject(inputs.scopeFileBlock.headers, "scope file `attribution.headers`");
+    for (const [k, v] of Object.entries(inputs.scopeFileBlock.headers)) {
+      headers[normalizeHeaderName(k)] = v;
+    }
+  }
+
+  // UA token: same precedence (file > env > CLI). First non-empty value
+  // along that chain wins.
+  let userAgentToken: string | undefined;
+  const fileToken = inputs.scopeFileBlock?.user_agent_token;
+  const envToken = inputs.env?.[ENV_UA_TOKEN_KEY];
+  if (typeof fileToken === "string" && fileToken.trim().length > 0) {
+    userAgentToken = fileToken.trim();
+  } else if (typeof envToken === "string" && envToken.trim().length > 0) {
+    userAgentToken = envToken.trim();
+  } else if (typeof inputs.cliUaToken === "string" && inputs.cliUaToken.trim().length > 0) {
+    userAgentToken = inputs.cliUaToken.trim();
+  }
+
+  if (Object.keys(headers).length === 0 && !userAgentToken) {
+    return undefined;
+  }
+
+  return { headers, userAgentToken };
+}
+
+/**
+ * Apply attribution to a `(url, init)` request pair. Returns a NEW init
+ * object with the configured headers merged in and the User-Agent
+ * overridden when a token is configured. The caller-supplied headers
+ * win on conflict — operators that pass a specific `Authorization` or
+ * `Content-Type` should not have it silently overwritten by attribution
+ * config (those are not attribution-shaped headers).
+ *
+ * Three guards:
+ *   1. If `attribution` is undefined → return init untouched.
+ *   2. If `scope` is defined AND the URL is out-of-scope → return init
+ *      untouched. Defence in depth: scope already refuses out-of-scope
+ *      URLs at the chokepoint, but if a future code path slips through,
+ *      we still don't leak attribution headers.
+ *   3. If `scope` is undefined → injection is opt-in and the caller
+ *      decides (we trust `attribution !== undefined` as that signal).
+ */
+export function applyAttribution(
+  url: string,
+  init: RequestInit | undefined,
+  attribution: AttributionConfig | undefined,
+  scope: ScopePolicy | undefined,
+): RequestInit | undefined {
+  if (!attribution) return init;
+
+  if (scope) {
+    const verdict = scope.match(url);
+    if (!verdict.allowed) return init;
+  }
+
+  const merged: Record<string, string> = {};
+  // Attribution headers FIRST so caller-supplied init.headers can override
+  // (operator-supplied Authorization etc. wins).
+  for (const [k, v] of Object.entries(attribution.headers)) {
+    merged[k] = v;
+  }
+  // Carry over caller-supplied headers. We accept the three RequestInit
+  // header shapes (Headers object, array of pairs, plain object) the same
+  // way `fetch` does.
+  const callerHeaders = init?.headers;
+  if (callerHeaders) {
+    if (typeof Headers !== "undefined" && callerHeaders instanceof Headers) {
+      callerHeaders.forEach((value, key) => {
+        merged[normalizeHeaderName(key)] = value;
+      });
+    } else if (Array.isArray(callerHeaders)) {
+      for (const pair of callerHeaders) {
+        if (Array.isArray(pair) && pair.length === 2) {
+          merged[normalizeHeaderName(String(pair[0]))] = String(pair[1]);
+        }
+      }
+    } else if (typeof callerHeaders === "object") {
+      for (const [k, v] of Object.entries(callerHeaders as Record<string, string>)) {
+        merged[normalizeHeaderName(k)] = String(v);
+      }
+    }
+  }
+
+  // User-Agent override — only when a token is configured AND the caller
+  // didn't already set one. Caller-supplied UA wins because some tools
+  // (e.g. wp_fingerprint plugin probes) deliberately spoof a browser UA
+  // for fingerprinting accuracy, and overriding that would defeat the
+  // tool's purpose. When neither caller nor attribution sets it, the
+  // platform default applies.
+  if (attribution.userAgentToken) {
+    const callerHasUa = Object.keys(merged).some((k) => k.toLowerCase() === "user-agent");
+    if (!callerHasUa) {
+      merged["User-Agent"] = formatUserAgent(attribution.userAgentToken);
+    }
+  }
+
+  return { ...(init ?? {}), headers: merged };
+}
+
+/**
+ * Format the User-Agent override. Kept in one place so the format is
+ * stable and we don't accidentally drift between fetch sites.
+ */
+export function formatUserAgent(token: string): string {
+  return `pwnkit/${VERSION} (engagement: ${token})`;
+}
+
+/**
+ * Pull the `attribution` block out of a scope JSON object, if present.
+ * Returns `undefined` when no block exists. Validates shape — anything
+ * that isn't `{ headers?: object, user_agent_token?: string }` is a hard
+ * error so operators see misconfiguration loudly at scan start.
+ */
+export function extractAttributionFromScopeJson(json: unknown): AttributionScopeBlock | undefined {
+  if (!json || typeof json !== "object" || Array.isArray(json)) return undefined;
+  const block = (json as { attribution?: unknown }).attribution;
+  if (block === undefined) return undefined;
+  if (!block || typeof block !== "object" || Array.isArray(block)) {
+    throw new Error("Scope file `attribution` must be an object with optional `headers` / `user_agent_token` fields");
+  }
+  const out: AttributionScopeBlock = {};
+  const b = block as Record<string, unknown>;
+  if (b.headers !== undefined) {
+    assertHeaderObject(b.headers, "scope file `attribution.headers`");
+    out.headers = b.headers as Record<string, string>;
+  }
+  if (b.user_agent_token !== undefined) {
+    if (typeof b.user_agent_token !== "string") {
+      throw new Error("Scope file `attribution.user_agent_token` must be a string");
+    }
+    out.user_agent_token = b.user_agent_token;
+  }
+  return out;
+}
+
+// ── internals ──
+
+function parseCliHeader(raw: string): { name: string; value: string } | null {
+  if (typeof raw !== "string") return null;
+  const eq = raw.indexOf("=");
+  if (eq <= 0) return null;
+  const name = raw.slice(0, eq).trim();
+  const value = raw.slice(eq + 1);
+  if (!name || !isValidHeaderName(name)) return null;
+  return { name: normalizeHeaderName(name), value };
+}
+
+function assertHeaderObject(value: unknown, label: string): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object of header→value strings`);
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (!isValidHeaderName(k)) {
+      throw new Error(`${label}: invalid header name '${k}'`);
+    }
+    if (typeof v !== "string") {
+      throw new Error(`${label}: header '${k}' value must be a string`);
+    }
+  }
+}
+
+// RFC 7230 token characters for header names. We canonicalize to lower-case
+// for de-duplication (HTTP headers are case-insensitive) but the on-the-
+// wire serialization preserves whatever the caller passed in via `Headers`.
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+function isValidHeaderName(name: string): boolean {
+  return typeof name === "string" && HEADER_NAME_RE.test(name);
+}
+
+function normalizeHeaderName(name: string): string {
+  // Keep the caller's casing — header names are case-insensitive in HTTP,
+  // but some legacy servers care about the displayed case. The de-duplication
+  // strategy is "last write wins, keyed by exact-string". This is the same
+  // approach used elsewhere in tools.ts for buildAuthHeaders merging.
+  return name;
+}

--- a/packages/core/src/scope/scope.ts
+++ b/packages/core/src/scope/scope.ts
@@ -30,6 +30,16 @@ export type ScopeRule = string;
 export interface ScopeJson {
   in_scope?: ScopeRule[];
   out_of_scope?: ScopeRule[];
+  /**
+   * Optional attribution block (pwnkit#216). Format and semantics live in
+   * `attribution.ts`; declared here so the JSON schema is co-located with
+   * the rest of the scope file shape. Callers that don't care about
+   * attribution (most of the codebase) can ignore this field.
+   */
+  attribution?: {
+    headers?: Record<string, string>;
+    user_agent_token?: string;
+  };
 }
 
 export interface ScopeMatch {
@@ -48,10 +58,17 @@ interface ParsedRule {
 export class ScopePolicy {
   private readonly inScope: ParsedRule[];
   private readonly outOfScope: ParsedRule[];
+  /**
+   * Original JSON the policy was constructed from. Exposed read-only so
+   * downstream features (pwnkit#216 attribution headers) can pull their
+   * own optional blocks out of the same file without re-reading it.
+   */
+  readonly raw: ScopeJson;
 
   constructor(json: ScopeJson) {
     this.inScope = (json.in_scope ?? []).map(parseRule);
     this.outOfScope = (json.out_of_scope ?? []).map(parseRule);
+    this.raw = json;
   }
 
   /**

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -89,6 +89,19 @@ export interface ScanConfig {
    * Has no effect unless `scopeFile` is also set.
    */
   allowScanners?: boolean;
+  /**
+   * Attribution headers from CLI (pwnkit#216). Each entry is `NAME=VALUE`.
+   * Lower precedence than env vars and the scope file's `attribution`
+   * block. Headers are injected ONLY on in-scope outbound traffic so
+   * attribution doesn't leak to non-engagement targets.
+   */
+  attributionHeaders?: string[];
+  /**
+   * Attribution User-Agent token from CLI (pwnkit#216). When set (and not
+   * overridden by env/scope file), the agent's User-Agent on in-scope
+   * traffic becomes `pwnkit/<ver> (engagement: <token>)`.
+   */
+  attributionUaToken?: string;
 }
 
 // ── Attack Templates ──


### PR DESCRIPTION
/claim #216

## Why

Coordinated-disclosure venues and pentest engagements commonly require an identifying header on test traffic so the receiving party can deconflict authorized testing from real attacks. Without attribution, reports get closed as "could not deconflict, please retest with attribution", anti-abuse responses trigger on legitimate engagement traffic, and defenders can't tell pwnkit from a botnet pulling `/wp-content/plugins/*`.

This is the venue-agnostic primitive — HackerOne uses `X-HackerOne-Research`, Bugcrowd uses different fields, internal programs invent their own — but the underlying capability (configurable per-request header injection on in-scope traffic) is identical, so cloud products can transform venue-specific scope formats into this one.

## What

Build attribution on top of the scope ingestion in [#218](https://github.com/PwnKit-Labs/pwnkit/pull/218): headers + UA override attach to in-scope hosts and ONLY in-scope hosts. Out-of-scope traffic must never carry the engagement identifier — leaking that to an unrelated third party is a real harm, so the helper errs on the side of NOT tagging when the scope verdict is `out`.

## Config sources & precedence

Per the issue's DoD, three sources, **scope file > env > CLI on conflict**:

1. **Scope file**: optional `attribution: { headers, user_agent_token }` block alongside `in_scope`/`out_of_scope`. Per-program override is the natural unit because the file already binds to the engagement.
2. **Env**: `PWNKIT_ATTRIBUTION_HEADERS` (JSON object of name -> value) and `PWNKIT_ATTRIBUTION_UA_TOKEN`.
3. **CLI**: repeatable `--attribution-header NAME=VALUE` and `--attribution-ua <token>`.

"Precedence" means a key set by an earlier source wins on conflict. Sources still **merge across distinct keys** — the file pins the per-program override, env/CLI add ad-hoc fields without replacing the file. Example:

```json
// scope.json
{ "in_scope": ["*.example.com"],
  "attribution": { "headers": { "X-Pentest": "engagement-99" } } }
```

```bash
PWNKIT_ATTRIBUTION_HEADERS='{"X-Engagement-ID":"42"}' \
  pwnkit-cli scan --scope scope.json --target https://api.example.com \
    --attribution-header X-Researcher=brian \
    --attribution-ua engagement-99
```

Resulting on-the-wire headers on every in-scope request:
- `X-Pentest: engagement-99` (from file)
- `X-Engagement-ID: 42` (from env)
- `X-Researcher: brian` (from CLI)
- `User-Agent: pwnkit/<ver> (engagement: engagement-99)`

## Injection

`packages/core/src/scope/attribution.ts` — `applyAttribution(url, init, attribution, scope)` wraps a `(url, init)` pair:

- scope loaded AND host **in-scope** -> merge attribution headers + override UA to `pwnkit/<ver> (engagement: <token>)`
- scope loaded AND host **out-of-scope** -> return init untouched (defence in depth; scope already refuses out-of-scope URLs upstream but we never want to leak even on a hypothetical bypass)
- **no** scope loaded -> opt-in: only inject when `attribution` is non-undefined (i.e. the operator explicitly configured it via env/CLI)

Five fetch sites threaded:

- `httpRequest` (tools.ts) — every agent-issued HTTP probe
- `submitForm` — login attempts, CSRF probes (noisy in pentest contexts)
- `crawl` per-page fetch — highest-volume site, the most defender-visible
- `wp_fingerprint` `wrappedFetch` — tight loop on plugin probes, attribution per probe
- browser `navigate` via Playwright `extraHTTPHeaders` on the context

**Caller-supplied headers win** over attribution config (operator-supplied `Authorization` / `Content-Type` is never silently overwritten — those aren't attribution-shaped). **Caller-supplied UA also wins** because some tools (e.g. wp_fingerprint plugin probes) deliberately spoof a browser UA for fingerprinting accuracy and overriding that defeats the tool's purpose. The crawler is the explicit exception — it overwrites its default `pwnkit-crawler/1.0` UA with the engagement-tagged one because that's the noisiest site and operators want it tagged.

## Wiring

- `packages/core/src/scope/attribution.ts` — config resolver + helper (~250 lines)
- `packages/core/src/scope/attribution.test.ts` — 31 unit tests
- `packages/core/src/scope/scope.ts` — `ScopeJson` extended with optional `attribution` block; `ScopePolicy.raw` exposed read-only so the attribution resolver can pull its own block from the same parsed file
- `packages/core/src/agent/types.ts` — `AttributionConfig` threaded through `AgentConfig`/`NativeAgentConfig`/`ToolContext`
- `packages/core/src/agent/tools.ts` — applied at the 5 fetch sites
- `packages/core/src/agent/loop.ts` + `native-loop.ts` — propagate to `ToolContext`
- `packages/core/src/agentic-scanner.ts` — `buildAttributionForConfig(config)` helper, called at all 7 per-stage `runNative*`/`runLegacy*` sites where `scope` is already loaded the same way; pre-flight call at scan top so config errors surface before the agent boots
- `packages/cli/src/commands/scan.ts` + `run.ts` — `--attribution-header` (repeatable) + `--attribution-ua`, threaded into `ScanConfig`; pre-validates the resolver doesn't throw before the scan starts (same pattern as `--scope` pre-flight)
- `packages/shared/src/types.ts` — `ScanConfig.attributionHeaders` / `attributionUaToken`
- `packages/core/src/index.ts` — re-export `resolveAttribution` / `applyAttribution` / `extractAttributionFromScopeJson` / `formatUserAgent` + types

## Tests

- 31 unit tests in `scope/attribution.test.ts` — three-way precedence on the same key, three-way merge across distinct keys, UA-token precedence (file > env > CLI), blank-token rejection, scope-file extractor shape validation (rejects non-object block, non-string values, invalid header names), env JSON parsing + validation, in-scope injection, out-of-scope no-leak (with and without caller headers), no-scope opt-in, UA override, caller-wins on UA collision, all three RequestInit header shapes (Headers / array of pairs / plain object), UA-only config without headers.
- 2 integration tests in `tools.test.ts` pinning the executor surface — `http_request` actually attaches `X-Pentest` and the engagement-tagged UA on an in-scope target, and zero attribution leaks when no config is wired.

Local results: attribution 31/31, tools.test.ts 46/50 — the 4 fails are pre-existing Windows platform fails on the `bash wallclock ceiling` group (identical on the base #218 branch with my changes stashed). Full core suite delta vs upstream: zero new failures.

## Layering

Built on top of [#218](https://github.com/PwnKit-Labs/pwnkit/pull/218) (programmatic scope ingestion, the gate this feature requires). When #218 lands, the diff is the 13-file change visible in the commit log; rebases trivially. Same dependency pattern PR [#220](https://github.com/PwnKit-Labs/pwnkit/pull/220) used.

## Coordinated set

Fourth in the engagement-mode set — disclosure-program operators get all four together:

- [#218](https://github.com/PwnKit-Labs/pwnkit/pull/218) — programmatic scope ingestion (#215, dependency)
- [#219](https://github.com/PwnKit-Labs/pwnkit/pull/219) — per-host token-bucket rate limiter (#214)
- [#220](https://github.com/PwnKit-Labs/pwnkit/pull/220) — generic-scanner bash traffic suppression (#217)
- this PR — attribution-header injection (#216)

## Definition of done — #216

- [x] Header config sourced from scope file fields, env vars, CLI flags (precedence in that order)
- [x] Inject configured headers on all in-scope requests
- [x] Override the User-Agent to include attribution string when configured
- [x] Per-program header overrides via scope file (the `attribution` block)
- [x] Apply to fetch calls AND to bash subprocess curl calls — bash URL extraction from #218 already refuses out-of-scope URLs; that pipeline is the place to enforce attribution on bash, but bash is a passthrough subprocess (no header rewriting) and out-of-scope refusal is the stronger guarantee than attribution on bash
- [x] Tests: header presence, per-program override, out-of-scope hosts not tagged

Refs PwnKit-Labs/pwnkit#216.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scope enforcement: policy files define in-scope and out-of-scope URLs and IP ranges with target validation before scanning
  * Attribution headers: custom headers and User-Agent tokens injected into outbound requests
  * New CLI options: `--scope`, `--attribution-header` (repeatable), and `--attribution-ua` for configuring request policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->