### PR TITLE
runtime: subscription-CLI mode via CliNativeRuntime (#173)

### DIFF
--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -12,6 +12,7 @@ import { loadTemplates } from "@pwnkit/templates";
 import { createRuntime } from "./runtime/index.js";
 import { LlmApiRuntime } from "./runtime/llm-api.js";
 import type { ApiRuntimeDiagnostics } from "./runtime/llm-api.js";
+import { CliNativeRuntime } from "./runtime/cli-native.js";
 import { detectAvailableRuntimes } from "./runtime/registry.js";
 // DB lazy-loaded to avoid native module issues
 import { runAgentLoop } from "./agent/loop.js";
@@ -271,6 +272,11 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
 
   let selectedRuntimeType: "api" | "claude" | "codex" | "gemini" = "api";
   let useNative = false;
+  // Subscription-CLI mode: when claude is selected without an API key,
+  // we drive the native loop through the local CLI's session-resume
+  // protocol (see CliNativeRuntime). This unlocks Claude Max users who
+  // never set ANTHROPIC_API_KEY but have already run `claude login`.
+  let cliNativeRuntime: CliNativeRuntime | undefined;
 
   if (requestedRuntime === "api") {
     selectedRuntimeType = "api";
@@ -285,6 +291,20 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       // Codex and Gemini are experimental and limited to source-analysis workflows.
       if (availableCli.has("claude")) {
         selectedRuntimeType = "claude";
+        // No API key but Claude Code is installed — opt the native
+        // loop in via the CLI subscription path instead of falling
+        // back to the legacy text-based loop.
+        cliNativeRuntime = new CliNativeRuntime({
+          type: "claude",
+          timeout: config.timeout ?? 600_000,
+          model: config.model,
+        });
+        useNative = true;
+        emit({
+          type: "stage:start",
+          stage: "discovery",
+          message: "No API key found — running native agent loop through `claude` CLI (subscription mode).",
+        });
       } else if (availableCli.has("codex")) {
         selectedRuntimeType = "codex";
         emit({ type: "stage:start", stage: "discovery", message: "Warning: codex is experimental for live targets. Prefer runtime=api or install Claude Code CLI for full tool-loop support." });
@@ -294,12 +314,30 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       } else {
         selectedRuntimeType = "api";
       }
-      useNative = false;
     }
+  } else if (requestedRuntime === "claude" && !nativeApiAvailable) {
+    // Explicit `--runtime claude` with no API key → subscription mode.
+    selectedRuntimeType = "claude";
+    cliNativeRuntime = new CliNativeRuntime({
+      type: "claude",
+      timeout: config.timeout ?? 600_000,
+      model: config.model,
+    });
+    useNative = true;
+    emit({
+      type: "stage:start",
+      stage: "discovery",
+      message: "Running native agent loop through `claude` CLI (subscription mode).",
+    });
   } else {
     selectedRuntimeType = requestedRuntime;
     useNative = false;
   }
+
+  // The native-loop entry points all take a NativeRuntime. When the
+  // user is in subscription mode, swap the LLM-API runtime for the
+  // CLI-backed one. Everywhere else, the API runtime is still in use.
+  const nativeRuntime: NativeRuntime = cliNativeRuntime ?? nativeApiRuntime;
 
   const legacyRuntime = createRuntime({
     type: selectedRuntimeType,
@@ -533,7 +571,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
     });
 
     const discoveryState = useNative
-      ? await runNativeDiscovery(nativeApiRuntime, db, config, scanId, emit, apiSpecPromptText, getPendingUserMessages)
+      ? await runNativeDiscovery(nativeRuntime, db, config, scanId, emit, apiSpecPromptText, getPendingUserMessages)
       : await runLegacyDiscovery(legacyRuntime, db, config, scanId, emit, dbPath, apiSpecPromptText);
 
     // Persist target profile
@@ -609,7 +647,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       const egatsResult = await runEGATSWithDefaults(
         config.target,
         scanId,
-        nativeApiRuntime,
+        nativeRuntime,
         db,
         {
           repoPath: config.repoPath,
@@ -642,7 +680,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       const raceResult = await raceWithDefaults(
         config.target,
         scanId,
-        nativeApiRuntime,
+        nativeRuntime,
         db,
         {
           maxConcurrency: config.maxConcurrency ?? 3,
@@ -676,7 +714,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       }
     } else {
       attackState = useNative
-        ? await runNativeAttack(nativeApiRuntime, db, config, scanId, discoveryState.targetInfo, categories, maxAttackTurns, emit, opts.challengeHint, apiSpecPromptText, getPendingUserMessages)
+        ? await runNativeAttack(nativeRuntime, db, config, scanId, discoveryState.targetInfo, categories, maxAttackTurns, emit, opts.challengeHint, apiSpecPromptText, getPendingUserMessages)
         : await runLegacyAttack(legacyRuntime, db, config, scanId, discoveryState.targetInfo, categories, maxAttackTurns, emit, dbPath, apiSpecPromptText);
     }
 
@@ -1441,7 +1479,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
           message: "All candidates rejected by consensus — skipping agentic verify.",
         });
       } else if (useNative) {
-        await runNativeVerify(nativeApiRuntime, db, config, scanId, consensusFiltered, emit);
+        await runNativeVerify(nativeRuntime, db, config, scanId, consensusFiltered, emit);
       } else {
         await runLegacyVerify(legacyRuntime, db, config, scanId, consensusFiltered, emit, dbPath);
       }

--- a/packages/core/src/agentic-scanner.ts
+++ b/packages/core/src/agentic-scanner.ts
@@ -315,8 +315,12 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
         selectedRuntimeType = "api";
       }
     }
-  } else if (requestedRuntime === "claude" && !nativeApiAvailable) {
-    // Explicit `--runtime claude` with no API key → subscription mode.
+  } else if (requestedRuntime === "claude") {
+    // Explicit `--runtime claude` always picks the CLI native loop,
+    // regardless of whether ANTHROPIC_API_KEY is set. The flag is the
+    // user's explicit opt-in to the subscription path; falling through
+    // to the legacy text loop on the basis of an env var that happens
+    // to be present would silently subvert that intent.
     selectedRuntimeType = "claude";
     cliNativeRuntime = new CliNativeRuntime({
       type: "claude",
@@ -327,7 +331,9 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
     emit({
       type: "stage:start",
       stage: "discovery",
-      message: "Running native agent loop through `claude` CLI (subscription mode).",
+      message: nativeApiAvailable
+        ? "Explicit --runtime claude: running native agent loop through `claude` CLI (subscription mode); ANTHROPIC_API_KEY ignored."
+        : "Running native agent loop through `claude` CLI (subscription mode).",
     });
   } else {
     selectedRuntimeType = requestedRuntime;
@@ -1280,12 +1286,12 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       // is enabled and we have a native runtime.
       if (
         features.povGate
-        && nativeApiRuntime
+        && (nativeApiAvailable || cliNativeRuntime)
         && finding.triageStatus !== "accepted"
       ) {
         const povStart = Date.now();
         try {
-          const pov = await generatePov(finding, config.target, nativeApiRuntime, 5);
+          const pov = await generatePov(finding, config.target, nativeRuntime, 5);
           db.logEvent?.({
             scanId,
             stage: "verify",
@@ -1372,7 +1378,7 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
           verdict: "skip",
           reason: !features.povGate
             ? "PWNKIT_FEATURE_POV_GATE=0"
-            : !nativeApiRuntime
+            : !(nativeApiAvailable || cliNativeRuntime)
               ? "no native runtime available"
               : "already accepted by upstream layer",
           startedAt: Date.now(),
@@ -1413,14 +1419,14 @@ export async function agenticScan(opts: AgenticScanOptions): Promise<ScanReport>
       // verify queue and marked as false positives — this is the cheapest
       // remaining FP-reduction knob in the pipeline (~15% in research).
       let consensusFiltered = verifyCandidates;
-      if (features.selfConsistencyVerify && nativeApiRuntime) {
+      if (features.selfConsistencyVerify && (nativeApiAvailable || cliNativeRuntime)) {
         const survivors: Finding[] = [];
         for (const finding of verifyCandidates) {
           try {
             const consensus = await runSelfConsistencyVerify(
               finding,
               config.target,
-              nativeApiRuntime,
+              nativeRuntime,
               { numRuns: 3, temperature: 0.7, earlyStopThreshold: 0.8 },
             );
             db.logEvent?.({

--- a/packages/core/src/runtime/cli-native.test.ts
+++ b/packages/core/src/runtime/cli-native.test.ts
@@ -387,6 +387,82 @@ describe("CliNativeRuntime — claude subscription mode", () => {
     expect(onUsage).toHaveBeenCalledWith({ inputTokens: 7, outputTokens: 3 });
   });
 
+  it("auto-clears cached session id when a resume turn exits non-zero (no infinite stale-resume loop)", async () => {
+    // Turn 1 — establishes a session id.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "stale-id" }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: "stale-id",
+            message: {
+              content: [{ type: "tool_use", id: "tu_a", name: "http_request", input: {} }],
+            },
+          }),
+          JSON.stringify({ type: "result", stop_reason: "tool_use" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+    // Turn 2 — `--resume stale-id` fails because Claude Code lost the
+    // session server-side. CliNativeRuntime must drop the cached id.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [],
+        stderr: "Error: session not found\n",
+        exitCode: 1,
+      }),
+    );
+    // Turn 3 — should NOT re-send `--resume stale-id`; it should start
+    // a fresh session with `--system-prompt` instead.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "fresh-id" }),
+          JSON.stringify({ type: "result", stop_reason: "end_turn" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+    await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      [],
+    );
+    const r2 = await rt.executeNative(
+      "sys",
+      [
+        { role: "user", content: [{ type: "text", text: "go" }] },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu_a", name: "http_request", input: {} }],
+        },
+        {
+          role: "user",
+          content: [{ type: "tool_result", tool_use_id: "tu_a", content: "200" }],
+        },
+      ],
+      [],
+    );
+    expect(r2.stopReason).toBe("error");
+
+    await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "retry" }] }],
+      [],
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+    const args3 = spawnMock.mock.calls[2]![1] as string[];
+    // After the failed resume, the next call must start fresh, not
+    // replay `--resume stale-id`.
+    expect(args3).not.toContain("--resume");
+    expect(args3).toContain("--system-prompt");
+  });
+
   it("resetSession() clears the cached session id so the next turn starts fresh", async () => {
     spawnMock.mockImplementation(() =>
       makeFakeChild({

--- a/packages/core/src/runtime/cli-native.test.ts
+++ b/packages/core/src/runtime/cli-native.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// Mock child_process.spawn before importing the module under test so the
+// hoisted import inside cli-native.ts picks up the mock.
+const spawnMock = vi.fn();
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+import {
+  CliNativeRuntime,
+  buildClaudePromptFromLastUser,
+  mapClaudeStopReason,
+} from "./cli-native.js";
+import type { NativeMessage } from "./types.js";
+
+/**
+ * Build a fake `claude` subprocess that:
+ *   - emits the canned stream-json lines on stdout
+ *   - closes with the given exit code
+ *
+ * Returns a tuple of the fake child and a function to fire the events,
+ * so tests can control the timing of the close event.
+ */
+function makeFakeChild(opts: {
+  stdoutLines: string[];
+  stderr?: string;
+  exitCode?: number;
+}) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: (sig?: string) => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+
+  // Fire data + close on the next microtask so the runtime has time to
+  // attach its listeners.
+  Promise.resolve().then(() => {
+    for (const line of opts.stdoutLines) {
+      child.stdout.emit("data", Buffer.from(line + "\n", "utf-8"));
+    }
+    if (opts.stderr) {
+      child.stderr.emit("data", Buffer.from(opts.stderr, "utf-8"));
+    }
+    child.emit("close", opts.exitCode ?? 0);
+  });
+
+  return child;
+}
+
+describe("buildClaudePromptFromLastUser", () => {
+  it("returns empty string when no user message exists", () => {
+    expect(buildClaudePromptFromLastUser([])).toBe("");
+  });
+
+  it("returns plain text when last user message is just text", () => {
+    const messages: NativeMessage[] = [
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+    expect(buildClaudePromptFromLastUser(messages)).toBe("hello");
+  });
+
+  it("serializes tool_results as JSON with a marker", () => {
+    const messages: NativeMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tu_1", name: "http_request", input: { url: "x" } },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tu_1", content: "200 OK" },
+        ],
+      },
+    ];
+    const prompt = buildClaudePromptFromLastUser(messages);
+    expect(prompt).toContain("[pwnkit:tool_results]");
+    expect(prompt).toContain('"tool_use_id": "tu_1"');
+    expect(prompt).toContain('"content": "200 OK"');
+  });
+
+  it("uses the LAST user message, not the first", () => {
+    const messages: NativeMessage[] = [
+      { role: "user", content: [{ type: "text", text: "first" }] },
+      { role: "assistant", content: [{ type: "text", text: "ack" }] },
+      { role: "user", content: [{ type: "text", text: "second" }] },
+    ];
+    expect(buildClaudePromptFromLastUser(messages)).toBe("second");
+  });
+
+  it("merges tool_result + free text in the same user turn", () => {
+    const messages: NativeMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tu_x", content: "ok", is_error: true },
+          { type: "text", text: "Now what?" },
+        ],
+      },
+    ];
+    const prompt = buildClaudePromptFromLastUser(messages);
+    expect(prompt).toContain("[pwnkit:tool_results]");
+    expect(prompt).toContain('"is_error": true');
+    expect(prompt).toContain("Now what?");
+  });
+});
+
+describe("mapClaudeStopReason", () => {
+  it("maps tool_use", () => {
+    expect(mapClaudeStopReason("tool_use")).toBe("tool_use");
+  });
+  it("maps end_turn / success / stop_sequence", () => {
+    expect(mapClaudeStopReason("end_turn")).toBe("end_turn");
+    expect(mapClaudeStopReason("success")).toBe("end_turn");
+    expect(mapClaudeStopReason("stop_sequence")).toBe("end_turn");
+  });
+  it("maps max_tokens variants", () => {
+    expect(mapClaudeStopReason("max_tokens")).toBe("max_tokens");
+    expect(mapClaudeStopReason("success_max_turns")).toBe("max_tokens");
+  });
+  it("maps error variants", () => {
+    expect(mapClaudeStopReason("error")).toBe("error");
+    expect(mapClaudeStopReason("error_max_turns")).toBe("error");
+    expect(mapClaudeStopReason("error_during_execution")).toBe("error");
+  });
+  it("falls back to end_turn for unknown / undefined", () => {
+    expect(mapClaudeStopReason(undefined)).toBe("end_turn");
+    expect(mapClaudeStopReason("brand_new_reason")).toBe("end_turn");
+  });
+});
+
+describe("CliNativeRuntime — claude subscription mode", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("rejects type=api at construction time", () => {
+    expect(
+      () =>
+        new CliNativeRuntime({
+          type: "api" as any,
+          timeout: 1000,
+        }),
+    ).toThrow(/CliNativeRuntime/);
+  });
+
+  it("returns a clear error for codex / gemini (no native multi-turn yet)", async () => {
+    const rt = new CliNativeRuntime({ type: "codex", timeout: 1000 });
+    const result = await rt.executeNative(
+      "system",
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      [],
+    );
+    expect(result.stopReason).toBe("error");
+    expect(result.error).toContain("only supported for the 'claude' CLI runtime");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("turn 1: spawns claude with -p, --output-format stream-json, and --system-prompt", async () => {
+    const sessionId = "session-abc-123";
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({
+            type: "system",
+            subtype: "init",
+            session_id: sessionId,
+          }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: sessionId,
+            message: {
+              content: [
+                { type: "text", text: "I'll probe the target." },
+                {
+                  type: "tool_use",
+                  id: "tu_1",
+                  name: "http_request",
+                  input: { url: "https://example.com" },
+                },
+              ],
+              usage: { input_tokens: 100, output_tokens: 25 },
+            },
+          }),
+          JSON.stringify({
+            type: "result",
+            stop_reason: "tool_use",
+            usage: { input_tokens: 100, output_tokens: 25 },
+          }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+    const result = await rt.executeNative(
+      "you are pwnkit attack agent",
+      [{ role: "user", content: [{ type: "text", text: "scan https://x" }] }],
+      [],
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, args] = spawnMock.mock.calls[0]!;
+    expect(cmd).toBe("claude");
+    expect(args).toContain("-p");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    // Turn 1 must NOT have --resume
+    expect(args).not.toContain("--resume");
+    // Turn 1 SHOULD pass the system prompt
+    const sysIdx = args.indexOf("--system-prompt");
+    expect(sysIdx).toBeGreaterThan(-1);
+    expect(args[sysIdx + 1]).toBe("you are pwnkit attack agent");
+
+    // Result blocks
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.content).toEqual([
+      { type: "text", text: "I'll probe the target." },
+      {
+        type: "tool_use",
+        id: "tu_1",
+        name: "http_request",
+        input: { url: "https://example.com" },
+      },
+    ]);
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 25 });
+  });
+
+  it("turn N: spawns claude with --resume <session_id> and JSON-encoded tool_results", async () => {
+    const sessionId = "session-xyz-789";
+
+    // Turn 1 — capture session id from system event.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({
+            type: "system",
+            subtype: "init",
+            session_id: sessionId,
+          }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: sessionId,
+            message: {
+              content: [
+                { type: "tool_use", id: "tu_a", name: "http_request", input: { url: "https://x" } },
+              ],
+              usage: { input_tokens: 50, output_tokens: 10 },
+            },
+          }),
+          JSON.stringify({ type: "result", stop_reason: "tool_use" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    // Turn 2 — should --resume.
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({
+            type: "assistant",
+            session_id: sessionId,
+            message: {
+              content: [{ type: "text", text: "Got the response, finishing up." }],
+              usage: { input_tokens: 60, output_tokens: 8 },
+            },
+          }),
+          JSON.stringify({ type: "result", stop_reason: "end_turn" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+
+    // Turn 1
+    await rt.executeNative(
+      "system prompt",
+      [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      [],
+    );
+
+    // Turn 2 — feed back the tool_result for tu_a.
+    const result2 = await rt.executeNative(
+      "system prompt",
+      [
+        { role: "user", content: [{ type: "text", text: "go" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tu_a", name: "http_request", input: { url: "https://x" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu_a", content: '{"status":200}' },
+          ],
+        },
+      ],
+      [],
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const [cmd2, args2] = spawnMock.mock.calls[1]!;
+    expect(cmd2).toBe("claude");
+    const resumeIdx = args2.indexOf("--resume");
+    expect(resumeIdx).toBeGreaterThan(-1);
+    expect(args2[resumeIdx + 1]).toBe(sessionId);
+    // System prompt must NOT be re-sent on resume — Claude Code retains it
+    // server-side, and re-passing it would re-prepend on every turn.
+    expect(args2).not.toContain("--system-prompt");
+    // The prompt argument should carry the JSON-encoded tool_result.
+    const pIdx = args2.indexOf("-p");
+    expect(pIdx).toBeGreaterThan(-1);
+    const promptArg = args2[pIdx + 1] as string;
+    expect(promptArg).toContain("[pwnkit:tool_results]");
+    expect(promptArg).toContain('"tool_use_id": "tu_a"');
+    expect(promptArg).toContain('"content": "{\\"status\\":200}"');
+
+    expect(result2.stopReason).toBe("end_turn");
+    expect(result2.content).toEqual([
+      { type: "text", text: "Got the response, finishing up." },
+    ]);
+  });
+
+  it("surfaces a helpful auth hint when claude exits non-zero with login error", async () => {
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [],
+        stderr: "Error: Please run claude login\n",
+        exitCode: 1,
+      }),
+    );
+
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+    const result = await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      [],
+    );
+    expect(result.stopReason).toBe("error");
+    expect(result.error).toMatch(/claude login/i);
+  });
+
+  it("forwards onThinking and onUsage callbacks", async () => {
+    spawnMock.mockImplementationOnce(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "s1" }),
+          JSON.stringify({
+            type: "assistant",
+            session_id: "s1",
+            message: {
+              content: [{ type: "text", text: "thinking..." }],
+              usage: { input_tokens: 7, output_tokens: 3 },
+            },
+          }),
+          JSON.stringify({ type: "result", stop_reason: "end_turn" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    const onThinking = vi.fn();
+    const onUsage = vi.fn();
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+    await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "go" }] }],
+      [],
+      { onThinking, onUsage },
+    );
+
+    expect(onThinking).toHaveBeenCalledWith("thinking...");
+    expect(onUsage).toHaveBeenCalledWith({ inputTokens: 7, outputTokens: 3 });
+  });
+
+  it("resetSession() clears the cached session id so the next turn starts fresh", async () => {
+    spawnMock.mockImplementation(() =>
+      makeFakeChild({
+        stdoutLines: [
+          JSON.stringify({ type: "system", subtype: "init", session_id: "fresh" }),
+          JSON.stringify({ type: "result", stop_reason: "end_turn" }),
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    const rt = new CliNativeRuntime({ type: "claude", timeout: 5000 });
+    await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "first" }] }],
+      [],
+    );
+    rt.resetSession();
+    await rt.executeNative(
+      "sys",
+      [{ role: "user", content: [{ type: "text", text: "second" }] }],
+      [],
+    );
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    // After reset, the second call should NOT carry --resume.
+    const args2 = spawnMock.mock.calls[1]![1] as string[];
+    expect(args2).not.toContain("--resume");
+  });
+});

--- a/packages/core/src/runtime/cli-native.ts
+++ b/packages/core/src/runtime/cli-native.ts
@@ -1,0 +1,417 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import type {
+  NativeRuntime,
+  NativeMessage,
+  NativeContentBlock,
+  NativeToolDef,
+  NativeRuntimeResult,
+  NativeStreamCallbacks,
+  RuntimeConfig,
+  RuntimeType,
+} from "./types.js";
+
+/**
+ * CliNativeRuntime — wraps a CLI runtime (`claude`, `codex`, `gemini`) so
+ * that it satisfies the {@link NativeRuntime} contract used by
+ * `runNativeAgentLoop()`.
+ *
+ * The motivation is subscription auth: users who pay for Claude Max /
+ * ChatGPT / Gemini already have working CLI auth on their machine, but
+ * the legacy {@link Runtime} interface only supports a single
+ * round-trip per call. The native loop drives a multi-turn conversation
+ * through structured `tool_use` / `tool_result` blocks, which until now
+ * required a raw API key.
+ *
+ * ## Strategy: session resume
+ *
+ * Claude Code emits a `session_id` in its `system` init event and on
+ * every subsequent `assistant` event. We capture it on turn 1 and pass
+ * `--resume <session_id>` on every later call. Claude Code holds the
+ * conversation server-side, so we only need to feed the *latest* user
+ * turn (a JSON-encoded array of `tool_result` blocks plus any free
+ * text) on each invocation.
+ *
+ * Codex and Gemini are not currently supported for multi-turn — their
+ * resume semantics are either undocumented or differ enough that this
+ * PR keeps the surface area small. They fall through with a clear
+ * error directing the user to `--runtime claude` or to set an API key.
+ *
+ * ## Known tradeoffs (called out in the bounty discussion)
+ *
+ * - **Dual context windows.** Claude Code manages its own context
+ *   internally; pwnkit's native loop also manages context (compaction,
+ *   message history). Both are running, side-by-side, on the same
+ *   conversation. This is acceptable: Claude Code's own compaction
+ *   prevents the subprocess from blowing up, and pwnkit's native-loop
+ *   features (loop detection, early-stop, playbook injection) still
+ *   fire on top of whatever Claude Code returns.
+ * - **Token usage opacity.** stream-json reports the same token counts
+ *   the Anthropic API returns to Claude Code itself, which is good
+ *   enough for soft cost-ceiling enforcement.
+ * - **Subprocess fragility.** If the spawn crashes, we surface
+ *   `stopReason: "error"`. The native loop's existing retry path
+ *   handles that the same way it handles an API 5xx.
+ */
+export class CliNativeRuntime implements NativeRuntime {
+  readonly type: RuntimeType;
+  private config: RuntimeConfig;
+  private command: string;
+  /** Populated from the first turn's stream-json `system` event. */
+  private sessionId: string | undefined;
+
+  constructor(config: RuntimeConfig) {
+    if (config.type === "api") {
+      throw new Error(
+        "CliNativeRuntime does not support type=api. Use LlmApiRuntime instead.",
+      );
+    }
+    this.type = config.type;
+    this.config = config;
+    this.command = config.type;
+  }
+
+  /**
+   * Reset the cached session id so the next call starts a brand-new
+   * Claude Code session. The native loop uses this between scans.
+   */
+  resetSession(): void {
+    this.sessionId = undefined;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const proc = spawn(this.command, ["--version"], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const timer = setTimeout(() => {
+        proc.kill();
+        resolve(false);
+      }, 5_000);
+      proc.on("close", (code) => {
+        clearTimeout(timer);
+        resolve(code === 0);
+      });
+      proc.on("error", () => {
+        clearTimeout(timer);
+        resolve(false);
+      });
+    });
+  }
+
+  async executeNative(
+    system: string,
+    messages: NativeMessage[],
+    _tools: NativeToolDef[],
+    callbacks?: NativeStreamCallbacks,
+  ): Promise<NativeRuntimeResult> {
+    const start = Date.now();
+
+    if (this.type !== "claude") {
+      return {
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        durationMs: Date.now() - start,
+        error:
+          `Native multi-turn agent loop is only supported for the 'claude' CLI runtime. ` +
+          `'${this.type}' does not yet expose a stable session-resume protocol — ` +
+          `use --runtime claude (with 'claude login') for subscription auth, ` +
+          `or set ANTHROPIC_API_KEY / OPENROUTER_API_KEY / OPENAI_API_KEY for --runtime api.`,
+      };
+    }
+
+    // The native loop accumulates the entire conversation in `messages`.
+    // Claude Code holds it server-side once we have a session id, so we
+    // only need to push the latest user turn down the wire.
+    const promptText = buildClaudePromptFromLastUser(messages);
+    if (!promptText) {
+      return {
+        content: [{ type: "text", text: "" }],
+        stopReason: "error",
+        durationMs: Date.now() - start,
+        error: "CliNativeRuntime: last message was not a user turn (cannot prompt Claude Code).",
+      };
+    }
+
+    const args: string[] = ["-p", promptText, "--verbose", "--output-format", "stream-json"];
+    if (this.sessionId) {
+      args.push("--resume", this.sessionId);
+    } else if (system && system.trim().length > 0) {
+      // System prompt is only meaningful on the first turn — once a
+      // session exists, Claude Code retains the original system prompt
+      // and re-passing it via `--append-system-prompt` would silently
+      // double-append on every turn.
+      args.push("--system-prompt", system);
+    }
+
+    return new Promise((resolve) => {
+      let stdoutBuf = "";
+      let stderrBuf = "";
+      let timedOut = false;
+      const content: NativeContentBlock[] = [];
+      let stopReason: NativeRuntimeResult["stopReason"] = "end_turn";
+      let usage: { inputTokens: number; outputTokens: number } | undefined;
+      let sawAssistantEnd = false;
+
+      const proc: ChildProcess = spawn(this.command, args, {
+        cwd: this.config.cwd ?? process.cwd(),
+        env: { ...process.env, ...this.config.env },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      proc.stdout?.on("data", (chunk: Buffer) => {
+        stdoutBuf += chunk.toString("utf-8");
+
+        // Newline-delimited JSON. Drain complete lines; leave any
+        // trailing partial in the buffer for the next chunk.
+        let nl = stdoutBuf.indexOf("\n");
+        while (nl >= 0) {
+          const line = stdoutBuf.slice(0, nl).trim();
+          stdoutBuf = stdoutBuf.slice(nl + 1);
+          nl = stdoutBuf.indexOf("\n");
+          if (!line) continue;
+          const event = tryParseJson(line);
+          if (!event) continue;
+
+          // Capture session id from the first event that carries it —
+          // both the `system` init event and every `assistant` event
+          // include `session_id` at the top level.
+          if (typeof event.session_id === "string" && !this.sessionId) {
+            this.sessionId = event.session_id;
+          }
+
+          // ── Assistant message blocks ──
+          if (
+            event.type === "assistant"
+            && event.message
+            && Array.isArray(event.message.content)
+          ) {
+            for (const block of event.message.content) {
+              if (block?.type === "text" && typeof block.text === "string") {
+                content.push({ type: "text", text: block.text });
+                if (block.text.trim()) callbacks?.onThinking?.(block.text);
+              } else if (
+                block?.type === "tool_use"
+                && typeof block.id === "string"
+                && typeof block.name === "string"
+              ) {
+                content.push({
+                  type: "tool_use",
+                  id: block.id,
+                  name: block.name,
+                  input:
+                    block.input && typeof block.input === "object"
+                      ? (block.input as Record<string, unknown>)
+                      : {},
+                });
+              }
+            }
+
+            // Surface any per-turn usage Claude Code attaches to
+            // assistant events so the cost ceiling has fresher data
+            // than waiting for the terminal `result` event.
+            const u = event.message?.usage as Record<string, unknown> | undefined;
+            if (u) {
+              const partial = readUsage(u);
+              if (partial) callbacks?.onUsage?.(partial);
+            }
+          }
+
+          // ── Final result event ──
+          if (event.type === "result") {
+            sawAssistantEnd = true;
+            stopReason = mapClaudeStopReason(event.stop_reason ?? event.subtype);
+            const u = event.usage as Record<string, unknown> | undefined;
+            if (u) usage = readUsage(u) ?? usage;
+          }
+        }
+      });
+
+      proc.stderr?.on("data", (chunk: Buffer) => {
+        stderrBuf += chunk.toString("utf-8");
+      });
+
+      const timer = setTimeout(() => {
+        timedOut = true;
+        proc.kill("SIGTERM");
+        setTimeout(() => proc.kill("SIGKILL"), 5_000).unref();
+      }, this.config.timeout || 600_000);
+
+      proc.on("error", (err) => {
+        clearTimeout(timer);
+        resolve({
+          content: [{ type: "text", text: "" }],
+          stopReason: "error",
+          durationMs: Date.now() - start,
+          error: `claude CLI spawn failed: ${err.message}`,
+        });
+      });
+
+      proc.on("close", (code) => {
+        clearTimeout(timer);
+
+        if (timedOut) {
+          resolve({
+            content: content.length > 0 ? content : [{ type: "text", text: "" }],
+            stopReason: "error",
+            usage,
+            durationMs: Date.now() - start,
+            error: `claude CLI timed out after ${this.config.timeout}ms`,
+          });
+          return;
+        }
+
+        if (code !== 0 && !sawAssistantEnd) {
+          // Surface any auth / login hint Claude Code dumped to stderr.
+          // Common modes: "Please run claude login", "session expired".
+          const hint = extractAuthHint(stderrBuf);
+          resolve({
+            content: [{ type: "text", text: "" }],
+            stopReason: "error",
+            usage,
+            durationMs: Date.now() - start,
+            error:
+              `claude CLI exited ${code}` +
+              (hint ? ` — ${hint}` : "") +
+              (stderrBuf.trim() ? `\nstderr: ${stderrBuf.trim().slice(0, 500)}` : ""),
+          });
+          return;
+        }
+
+        resolve({
+          content:
+            content.length > 0 ? content : [{ type: "text", text: "" }],
+          stopReason,
+          usage,
+          durationMs: Date.now() - start,
+        });
+      });
+    });
+  }
+}
+
+/**
+ * Build the prompt string for a single `claude -p ...` invocation from
+ * the last user turn in the native-loop conversation.
+ *
+ * Claude Code expects a flat string. `tool_result` blocks are
+ * serialized as a JSON array prefixed with a marker so Claude Code
+ * recognises them as previous-turn outputs. Any free-form text in the
+ * same user turn is appended verbatim.
+ *
+ * Exported for unit testing.
+ */
+export function buildClaudePromptFromLastUser(messages: NativeMessage[]): string {
+  // Walk backwards to find the most recent user message.
+  let last: NativeMessage | undefined;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === "user") {
+      last = messages[i];
+      break;
+    }
+  }
+  if (!last) return "";
+
+  const toolResults: Array<{
+    tool_use_id: string;
+    content: string;
+    is_error?: boolean;
+  }> = [];
+  const textParts: string[] = [];
+
+  for (const block of last.content) {
+    if (block.type === "tool_result") {
+      toolResults.push({
+        tool_use_id: block.tool_use_id,
+        content: block.content,
+        ...(block.is_error ? { is_error: true } : {}),
+      });
+    } else if (block.type === "text") {
+      textParts.push(block.text);
+    }
+  }
+
+  const parts: string[] = [];
+  if (toolResults.length > 0) {
+    parts.push(
+      `[pwnkit:tool_results]\n${JSON.stringify(toolResults, null, 2)}`,
+    );
+  }
+  if (textParts.length > 0) {
+    parts.push(textParts.join("\n").trim());
+  }
+  return parts.filter((p) => p.length > 0).join("\n\n").trim();
+}
+
+/**
+ * Map Claude Code's stop-reason vocabulary to the native runtime's
+ * normalized set. Both the Anthropic Messages API and Claude Code
+ * stream-json use the same string constants for the common cases, but
+ * the `result` event sometimes only sets `subtype` (e.g.
+ * "success_max_turns") so we accept either.
+ *
+ * Exported for unit testing.
+ */
+export function mapClaudeStopReason(
+  raw: string | undefined,
+): NativeRuntimeResult["stopReason"] {
+  if (!raw) return "end_turn";
+  switch (raw) {
+    case "tool_use":
+      return "tool_use";
+    case "max_tokens":
+    case "success_max_turns":
+      return "max_tokens";
+    case "end_turn":
+    case "success":
+    case "stop_sequence":
+      return "end_turn";
+    case "error":
+    case "error_max_turns":
+    case "error_during_execution":
+      return "error";
+    default:
+      return "end_turn";
+  }
+}
+
+function tryParseJson(line: string): Record<string, any> | null {
+  try {
+    const parsed = JSON.parse(line);
+    if (parsed && typeof parsed === "object") {
+      return parsed as Record<string, any>;
+    }
+  } catch {
+    // not all stdout lines are stream-json events (e.g. log lines from
+    // npm wrappers); ignore and move on.
+  }
+  return null;
+}
+
+function readUsage(
+  u: Record<string, unknown>,
+): { inputTokens: number; outputTokens: number } | undefined {
+  const input = num(u.input_tokens) ?? num(u.prompt_tokens);
+  const output = num(u.output_tokens) ?? num(u.completion_tokens);
+  if (input === undefined && output === undefined) return undefined;
+  return { inputTokens: input ?? 0, outputTokens: output ?? 0 };
+}
+
+function num(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && /^\d+$/.test(v)) return Number(v);
+  return undefined;
+}
+
+function extractAuthHint(stderr: string): string | undefined {
+  if (!stderr) return undefined;
+  if (/please\s+run\s+claude\s+login/i.test(stderr)) {
+    return "run `claude login` to authenticate the CLI with your subscription";
+  }
+  if (/not\s+(?:logged|authenticated)/i.test(stderr)) {
+    return "Claude Code reports the user is not authenticated — run `claude login`";
+  }
+  if (/session\s+expired/i.test(stderr)) {
+    return "Claude Code session expired — run `claude login` again";
+  }
+  return undefined;
+}

--- a/packages/core/src/runtime/cli-native.ts
+++ b/packages/core/src/runtime/cli-native.ts
@@ -81,6 +81,8 @@ export class CliNativeRuntime implements NativeRuntime {
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
       const proc = spawn(this.command, ["--version"], {
+        cwd: this.config.cwd ?? process.cwd(),
+        env: { ...process.env, ...this.config.env },
         stdio: ["ignore", "pipe", "pipe"],
       });
       const timer = setTimeout(() => {
@@ -238,6 +240,9 @@ export class CliNativeRuntime implements NativeRuntime {
 
       proc.on("error", (err) => {
         clearTimeout(timer);
+        // Spawn-level failure also invalidates any cached session id —
+        // see the `close` handlers below for the same rationale.
+        this.sessionId = undefined;
         resolve({
           content: [{ type: "text", text: "" }],
           stopReason: "error",
@@ -250,6 +255,11 @@ export class CliNativeRuntime implements NativeRuntime {
         clearTimeout(timer);
 
         if (timedOut) {
+          // A timed-out resume often means Claude Code lost the session
+          // server-side (idle eviction, restart, expiry). Drop the cached
+          // id so the next call falls back to a fresh `--system-prompt`
+          // invocation instead of looping on `--resume <stale_id>`.
+          this.sessionId = undefined;
           resolve({
             content: content.length > 0 ? content : [{ type: "text", text: "" }],
             stopReason: "error",
@@ -264,6 +274,11 @@ export class CliNativeRuntime implements NativeRuntime {
           // Surface any auth / login hint Claude Code dumped to stderr.
           // Common modes: "Please run claude login", "session expired".
           const hint = extractAuthHint(stderrBuf);
+          // Same rationale as the timeout path: a non-zero exit on a
+          // resume usually means the server-side session is gone. Clear
+          // the cached id so we don't wedge the native loop replaying
+          // `--resume` against an id Claude Code no longer recognises.
+          this.sessionId = undefined;
           resolve({
             content: [{ type: "text", text: "" }],
             stopReason: "error",

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -12,6 +12,7 @@ export type {
 } from "./types.js";
 export { LlmApiRuntime } from "./llm-api.js";
 export { ProcessRuntime } from "./process.js";
+export { CliNativeRuntime } from "./cli-native.js";
 export { OpenRouterRuntime, DEFAULT_ENSEMBLE_MODELS } from "./openrouter.js";
 export type { OpenRouterConfig } from "./openrouter.js";
 export {


### PR DESCRIPTION
/claim #173

Closes #173.

## Summary

Adds `CliNativeRuntime` — a thin wrapper that exposes the local `claude` CLI as a `NativeRuntime`, so pwnkit's existing `runNativeAgentLoop()` can drive a multi-turn attack loop through a Claude Max subscription with **no API key required**.

```
claude login                                # one-time
pwnkit scan --target https://example.com    # auto picks claude when no key is set
# or explicitly:
pwnkit scan --target https://example.com --runtime claude
```

When `--runtime claude` (or `--runtime auto` with no key) is selected, pwnkit now routes discovery / attack / verify / race / egats through the same native loop API-key users get — including loop detection, early-stop, playbook injection, and soft cost-ceiling enforcement. The legacy text-based `runAgentLoop` is untouched; it's still the path for `--runtime codex` / `--runtime gemini` and remains the fallback.

## Strategy: session resume

Claude Code emits a `session_id` in its `system` init event and on every subsequent `assistant` event. The runtime captures it on turn 1 and passes `--resume <session_id>` on every later call:

```
turn 1: claude -p "<initial prompt>" --output-format stream-json --verbose --system-prompt "..."
turn N: claude --resume <session_id> -p "<tool_results JSON>" --output-format stream-json --verbose
```

Claude Code holds the conversation server-side, so pwnkit only ships the *latest* user turn on each invocation — a JSON-encoded `[pwnkit:tool_results]` array plus any free text. The system prompt is only passed on turn 1 (re-passing it on resume would silently re-prepend on every turn).

This is the same session-resume pattern Paperclip's `adapter-claude-local` uses, and it's the cleanest way to get multi-turn out of a CLI that doesn't expose a stdin protocol.

## Stream-json -> NativeContentBlock

Reuses the same parsing shape that `process.ts:124-159` already uses for simple stages:

| stream-json event              | NativeContentBlock                                |
| ------------------------------ | ------------------------------------------------- |
| `assistant.message.content[].type=text`     | `{ type: "text", text }`             |
| `assistant.message.content[].type=tool_use` | `{ type: "tool_use", id, name, input }` |
| `result.stop_reason`           | mapped to `end_turn` / `tool_use` / `max_tokens` / `error` |
| `result.usage` / `assistant.message.usage` | `{ inputTokens, outputTokens }` (forwarded via `onUsage`) |

Stop-reason mapping handles Claude Code's extended vocabulary (`success`, `success_max_turns`, `error_during_execution`, etc.) in addition to the bare Anthropic Messages API names.

## What about codex / gemini?

Out of scope for this PR. Codex doesn't yet expose a stable session-resume flag, and Gemini's resume semantics are undocumented. `executeNative()` for those types short-circuits with a clear error directing the user at `--runtime claude` or an API key — they continue to work via the legacy text loop unchanged.

## Addressing the viability assessment (Apr 27)

@Darkroom4364 raised four concerns; here's how this PR handles each:

1. **Native loop gap.** The PR doesn't reimplement the loop. It exposes Claude Code's stream-json as a thin `NativeRuntime` so the existing `runNativeAgentLoop` (compaction, loop detection, early-stop, cost ceiling, playbook injection) runs unchanged on top of it.
2. **Dual context windows.** Acknowledged. Claude Code manages its own context internally; pwnkit's native loop also manages context (compaction, message history). Both run side-by-side — Claude Code's compaction prevents the subprocess from blowing up, pwnkit's native-loop features fire on top of whatever Claude Code returns. Documented in the file header as a known tradeoff.
3. **Session resume reliability.** If a subprocess crashes, `executeNative()` returns `stopReason: "error"` and the existing native-loop retry path handles it the same way it handles a 5xx from the API. Subsequent turns use the cached session id; if the upstream session has been GC'd by Claude Code, we get a non-zero exit and the same retry path triggers.
4. **Token usage opacity.** `stream-json`'s `result.usage` reports the same token counts the Anthropic API hands to Claude Code. That's good enough for soft cost-ceiling estimation. Hard per-token billing isn't the point of subscription mode anyway — it's $20/mo flat.

## Tests

`packages/core/src/runtime/cli-native.test.ts` — 17 tests, all passing. Mocks `child_process.spawn` and emits canned stream-json:

- `buildClaudePromptFromLastUser` collapses tool_result + free text correctly, picks the LAST user turn, handles the empty-conversation edge case
- `mapClaudeStopReason` covers `tool_use`, `end_turn` / `success` / `stop_sequence`, `max_tokens` / `success_max_turns`, `error` / `error_max_turns` / `error_during_execution`, undefined fallback
- turn 1 spawns `claude` with `-p`, `--output-format stream-json`, `--system-prompt`, NO `--resume`
- turn 2 spawns with `--resume <session_id>`, a JSON-encoded tool_result payload, NO re-sent system prompt
- `onThinking` / `onUsage` fire from assistant + result events
- helpful auth hint surfaces when claude exits with a "Please run claude login" stderr
- `resetSession()` clears the cached session id so the next call starts fresh
- `type: "api"` is rejected at construction; codex / gemini get a clear error directing the user to `claude` or an API key

```
✓ src/runtime/cli-native.test.ts (17 tests) 18ms
Test Files  1 passed (1)
     Tests  17 passed (17)
```

Full monorepo `pnpm -r build` is green. Existing test failures on the Windows host I tested on (`tools.test.ts`, `disclose/`, `triage/reachability.test.ts`) are pre-existing and unrelated to this PR — they fail identically on a clean checkout of `main`.

## Files touched

- **NEW** `packages/core/src/runtime/cli-native.ts` — the wrapper (~280 LOC)
- **NEW** `packages/core/src/runtime/cli-native.test.ts` — tests
- `packages/core/src/runtime/index.ts` — re-export `CliNativeRuntime`
- `packages/core/src/agentic-scanner.ts` — runtime-selection wiring (~50 LOC, mostly the new claude+no-key branch + swapping `nativeApiRuntime` -> `nativeRuntime` in 5 call sites)

No changes to `.github/workflows/*`, no docs churn, no breaking API.

## Test plan

- [x] Unit: 17 new tests cover prompt builder, stop-reason mapper, turn 1 / turn N spawn shape, callbacks, auth hints, resetSession
- [x] Type-check: `tsc --noEmit` clean
- [x] Build: `pnpm -r build` clean
- [ ] Manual smoke (reviewer): `claude login` then `pwnkit scan --target <local app> --runtime claude` with no `ANTHROPIC_API_KEY` set — should see "running native agent loop through `claude` CLI (subscription mode)" then a normal native discovery + attack pipeline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using Claude CLI as an alternative runtime when an API key is not provided. The system automatically detects Claude installation and switches to CLI-based operations when ANTHROPIC_API_KEY is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->